### PR TITLE
refactor(core): ThreadHelper 迁至 app.core.thread，消除 core→helper 反向依赖

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -16,10 +16,10 @@ from app.core.context import MediaInfo, SubtitleInfo, TorrentInfo, Context
 from app.core.event import eventmanager, Event
 from app.core.meta import MetaBase
 from app.core.metainfo import MetaInfo
+from app.core.thread import ThreadHelper
 from app.db.downloadhistory_oper import DownloadHistoryOper
 from app.db.mediaserver_oper import MediaServerOper
 from app.helper.directory import DirectoryHelper
-from app.helper.thread import ThreadHelper
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.schemas import ExistMediaInfo, FileURI, NotExistMediaInfo, DownloaderTorrent, Notification, ResourceSelectionEventData, \

--- a/app/command.py
+++ b/app/command.py
@@ -13,8 +13,8 @@ from app.chain.system import SystemChain
 from app.chain.transfer import TransferChain
 from app.core.event import Event as ManagerEvent, eventmanager, Event
 from app.core.plugin import PluginManager
+from app.core.thread import ThreadHelper
 from app.helper.message import MessageHelper
-from app.helper.thread import ThreadHelper
 from app.log import logger
 from app.scheduler import Scheduler
 from app.schemas import Notification, CommandRegisterEventData

--- a/app/core/event.py
+++ b/app/core/event.py
@@ -12,7 +12,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union, Any
 from fastapi.concurrency import run_in_threadpool
 
 from app.core.config import global_vars
-from app.helper.thread import ThreadHelper
+from app.core.thread import ThreadHelper
 from app.log import logger
 from app.schemas import ChainEventData
 from app.schemas.types import ChainEventType, EventType

--- a/app/core/thread.py
+++ b/app/core/thread.py
@@ -1,0 +1,29 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from app.core.config import settings
+from app.utils.singleton import Singleton
+
+
+class ThreadHelper(metaclass=Singleton):
+    """
+    线程池管理
+    """
+    def __init__(self):
+        self.pool = ThreadPoolExecutor(max_workers=settings.CONF.threadpool)
+
+    def submit(self, func, *args, **kwargs):
+        """
+        提交任务
+        :param func: 函数
+        :param args: 参数
+        :param kwargs: 参数
+        :return: future
+        """
+        return self.pool.submit(func, *args, **kwargs)
+
+    def shutdown(self):
+        """
+        关闭线程池
+        :return:
+        """
+        self.pool.shutdown()

--- a/app/helper/thread.py
+++ b/app/helper/thread.py
@@ -1,29 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
+# 兼容垫片：ThreadHelper 已迁移至 app.core.thread（线程池属核心基础设施且依赖 settings，
+# 不应位于 helper 层而被 core 反向依赖）。此处保留 re-export 以兼容历史导入路径。
+from app.core.thread import ThreadHelper
 
-from app.core.config import settings
-from app.utils.singleton import Singleton
-
-
-class ThreadHelper(metaclass=Singleton):
-    """
-    线程池管理
-    """
-    def __init__(self):
-        self.pool = ThreadPoolExecutor(max_workers=settings.CONF.threadpool)
-
-    def submit(self, func, *args, **kwargs):
-        """
-        提交任务
-        :param func: 函数
-        :param args: 参数
-        :param kwargs: 参数
-        :return: future
-        """
-        return self.pool.submit(func, *args, **kwargs)
-
-    def shutdown(self):
-        """
-        关闭线程池
-        :return:
-        """
-        self.pool.shutdown()
+__all__ = ["ThreadHelper"]

--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -20,8 +20,8 @@ from telegramify_markdown.type import ContentTypes, SentType
 from app.core.config import settings
 from app.core.context import MediaInfo, Context
 from app.core.metainfo import MetaInfo
+from app.core.thread import ThreadHelper
 from app.helper.image import ImageHelper
-from app.helper.thread import ThreadHelper
 from app.log import logger
 from app.utils.common import retry
 from app.utils.http import RequestUtils

--- a/app/startup/modules_initializer.py
+++ b/app/startup/modules_initializer.py
@@ -16,7 +16,7 @@ from app.log import logger
 from app.core.config import settings
 from app.core.module import ModuleManager
 from app.core.event import EventManager
-from app.helper.thread import ThreadHelper
+from app.core.thread import ThreadHelper
 from app.helper.display import DisplayHelper
 from app.helper.doh import DohHelper
 from app.helper.resource import ResourceHelper

--- a/tests/test_core_thread_relocation.py
+++ b/tests/test_core_thread_relocation.py
@@ -1,0 +1,29 @@
+import inspect
+from unittest import TestCase
+
+from app.core.thread import ThreadHelper
+
+
+class CoreThreadRelocationTest(TestCase):
+    """ThreadHelper 迁移至 app.core.thread：核心可用、helper 垫片兼容、core 不再反向依赖 helper.thread。"""
+
+    def test_helper_shim_reexports_same_class(self):
+        """app.helper.thread 作为兼容垫片应 re-export 同一个类。"""
+        from app.core.thread import ThreadHelper as CoreTH
+        from app.helper.thread import ThreadHelper as HelperTH
+        self.assertIs(CoreTH, HelperTH)
+
+    def test_submit_executes(self):
+        """迁移后的线程池仍能正常提交并执行任务。"""
+        future = ThreadHelper().submit(lambda x: x + 1, 41)
+        self.assertEqual(future.result(timeout=5), 42)
+
+    def test_core_event_no_longer_imports_helper_thread(self):
+        """core/event 不应再从 helper 反向导入 ThreadHelper。"""
+        import app.core.event as event_mod
+        self.assertNotIn("app.helper.thread", inspect.getsource(event_mod))
+
+    def test_core_thread_has_no_helper_dependency(self):
+        """新的 core.thread 自身不应依赖 helper 层。"""
+        import app.core.thread as thread_mod
+        self.assertNotIn("app.helper", inspect.getsource(thread_mod))


### PR DESCRIPTION
## 背景（架构审计 P1 · S3 的 thread 部分）

`ThreadHelper`（线程池，依赖 `settings`）位于 `app/helper/thread.py`，使 `core/event.py` **顶层反向依赖 helper 层**。审计目标是让 `core` 成为零 `helper` 依赖的稳定底座。本 PR 处理 `core→helper` 的 thread 边。

> 注：`ThreadHelper` 依赖 `settings`，**不能下沉到 `utils`**（会形成 `utils→core` 反向边，正是审计点名的 `core↔utils` 环之一），其正确归属是 `core` 自身。

## 改动

- 新增 `app/core/thread.py`：`ThreadHelper` 权威新家（**内容不变**；仅依赖 `core.config`、`utils.singleton`，方向正确）。
- `app/helper/thread.py` 改为 re-export 兼容垫片（无插件依赖该模块，纯防御性兼容）。
- 5 处内部 importer 改为 `from app.core.thread import ThreadHelper`：`core/event`、`command`、`chain/download`、`modules/telegram`、`startup/modules_initializer`。

## 兼容性 / 契约

- **零行为变化**：`ThreadHelper` 是同一个 Singleton 类，仅 import 路径变化。
- **无破坏性**：全仓无插件 import `helper.thread`；垫片保留旧路径以防外部代码引用。

## 测试

- [x] `tests/test_core_thread_relocation.py`（新，4 项）：垫片同类 / `submit` 实跑 / `core/event` 不再引用 `helper.thread` / `core.thread` 无 helper 依赖
- [x] 回归：`test_metainfo`(18) + `test_customization_matcher`(1) + `test_release_group`(2) 全过（共 25 项）
- [x] `py_compile` 全过；导入冒烟确认**无循环依赖**、shim 与 core 同类、`ThreadHelper().submit` 返回正确

## 范围外（后续接缝）

- `event.py:706` 的 lazy `helper.message`（`MessageHelper` 是插件注入 API，需更谨慎处理）。
- `core/cache → helper.redis`（`RedisHelper` 被 `p115strmhelper` 插件引用，属「破坏契约需迁移窗口」类，单独处理）。
