### PR TITLE
refactor(core): 注入式插件安装上报 seam 解耦 core/plugin→helper.server

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -23,9 +23,9 @@ from app import schemas
 from app.core.cache import fresh, async_fresh
 from app.core.config import settings
 from app.core.event import eventmanager
+from app.core.plugin_reporter import report_plugin_install
 from app.db.plugindata_oper import PluginDataOper
 from app.db.systemconfig_oper import SystemConfigOper
-from app.helper.server import MoviePilotServerHelper
 from app.helper.plugin import PluginHelper
 from app.helper.sites import SitesHelper  # noqa
 from app.log import logger
@@ -591,7 +591,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             state, msg = PluginHelper().install(pid=plugin.id, repo_url=plugin.repo_url, force_install=True)
             elapsed_time = time.time() - start_time
             if state:
-                MoviePilotServerHelper.install_plugin_reg(plugin_id=plugin.id, repo_url=plugin.repo_url)
+                report_plugin_install(plugin_id=plugin.id, repo_url=plugin.repo_url)
                 logger.info(
                     f"插件 {plugin.plugin_name} 安装成功，版本：{plugin.plugin_version}，耗时：{elapsed_time:.2f} 秒")
                 sync_plugins.append(plugin.id)

--- a/app/core/plugin_reporter.py
+++ b/app/core/plugin_reporter.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+插件安装上报注入式 seam：解耦 core/plugin -> helper.server。
+
+core/plugin 在插件安装成功后上报安装统计,原先直接调用
+MoviePilotServerHelper.install_plugin_reg（helper 层,依赖 db / http / 外部 MP 统计服务器）,
+形成 core -> helper 的反向依赖。此 seam 把"上报插件安装"抽象为可注入 reporter：
+
+  - 由组合根（app/startup/lifecycle.py）注入 MoviePilotServerHelper.install_plugin_reg;
+  - 未注册时为 no-op（与 settings.PLUGIN_STATISTIC_SHARE=False 时跳过上报的语义一致,
+    且上报本就是 fire-and-forget,调用方忽略返回值）;
+  - 本模块零外部依赖（仅 typing），不反向依赖 helper。
+
+与 app/core/auth_level.py（S1b）、app/core/meta/config_source.py（S1）同属注入式 seam。
+"""
+from typing import Any, Callable, Optional
+
+_install_reporter: Optional[Callable[..., Any]] = None
+
+
+def set_plugin_install_reporter(reporter: Callable[..., Any]) -> None:
+    """
+    注册插件安装上报器（由组合根调用）。
+    """
+    global _install_reporter
+    _install_reporter = reporter
+
+
+def report_plugin_install(plugin_id: str, repo_url: Optional[str] = None) -> Any:
+    """
+    上报单个插件安装统计；未注册 reporter 时为 no-op，返回 None。
+    """
+    if _install_reporter is None:
+        return None
+    return _install_reporter(plugin_id=plugin_id, repo_url=repo_url)

--- a/app/startup/lifecycle.py
+++ b/app/startup/lifecycle.py
@@ -18,6 +18,7 @@ except Exception:
 
 from app.chain.system import SystemChain
 from app.core.config import global_vars, settings
+from app.core.plugin_reporter import set_plugin_install_reporter
 from app.helper.server import MoviePilotServerHelper
 from app.helper.system import SystemHelper
 from app.startup.command_initializer import init_command, stop_command, restart_command
@@ -63,6 +64,8 @@ async def lifespan(app: FastAPI):
     print("Starting up...")
     # 存储当前循环
     global_vars.set_loop(asyncio.get_event_loop())
+    # 注入插件安装上报器（解耦 core/plugin -> helper.server）
+    set_plugin_install_reporter(MoviePilotServerHelper.install_plugin_reg)
     # 初始化路由
     init_routers(app)
     # 初始化模块

--- a/tests/test_core_plugin_reporter.py
+++ b/tests/test_core_plugin_reporter.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+S1c 解耦回归测试：core/plugin 通过注入式 seam 上报插件安装,
+不再直接 import app.helper.server.MoviePilotServerHelper。
+
+验证：
+  1. 未注册 reporter 时 report_plugin_install() 为 no-op,返回 None 且不抛异常;
+  2. 注册 reporter 后以正确 kwargs 调用（组合根注入 MoviePilotServerHelper.install_plugin_reg）;
+  3. core 层不再反向依赖 helper.server:
+     - app/core/plugin.py 不再 import app.helper.server / 引用 MoviePilotServerHelper;
+     - app/core/plugin_reporter.py 自身无 app.helper 依赖。
+"""
+from pathlib import Path
+from unittest import TestCase
+
+import app.core.plugin_reporter as plugin_reporter
+from app.core.plugin_reporter import report_plugin_install, set_plugin_install_reporter
+
+
+class CorePluginReporterSeamTest(TestCase):
+
+    def tearDown(self) -> None:
+        # 复位全局 reporter,避免测试间状态泄漏
+        plugin_reporter._install_reporter = None
+
+    def test_noop_when_no_reporter(self):
+        """未注册 reporter 时为 no-op:返回 None 且不抛异常"""
+        plugin_reporter._install_reporter = None
+        self.assertIsNone(report_plugin_install(plugin_id="demo", repo_url="https://example.com/repo"))
+
+    def test_injected_reporter_called_with_kwargs(self):
+        """注册 reporter 后以正确 kwargs 调用并透传返回值"""
+        calls = []
+
+        def fake_reporter(plugin_id, repo_url=None):
+            calls.append({"plugin_id": plugin_id, "repo_url": repo_url})
+            return True
+
+        set_plugin_install_reporter(fake_reporter)
+        result = report_plugin_install(plugin_id="p1", repo_url="https://example.com/p1")
+        self.assertTrue(result)
+        self.assertEqual(calls, [{"plugin_id": "p1", "repo_url": "https://example.com/p1"}])
+
+    def test_core_plugin_no_longer_imports_helper_server(self):
+        """app/core/plugin.py 不再 import app.helper.server / 引用 MoviePilotServerHelper"""
+        import app.core.plugin as plugin
+        source = Path(plugin.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("from app.helper.server", source)
+        self.assertNotIn("import app.helper.server", source)
+        self.assertNotIn("MoviePilotServerHelper", source)
+
+    def test_seam_module_has_no_helper_dependency(self):
+        """app/core/plugin_reporter.py 自身不依赖 app.helper（方向正确）"""
+        source = Path(plugin_reporter.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("app.helper", source)


### PR DESCRIPTION
## 背景

用**注入式 seam**(S1 技术)消除 `core/plugin → helper.server` 反向依赖,并评估后**否决了事件方案**。

`core/plugin` 在插件安装成功后调用 `MoviePilotServerHelper.install_plugin_reg` 上报安装统计(`helper` 层,依赖 db/http/外部 MP 统计服务器)。该调用:
- 是 **fire-and-forget**,调用方忽略返回值;
- 受 `settings.PLUGIN_STATISTIC_SHARE` 开关控制(关闭即跳过);
- 是 `core` 层对 `helper.server` 的**唯一**引用(async 变体的调用方都在 api/agent 层,允许)。

**为何不用事件:** 现有 EventType 无"插件已安装"(只有 PluginReload/Action/Triggered/DataReset),新增 EventType + emitter + 订阅者对一个受开关控制的 fire-and-forget 上报不成比例,且会改变分发时机。provider 方案保持**字节一致、非破坏**。

## 改动

- 新增 `app/core/plugin_reporter.py`(**零外部依赖**,仅 `typing`):`report_plugin_install()` / `set_plugin_install_reporter()`
- `core/plugin.py`:删除 `import MoviePilotServerHelper`,`install_plugin_reg(...)` → `report_plugin_install(...)`
- `startup/lifecycle.py`:组合根在 `lifespan`(`set_loop` 后、`init_plugins` 前)注入 `set_plugin_install_reporter(MoviePilotServerHelper.install_plugin_reg)`
- **未注册时 no-op**(与 `PLUGIN_STATISTIC_SHARE=False` 跳过上报语义一致);生产路径 provider 在 startup 注入,行为不变
- plugin.py 至此仅剩 `helper.plugin` 一条 `core→helper` 边(PluginHelper,~14 处深嵌市场/安装,S5 硬核,另行处理)

## 验证

- 新增 `tests/test_core_plugin_reporter.py`(4 项):no-op 默认 / 注入透传正确 kwargs / plugin.py 无 helper.server 引用 / seam 无 helper 依赖
- `test_core_plugin_reporter` + `test_plugin_helper` + `test_metainfo` = **83/83 通过**
- `py_compile` 洁净;导入冒烟确认无循环依赖、`app.core.plugin` 可独立导入、组合根已接线(源码校验,因 import lifecycle 触发预先缺失的 `jieba_next`)

## 关联

延续 #3(S1)/ #7(S1b)同为注入式 seam。独立可合并,base `v3-python`。**冲突提醒**:(1) 与 #3/#7 同样在 `lifecycle.py` 的 `set_loop` 后追加 provider 注册(解法=多行都留);(2) 与 #7 都改 `plugin.py` 导入块相邻行(#7 去 helper.sites,本 PR 去 helper.server),合并时该处 trivial 冲突。剩余 `core→helper`:`plugin.py→helper.plugin`(S5 硬核)、`event.py:706` 懒加载 `helper.message`。
