### PR TITLE
refactor(core/meta): 解耦 matcher 与数据库，改用可注入的 config provider

### DIFF
--- a/app/core/meta/config_source.py
+++ b/app/core/meta/config_source.py
@@ -1,0 +1,28 @@
+from typing import Any, Callable, Optional
+
+from app.schemas.types import SystemConfigKey
+
+# core/meta 不应依赖 app.db。识别相关的用户自定义配置（自定义识别词、自定义占位符、
+# 自定义制作组）统一通过此处的可注入 provider 读取，由应用启动层（app/startup）在启动时
+# 将其接到持久化存储（SystemConfigOper）。未注册 provider 时返回 None（无自定义、无需数据库），
+# 因此元数据解析算法可脱离数据库独立复用与测试。
+
+_provider: Optional[Callable[[SystemConfigKey], Any]] = None
+
+
+def set_meta_config_provider(provider: Optional[Callable[[SystemConfigKey], Any]]) -> None:
+    """
+    注册 core/meta 读取用户自定义识别配置的来源（由应用层在启动时接入 SystemConfigOper）。
+    传入 None 可解除注册（用于测试隔离）。
+    """
+    global _provider
+    _provider = provider
+
+
+def get_meta_config(key: SystemConfigKey) -> Any:
+    """
+    读取指定 key 的用户自定义识别配置；未注册 provider 时返回 None（无自定义、无需数据库）。
+    """
+    if _provider is None:
+        return None
+    return _provider(key)

--- a/app/core/meta/customization.py
+++ b/app/core/meta/customization.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from app.db.systemconfig_oper import SystemConfigOper
+from app.core.meta.config_source import get_meta_config
 from app.schemas.types import SystemConfigKey
 from app.utils.singleton import Singleton
 
@@ -11,7 +11,6 @@ class CustomizationMatcher(metaclass=Singleton):
     """
 
     def __init__(self):
-        self.systemconfig = SystemConfigOper()
         self.customization = None
         self.custom_separator = None
         self._customization_re_cache = {}
@@ -36,7 +35,7 @@ class CustomizationMatcher(metaclass=Singleton):
             return ""
         # 自定义占位符需要跟随系统配置实时生效，避免单例缓存导致保存后仍沿用旧规则。
         customization = self._normalize_customization(
-            self.systemconfig.get(SystemConfigKey.Customization)
+            get_meta_config(SystemConfigKey.Customization)
         )
         if not customization:
             self.customization = None

--- a/app/core/meta/releasegroup.py
+++ b/app/core/meta/releasegroup.py
@@ -1,6 +1,6 @@
 import regex as re
 
-from app.db.systemconfig_oper import SystemConfigOper
+from app.core.meta.config_source import get_meta_config
 from app.schemas.types import SystemConfigKey
 from app.utils.singleton import Singleton
 
@@ -86,7 +86,6 @@ class ReleaseGroupsMatcher(metaclass=Singleton):
             for release_group in site_groups:
                 release_groups.append(release_group)
         self.__release_groups = '|'.join(release_groups)
-        self.systemconfig = SystemConfigOper()
         self.__groups_re_cache = {}
 
     def __get_groups_re(self, groups: str):
@@ -109,7 +108,7 @@ class ReleaseGroupsMatcher(metaclass=Singleton):
             return ""
         if not groups:
             # 自定义组
-            custom_release_groups = self.systemconfig.get(SystemConfigKey.CustomReleaseGroups)
+            custom_release_groups = get_meta_config(SystemConfigKey.CustomReleaseGroups)
             if isinstance(custom_release_groups, list):
                 custom_release_groups = list(filter(None, custom_release_groups))
             if custom_release_groups:

--- a/app/core/meta/words.py
+++ b/app/core/meta/words.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 import cn2an
 import regex as re
 
-from app.db.systemconfig_oper import SystemConfigOper
+from app.core.meta.config_source import get_meta_config
 from app.log import logger
 from app.schemas.types import SystemConfigKey
 from app.utils.singleton import Singleton
@@ -24,9 +24,6 @@ def _compile_custom_word_regex(pattern: str):
 
 class WordsMatcher(metaclass=Singleton):
 
-    def __init__(self):
-        self.systemconfig = SystemConfigOper()
-
     def prepare(self, title: str, custom_words: List[str] = None) -> Tuple[str, List[str]]:
         """
         预处理标题，支持三种格式
@@ -36,7 +33,7 @@ class WordsMatcher(metaclass=Singleton):
         """
         appley_words = []
         # 读取自定义识别词
-        words: List[str] = custom_words or self.systemconfig.get(SystemConfigKey.CustomIdentifiers) or []
+        words: List[str] = custom_words or get_meta_config(SystemConfigKey.CustomIdentifiers) or []
         for word in words:
             if not word or word.startswith("#"):
                 continue

--- a/app/startup/lifecycle.py
+++ b/app/startup/lifecycle.py
@@ -18,6 +18,8 @@ except Exception:
 
 from app.chain.system import SystemChain
 from app.core.config import global_vars, settings
+from app.core.meta.config_source import set_meta_config_provider
+from app.db.systemconfig_oper import SystemConfigOper
 from app.helper.server import MoviePilotServerHelper
 from app.helper.system import SystemHelper
 from app.startup.command_initializer import init_command, stop_command, restart_command
@@ -63,6 +65,8 @@ async def lifespan(app: FastAPI):
     print("Starting up...")
     # 存储当前循环
     global_vars.set_loop(asyncio.get_event_loop())
+    # 将 core/meta 的用户自定义识别配置接到持久化存储（core/meta 本身不依赖 app.db）
+    set_meta_config_provider(lambda key: SystemConfigOper().get(key))
     # 初始化路由
     init_routers(app)
     # 初始化模块

--- a/tests/test_customization_matcher.py
+++ b/tests/test_customization_matcher.py
@@ -1,20 +1,20 @@
 from unittest import TestCase
-from unittest.mock import patch
 
+from app.core.meta.config_source import set_meta_config_provider
 from app.core.meta.customization import CustomizationMatcher
 
 
 class CustomizationMatcherTest(TestCase):
+    def tearDown(self):
+        # 还原注入，避免污染其它用例
+        set_meta_config_provider(None)
+
     def test_match_uses_latest_customization_setting(self):
         """自定义占位符修改后，下一次识别应直接使用新配置。"""
         matcher = CustomizationMatcher()
         values = [["GROUP"], ["TEAM"]]
-
-        with patch.object(
-            matcher.systemconfig,
-            "get",
-            side_effect=lambda _: values[0],
-        ):
-            self.assertEqual(matcher.match("[GROUP][TEAM] Movie"), "GROUP")
-            values[0] = ["TEAM"]
-            self.assertEqual(matcher.match("[GROUP][TEAM] Movie"), "TEAM")
+        # 通过注入的 config provider 提供配置，无需数据库
+        set_meta_config_provider(lambda _: values[0])
+        self.assertEqual(matcher.match("[GROUP][TEAM] Movie"), "GROUP")
+        values[0] = ["TEAM"]
+        self.assertEqual(matcher.match("[GROUP][TEAM] Movie"), "TEAM")

--- a/tests/test_meta_config_source.py
+++ b/tests/test_meta_config_source.py
@@ -1,0 +1,58 @@
+import inspect
+from unittest import TestCase
+
+from app.core.meta.config_source import get_meta_config, set_meta_config_provider
+from app.core.meta.customization import CustomizationMatcher
+from app.core.meta.releasegroup import ReleaseGroupsMatcher
+from app.core.meta.words import WordsMatcher
+from app.schemas.types import SystemConfigKey
+
+
+class MetaConfigSourceTest(TestCase):
+    """验证 core/meta 已与数据库解耦：无 provider 时纯算法可用，注入 provider 后生效。"""
+
+    def tearDown(self):
+        set_meta_config_provider(None)
+
+    def test_meta_matcher_modules_no_longer_depend_on_db(self):
+        """core/meta 的 matcher 模块不应再引用 app.db，实例也不应持有 DB 句柄。"""
+        import app.core.meta.customization as customization_mod
+        import app.core.meta.releasegroup as releasegroup_mod
+        import app.core.meta.words as words_mod
+
+        for mod in (words_mod, customization_mod, releasegroup_mod):
+            self.assertNotIn("app.db", inspect.getsource(mod), f"{mod.__name__} 仍引用 app.db")
+
+        self.assertFalse(hasattr(WordsMatcher(), "systemconfig"))
+        self.assertFalse(hasattr(CustomizationMatcher(), "systemconfig"))
+        self.assertFalse(hasattr(ReleaseGroupsMatcher(), "systemconfig"))
+
+    def test_matchers_work_without_provider(self):
+        """未注册 provider（无数据库）时，算法以“无自定义”语义工作。"""
+        set_meta_config_provider(None)
+        self.assertIsNone(get_meta_config(SystemConfigKey.CustomIdentifiers))
+        # 无自定义识别词：标题原样返回、无应用记录
+        title, applied = WordsMatcher().prepare("Some.Movie.2020.1080p")
+        self.assertEqual(title, "Some.Movie.2020.1080p")
+        self.assertEqual(applied, [])
+        # 无自定义占位符：返回空
+        self.assertEqual(CustomizationMatcher().match("[GROUP] Movie"), "")
+        # 无自定义制作组：仍可识别内置组
+        self.assertEqual(ReleaseGroupsMatcher().match("[FRDS] Movie"), "FRDS")
+
+    def test_injected_provider_is_used(self):
+        """注入 provider 后，三个 matcher 均读取注入的配置。"""
+        config = {
+            SystemConfigKey.CustomIdentifiers: ["屏蔽词"],
+            SystemConfigKey.Customization: ["GROUP"],
+            SystemConfigKey.CustomReleaseGroups: ["MyGroup"],
+        }
+        set_meta_config_provider(lambda key: config.get(key))
+        # 自定义屏蔽词生效
+        title, applied = WordsMatcher().prepare("电影 屏蔽词 2020")
+        self.assertNotIn("屏蔽词", title)
+        self.assertIn("屏蔽词", applied)
+        # 自定义占位符生效
+        self.assertEqual(CustomizationMatcher().match("[GROUP] Movie"), "GROUP")
+        # 自定义制作组生效
+        self.assertEqual(ReleaseGroupsMatcher().match("[MyGroup] Movie"), "MyGroup")

--- a/tests/test_release_group.py
+++ b/tests/test_release_group.py
@@ -1,11 +1,15 @@
 from unittest import TestCase
-from unittest.mock import patch
 
 from tests.cases.groups import release_group_cases
+from app.core.meta.config_source import set_meta_config_provider
 from app.core.meta.releasegroup import ReleaseGroupsMatcher
 
 
 class MetaInfoTest(TestCase):
+    def tearDown(self):
+        # 还原注入，避免污染其它用例
+        set_meta_config_provider(None)
+
     def test_release_group(self):
         for info in release_group_cases:
             print(f"开始测试 {info.get('domain')}")
@@ -18,14 +22,10 @@ class MetaInfoTest(TestCase):
     def test_custom_release_group_matches_multiple_adjacent_groups(self):
         """自定义制作组共用分隔符时，应完整保留所有命中项。"""
         matcher = ReleaseGroupsMatcher()
-
-        with patch.object(
-            matcher.systemconfig,
-            "get",
-            return_value=["VCB-Studio|hyakuhuyu|DMG|GM-Team"],
-        ):
-            release_group = matcher.match(
-                "[DMG&VCB-Studio] Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e"
-            )
+        # 通过注入的 config provider 提供自定义制作组，无需数据库
+        set_meta_config_provider(lambda _: ["VCB-Studio|hyakuhuyu|DMG|GM-Team"])
+        release_group = matcher.match(
+            "[DMG&VCB-Studio] Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e"
+        )
 
         self.assertEqual("DMG@VCB-Studio", release_group)


### PR DESCRIPTION
## 背景（架构审计 S1）

`core/meta` 的三个 matcher 此前在 `__init__` 直接 `SystemConfigOper()` 并在运行时读 DB，形成 **3 条 top-level `core→db` 反向依赖**，使元数据解析算法无法脱离数据库复用与单测。本 PR 是「v3-python 渐进式解耦」的第一条接缝（warmup，低成本高收益样板）。

## 改动

- 新增 `app/core/meta/config_source.py`：可注入的 config seam（`get_meta_config` / `set_meta_config_provider`），仅依赖 `app.schemas.types`，**零 `app.db` 依赖**。未注册 provider 时返回 `None`（语义为「无自定义、无需数据库」）。
- `WordsMatcher` / `CustomizationMatcher` / `ReleaseGroupsMatcher` 改用 `get_meta_config` 读取用户自定义配置，移除 `SystemConfigOper` 导入与 `self.systemconfig` 句柄。
- `app/startup/lifecycle.py`（composition root）启动时注册 DB-backed provider（`lambda key: SystemConfigOper().get(key)`），保持线上行为不变。

## 兼容性 / 契约

- **公共 API 不变**：`prepare()` / `match()` 签名与行为一致；自定义识别词/占位符/制作组「保存后实时生效」语义保留（仍经 `SystemConfigOper` 缓存读取）。
- **无破坏性变更**：插件仅使用 `MetaBase`/`MetaVideo`/`MetaInfo` 高层 API，不依赖这三个 matcher 内部；全仓无外部 `.systemconfig` 访问。

## 测试

- [x] `tests/test_meta_config_source.py`（新，3 项）：无 provider 纯算法可用 / 模块不再引用 `app.db` / 注入 provider 生效
- [x] `tests/test_customization_matcher.py`（改注入，1 项）
- [x] `tests/test_release_group.py`（改注入，2 项）
- [x] 回归：`tests/test_metainfo.py` 18 项、`tests/test_subscribe_source_keyword.py` 1 项 全过
- [x] `py_compile` 全过；解耦后 matcher 测试 0.10s 完成、**无需数据库**

## 后续（不在本 PR）

- `app/core/metainfo.py:_rust_default_parse_options` 仍有函数内 lazy `SystemConfigOper`，属另一接缝，后续单独处理。
