### PR TITLE
refactor(core): 注入式 auth_level seam — core 彻底去除 helper.sites(security/auth_bridge/plugin)

### DIFF
--- a/app/core/auth_bridge.py
+++ b/app/core/auth_bridge.py
@@ -6,10 +6,10 @@ from typing import Any, Optional
 
 from app import schemas
 from app.core import security
+from app.core.auth_level import get_auth_level
 from app.core.config import settings
 from app.db.models.user import User
 from app.db.systemconfig_oper import SystemConfigOper
-from app.helper.sites import SitesHelper
 from app.schemas.types import SystemConfigKey
 from app.utils.singleton import Singleton
 
@@ -122,7 +122,7 @@ def build_token_response(user: User) -> schemas.Token:
     :param user: 已认证的本地用户
     :return: 标准 Token 响应
     """
-    level = SitesHelper().auth_level
+    level = get_auth_level()
     show_wizard = (
         not SystemConfigOper().get(SystemConfigKey.SetupWizardState)
         and not settings.ADVANCED_MODE

--- a/app/core/auth_level.py
+++ b/app/core/auth_level.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+站点认证等级注入式 seam：解耦 core -> helper.sites。
+
+SitesHelper 是资源包拉取的编译模块（app/helper/sites.*.so），属于 helper 层。
+core 层（security / auth_bridge）原先直接 import SitesHelper 仅为读取 `auth_level`，
+形成 core -> helper 的反向依赖。此 seam 把"读取站点认证等级"抽象为可注入的 provider：
+
+  - 由组合根（app/startup/lifecycle.py）注入 `lambda: SitesHelper().auth_level`；
+  - 未注册时返回未认证默认等级（least privilege），与全新 SitesHelper().auth_level 一致；
+  - 本模块零外部依赖（仅 typing），不反向依赖 helper。
+
+与 app/core/meta/config_source.py（S1）同属注入式 seam 技术。
+"""
+from typing import Callable, Optional
+
+# 未注册 provider 时的默认认证等级：与全新 SitesHelper().auth_level 的初值一致（未认证 / 最小权限）
+DEFAULT_AUTH_LEVEL = 1
+
+_provider: Optional[Callable[[], int]] = None
+
+
+def set_auth_level_provider(provider: Callable[[], int]) -> None:
+    """
+    注册站点认证等级提供者（由组合根调用）。
+    """
+    global _provider
+    _provider = provider
+
+
+def get_auth_level() -> int:
+    """
+    获取当前站点认证等级；未注册 provider 时返回未认证默认等级。
+    """
+    if _provider is None:
+        return DEFAULT_AUTH_LEVEL
+    return _provider()

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -20,6 +20,7 @@ from starlette import status
 from watchfiles import watch
 
 from app import schemas
+from app.core.auth_level import get_auth_level
 from app.core.cache import fresh, async_fresh
 from app.core.config import settings
 from app.core.event import eventmanager
@@ -27,7 +28,6 @@ from app.db.plugindata_oper import PluginDataOper
 from app.db.systemconfig_oper import SystemConfigOper
 from app.helper.server import MoviePilotServerHelper
 from app.helper.plugin import PluginHelper
-from app.helper.sites import SitesHelper  # noqa
 from app.log import logger
 from app.schemas.types import EventType, SystemConfigKey
 from app.utils.crypto import RSAUtils
@@ -1663,8 +1663,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 3 - 站点&密钥认证可见
         # 99 - 站点&特殊密钥认证可见
         # 如果当前站点认证级别大于 1 且插件级别为 99，并存在插件公钥，说明为特殊密钥认证，通过密钥匹配进行认证
-        siteshelper = SitesHelper()
-        if siteshelper.auth_level > 1 and plugin.auth_level == 99 and hasattr(plugin, "plugin_public_key"):
+        current_auth_level = get_auth_level()
+        if current_auth_level > 1 and plugin.auth_level == 99 and hasattr(plugin, "plugin_public_key"):
             plugin_id = plugin.id if isinstance(plugin, schemas.Plugin) else plugin.__name__
             public_key = plugin.plugin_public_key
             if public_key:
@@ -1672,7 +1672,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 verify = RSAUtils.verify_rsa_keys(public_key=public_key, private_key=private_key)
                 return verify
         # 如果当前站点认证级别小于插件级别，则返回 False
-        if siteshelper.auth_level < plugin.auth_level:
+        if current_auth_level < plugin.auth_level:
             return False
         return True
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -17,6 +17,7 @@ from fastapi.security import OAuth2PasswordBearer, APIKeyHeader, APIKeyQuery, AP
 from passlib.context import CryptContext
 
 from app import schemas
+from app.core.auth_level import get_auth_level
 from app.core.cache import cached
 from app.core.config import settings
 from app.log import logger
@@ -84,7 +85,6 @@ def __create_superuser_token_payload() -> schemas.TokenPayload:
     # pylint: disable=import-outside-toplevel
     # pylint: disable=no-name-in-module
     from app.db.user_oper import UserOper
-    from app.helper.sites import SitesHelper  # noqa
 
     user = UserOper().get_by_name(settings.SUPERUSER)
     if not user or not user.is_superuser:
@@ -96,7 +96,7 @@ def __create_superuser_token_payload() -> schemas.TokenPayload:
         sub=user.id,
         username=user.name,
         super_user=user.is_superuser,
-        level=SitesHelper().auth_level,
+        level=get_auth_level(),
         purpose="authentication",
     )
 

--- a/app/startup/lifecycle.py
+++ b/app/startup/lifecycle.py
@@ -17,8 +17,10 @@ except Exception:
     pass
 
 from app.chain.system import SystemChain
+from app.core.auth_level import set_auth_level_provider
 from app.core.config import global_vars, settings
 from app.helper.server import MoviePilotServerHelper
+from app.helper.sites import SitesHelper
 from app.helper.system import SystemHelper
 from app.startup.command_initializer import init_command, stop_command, restart_command
 from app.startup.modules_initializer import init_modules, stop_modules
@@ -63,6 +65,8 @@ async def lifespan(app: FastAPI):
     print("Starting up...")
     # 存储当前循环
     global_vars.set_loop(asyncio.get_event_loop())
+    # 注入站点认证等级提供者（解耦 core -> helper.sites）
+    set_auth_level_provider(lambda: SitesHelper().auth_level)
     # 初始化路由
     init_routers(app)
     # 初始化模块

--- a/tests/test_core_auth_level.py
+++ b/tests/test_core_auth_level.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+S1b 解耦回归测试：core/security 与 core/auth_bridge 通过注入式 seam 读取站点认证等级,
+不再直接 import app.helper.sites（SitesHelper 为资源包拉取的编译 .so 模块,属 helper 层）。
+
+验证：
+  1. 未注册 provider 时 get_auth_level() 返回未认证默认等级（与全新 SitesHelper().auth_level 一致）;
+  2. 注册 provider 后返回注入值（组合根在 lifespan 注入 lambda: SitesHelper().auth_level）;
+  3. core 层不再反向依赖 helper.sites:
+     - app/core/security.py 不再 import app.helper.sites;
+     - app/core/auth_bridge.py 不再 import app.helper.sites;
+     - app/core/auth_level.py 自身无 app.helper 依赖。
+"""
+from pathlib import Path
+from unittest import TestCase
+
+import app.core.auth_level as auth_level
+from app.core.auth_level import DEFAULT_AUTH_LEVEL, get_auth_level, set_auth_level_provider
+
+
+class CoreAuthLevelSeamTest(TestCase):
+
+    def tearDown(self) -> None:
+        # 复位全局 provider,避免测试间状态泄漏
+        auth_level._provider = None
+
+    def test_default_when_no_provider(self):
+        """未注册 provider 时返回未认证默认等级 1"""
+        auth_level._provider = None
+        self.assertEqual(get_auth_level(), DEFAULT_AUTH_LEVEL)
+        self.assertEqual(DEFAULT_AUTH_LEVEL, 1)
+
+    def test_injected_provider_is_used(self):
+        """注册 provider 后 get_auth_level() 返回注入值"""
+        set_auth_level_provider(lambda: 2)
+        self.assertEqual(get_auth_level(), 2)
+
+    def test_core_security_no_longer_imports_helper_sites(self):
+        """app/core/security.py 不再 import app.helper.sites"""
+        import app.core.security as security
+        source = Path(security.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("from app.helper.sites", source)
+        self.assertNotIn("import app.helper.sites", source)
+
+    def test_core_auth_bridge_no_longer_imports_helper_sites(self):
+        """app/core/auth_bridge.py 不再 import app.helper.sites"""
+        import app.core.auth_bridge as auth_bridge
+        source = Path(auth_bridge.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("from app.helper.sites", source)
+        self.assertNotIn("import app.helper.sites", source)
+
+    def test_seam_module_has_no_helper_dependency(self):
+        """app/core/auth_level.py 自身不依赖 app.helper（方向正确）"""
+        source = Path(auth_level.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("app.helper", source)

--- a/tests/test_core_auth_level.py
+++ b/tests/test_core_auth_level.py
@@ -49,6 +49,15 @@ class CoreAuthLevelSeamTest(TestCase):
         self.assertNotIn("from app.helper.sites", source)
         self.assertNotIn("import app.helper.sites", source)
 
+    def test_core_plugin_no_longer_imports_helper_sites(self):
+        """app/core/plugin.py 的 auth_level 读取改走 seam,不再 import app.helper.sites
+        （plugin.py 仍保留 helper.server / helper.plugin,属各自独立接缝）"""
+        import app.core.plugin as plugin
+        source = Path(plugin.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("from app.helper.sites", source)
+        self.assertNotIn("import app.helper.sites", source)
+        self.assertNotIn("SitesHelper", source)
+
     def test_seam_module_has_no_helper_dependency(self):
         """app/core/auth_level.py 自身不依赖 app.helper（方向正确）"""
         source = Path(auth_level.__file__).read_text(encoding="utf-8")


### PR DESCRIPTION
## 背景

用**注入式 seam**(S1 技术)消除 `core→helper.sites` 反向依赖。`SitesHelper` 是资源包拉取的**编译 `.so`**(`app/helper/sites.cpython-*.so`),无源码 → 无法用搬迁+垫片,只能反转依赖方向。

复核全部 3 个 core 引用方,**均只读 `.auth_level` 一个值**:
- `core/security.py`(惰性 import)
- `core/auth_bridge.py`(顶层 import)
- `core/plugin.py`(`__verify_plugin` 中 `siteshelper.auth_level`,读两处)—— 起初误判为"完整对象用法"想推迟,复核后确认同属本接缝

→ 一条共享 seam 同时清掉全部 3 处,**core 层彻底不再 import `helper.sites`**。

## 改动

- 新增 `app/core/auth_level.py`(**零外部依赖**,仅 `typing`):`get_auth_level()` / `set_auth_level_provider()` / `DEFAULT_AUTH_LEVEL = 1`
- `core/security.py` / `core/auth_bridge.py` / `core/plugin.py`:`SitesHelper().auth_level` → `get_auth_level()`,删除各自的 `import SitesHelper`
- `startup/lifecycle.py`:组合根在 `lifespan`(`set_loop` 之后、`init_plugins` 之前)注入 `set_auth_level_provider(lambda: SitesHelper().auth_level)`,为唯一 import SitesHelper 处
- **未注册默认值 = 1**:运行时实测全新 `SitesHelper().auth_level` 初值即 `1`(未认证/最小权限),edge case 字节一致;`get_auth_level()` 解析到同一 SitesHelper 单例,行为不变
- `plugin.py` 仍保留 `helper.server` / `helper.plugin`(各自独立接缝,本 PR 不动)

## 验证

- `tests/test_core_auth_level.py`(6 项):默认=1 / 注入生效 / security、auth_bridge、plugin 三者均无 helper.sites / seam 无 helper 依赖
- `test_core_auth_level` + `test_security_utils` + `test_metainfo` = **57/57 通过**
- `grep` 确认 `app/core/*.py` **已无任何 `helper.sites` 导入**
- `py_compile` 洁净;导入冒烟确认无循环依赖;`app.core.plugin` 可独立导入
- 注:`test_api_authorization` 因本地 venv 预先缺失 `jieba_next`(经 agent 链传染)无法 collect,与本改动无关

## 关联

延续 #3(S1,同为注入式 seam)/ #4 #5 #6(搬迁式)。独立可合并,base `v3-python`。**冲突提醒**:与 #3 同样在 `lifecycle.py` 的 `set_loop` 之后追加 provider 注册,二者合并时该文件一处 trivial 冲突(解法=两行都留)。剩余 `core→helper`:`plugin.py→helper.{server,plugin}`、`event.py:706` 懒加载 `helper.message`。
