### PR TITLE
refactor(plugin): 抽取 local:// URL 纯工具至 app.utils.plugin_repo(S5a)

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -33,6 +33,7 @@ from app.schemas.types import EventType, SystemConfigKey
 from app.utils.crypto import RSAUtils
 from app.utils.mixins import ConfigReloadMixin
 from app.utils.object import ObjectUtils
+from app.utils.plugin_repo import is_local_repo_url, make_local_repo_url
 from app.utils.singleton import Singleton
 from app.utils.string import StringUtils
 from app.utils.system import SystemUtils
@@ -1319,7 +1320,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             plugin = self._process_plugin_info(
                 pid=pid,
                 plugin_info=plugin_info,
-                market=PluginHelper.make_local_repo_url(
+                market=make_local_repo_url(
                     pid,
                     plugin_info.get("repo_path"),
                     package_version
@@ -1418,7 +1419,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         markets = [item for item in settings.PLUGIN_MARKET.split(",") if item]
 
         def repo_order(plugin: schemas.Plugin) -> int:
-            if PluginHelper.is_local_repo_url(plugin.repo_url):
+            if is_local_repo_url(plugin.repo_url):
                 return len(markets) + 1
             if plugin.repo_url in markets:
                 return markets.index(plugin.repo_url)
@@ -1432,7 +1433,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             if not exists:
                 dedup_plugins[key] = plugin
                 continue
-            if PluginHelper.is_local_repo_url(exists.repo_url) and not PluginHelper.is_local_repo_url(plugin.repo_url):
+            if is_local_repo_url(exists.repo_url) and not is_local_repo_url(plugin.repo_url):
                 dedup_plugins[key] = plugin
 
         # 相同 ID 的插件保留版本号最大的版本；同版本市场来源优先。
@@ -1445,8 +1446,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             if StringUtils.compare_version(plugin.plugin_version, ">", exists.plugin_version):
                 result_by_id[plugin.id] = plugin
             elif plugin.plugin_version == exists.plugin_version \
-                    and PluginHelper.is_local_repo_url(exists.repo_url) \
-                    and not PluginHelper.is_local_repo_url(plugin.repo_url):
+                    and is_local_repo_url(exists.repo_url) \
+                    and not is_local_repo_url(plugin.repo_url):
                 result_by_id[plugin.id] = plugin
 
         return list(result_by_id.values())

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -36,10 +36,10 @@ from app.utils.singleton import WeakSingleton
 from app.utils.string import StringUtils
 from app.utils.system import SystemUtils
 from app.utils.url import UrlUtils
+from app.utils import plugin_repo
 from version import APP_VERSION
 
 PLUGIN_DIR = Path(settings.ROOT_PATH) / "app" / "plugins"
-LOCAL_REPO_PREFIX = "local://"
 PLUGIN_SYSTEM_VERSION_FIELD = "system_version"
 
 
@@ -75,7 +75,7 @@ class PluginHelper(metaclass=WeakSingleton):
         """
         判断是否为本地插件来源标识
         """
-        return bool(repo_url and repo_url.startswith(LOCAL_REPO_PREFIX))
+        return plugin_repo.is_local_repo_url(repo_url)
 
     @staticmethod
     def make_local_repo_url(pid: str, repo_path: Optional[Path] = None,
@@ -83,15 +83,7 @@ class PluginHelper(metaclass=WeakSingleton):
         """
         生成本地插件安装来源标识
         """
-        repo_url = f"{LOCAL_REPO_PREFIX}{quote(pid, safe='')}"
-        params = []
-        if repo_path:
-            params.append(f"path={quote(str(repo_path), safe='/:~')}")
-        if package_version:
-            params.append(f"version={quote(package_version, safe='')}")
-        if params:
-            repo_url = f"{repo_url}?{'&'.join(params)}"
-        return repo_url
+        return plugin_repo.make_local_repo_url(pid, repo_path, package_version)
 
     @staticmethod
     def parse_local_repo_url(repo_url: str) -> Optional[str]:
@@ -104,7 +96,7 @@ class PluginHelper(metaclass=WeakSingleton):
             parts = urlsplit(repo_url)
             pid = unquote(parts.netloc or parts.path.strip("/"))
         except Exception:
-            pid = repo_url[len(LOCAL_REPO_PREFIX):].split("?", 1)[0].strip("/")
+            pid = repo_url[len(plugin_repo.LOCAL_REPO_PREFIX):].split("?", 1)[0].strip("/")
         return pid or None
 
     @staticmethod

--- a/app/utils/plugin_repo.py
+++ b/app/utils/plugin_repo.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+本地插件来源标识(local:// URL)的纯工具函数。
+
+这些函数仅做字符串/URL 处理,零 app 依赖,原先以 @staticmethod 形式挂在
+app.helper.plugin.PluginHelper 上,导致 core/plugin 为调用它们而 import 整个 helper 层的
+PluginHelper(反向依赖)。抽取到 utils 纯工具层后,core 与 helper 均可直接引用,
+PluginHelper 保留同名静态方法委托至此(对插件/agent 调用方零改动)。
+
+这是 S5(plugin.py 去 helper.plugin)的第一刀:先剥离无状态的 URL 工具。
+"""
+from pathlib import Path
+from typing import Optional
+from urllib.parse import quote
+
+# 本地插件来源标识前缀
+LOCAL_REPO_PREFIX = "local://"
+
+
+def is_local_repo_url(repo_url: Optional[str]) -> bool:
+    """
+    判断是否为本地插件来源标识
+    """
+    return bool(repo_url and repo_url.startswith(LOCAL_REPO_PREFIX))
+
+
+def make_local_repo_url(pid: str, repo_path: Optional[Path] = None,
+                        package_version: Optional[str] = None) -> str:
+    """
+    生成本地插件安装来源标识
+    """
+    repo_url = f"{LOCAL_REPO_PREFIX}{quote(pid, safe='')}"
+    params = []
+    if repo_path:
+        params.append(f"path={quote(str(repo_path), safe='/:~')}")
+    if package_version:
+        params.append(f"version={quote(package_version, safe='')}")
+    if params:
+        repo_url = f"{repo_url}?{'&'.join(params)}"
+    return repo_url

--- a/tests/test_plugin_repo_url.py
+++ b/tests/test_plugin_repo_url.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+S5a 解耦回归测试：本地插件来源标识(local:// URL)的纯工具函数从
+app.helper.plugin.PluginHelper 抽取到 app.utils.plugin_repo,
+core/plugin 改用 utils,PluginHelper 保留同名静态方法委托至 utils。
+
+验证：
+  1. is_local_repo_url / make_local_repo_url 纯函数行为正确;
+  2. PluginHelper 的同名静态方法委托到 utils,结果一致（插件/agent 调用方零改动）;
+  3. core/plugin 的 6 处调用已改用 utils,不再经由 PluginHelper.{is_local,make_local}_repo_url;
+  4. utils.plugin_repo 自身零 app 依赖（纯工具层）。
+"""
+from pathlib import Path
+from unittest import TestCase
+
+import app.utils.plugin_repo as plugin_repo
+from app.utils.plugin_repo import LOCAL_REPO_PREFIX, is_local_repo_url, make_local_repo_url
+
+
+class PluginRepoUrlTest(TestCase):
+
+    def test_is_local_repo_url(self):
+        self.assertTrue(is_local_repo_url("local://demo"))
+        self.assertFalse(is_local_repo_url("https://github.com/u/r"))
+        self.assertFalse(is_local_repo_url(""))
+        self.assertFalse(is_local_repo_url(None))
+
+    def test_make_local_repo_url_and_roundtrip(self):
+        self.assertEqual(make_local_repo_url("demo"), f"{LOCAL_REPO_PREFIX}demo")
+        # 空格等字符被转义
+        self.assertEqual(make_local_repo_url("a b"), f"{LOCAL_REPO_PREFIX}a%20b")
+        # path / version 参数
+        self.assertEqual(make_local_repo_url("p", repo_path=Path("/a/b")), f"{LOCAL_REPO_PREFIX}p?path=/a/b")
+        self.assertEqual(make_local_repo_url("p", package_version="1.0"), f"{LOCAL_REPO_PREFIX}p?version=1.0")
+        # 生成的标识应被 is_local_repo_url 识别
+        self.assertTrue(is_local_repo_url(make_local_repo_url("p", repo_path=Path("/x"), package_version="2")))
+
+    def test_plugin_helper_delegates_to_utils(self):
+        """PluginHelper 的同名静态方法委托到 utils,结果一致"""
+        from app.helper.plugin import PluginHelper
+        self.assertEqual(PluginHelper.is_local_repo_url("local://demo"), is_local_repo_url("local://demo"))
+        self.assertFalse(PluginHelper.is_local_repo_url("https://x"))
+        self.assertEqual(
+            PluginHelper.make_local_repo_url("p", package_version="3"),
+            make_local_repo_url("p", package_version="3"),
+        )
+
+    def test_core_plugin_uses_utils_not_pluginhelper_for_url(self):
+        """app/core/plugin.py 不再经由 PluginHelper 调用这两个 URL 工具"""
+        import app.core.plugin as plugin
+        source = Path(plugin.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("PluginHelper.is_local_repo_url", source)
+        self.assertNotIn("PluginHelper.make_local_repo_url", source)
+        self.assertIn("from app.utils.plugin_repo import", source)
+
+    def test_util_module_has_no_app_dependency(self):
+        """app/utils/plugin_repo.py 为纯工具层,无 app 依赖"""
+        source = Path(plugin_repo.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("import app.", source)
+        self.assertNotIn("from app.", source)


### PR DESCRIPTION
## 背景

S5(`core/plugin → helper.plugin`)是最后一条非惰性 `core→helper` 边,也是最硬的一条:`PluginHelper` 是 **2488 行的源码大类**(插件市场/安装/仓库管理),`core/plugin.py` 有 **14 处**调用、跨 **9 个方法**。一次拆完风险高,故分两刀:

- **S5a(本 PR)** —— 剥离**无状态的 URL 工具**(`is_local_repo_url` / `make_local_repo_url`),它们是纯字符串处理却挂在 helper 大类上。
- **S5b(后续)** —— 用一个 Protocol 定型的 `get_plugin_source()` inject-provider 收尾剩余 8 处有状态调用(仓库发现/市场拉取/安装/annotate),**彻底移除 `from app.helper.plugin import PluginHelper`**。

## 改动

- 新增 `app/utils/plugin_repo.py`(**纯工具,零 app 依赖** —— 故归 utils 而非 core):`LOCAL_REPO_PREFIX` / `is_local_repo_url` / `make_local_repo_url`
- `core/plugin.py`:**6 处**调用改用 utils(`is_local_repo_url`×5、`make_local_repo_url`×1)
- `helper/plugin.py`:同名静态方法**委托**至 utils,`LOCAL_REPO_PREFIX` 统一来源(DRY)。**`PluginHelper.is_local_repo_url` 等公共静态方法保留** → 插件与 `agent/_plugin_tool_utils.py` 调用方零改动
- ⚠️ 本 PR **不移除** `core/plugin` 的 `PluginHelper` import(尚有 8 处有状态调用),该边由 S5b 收尾 —— 这是有意的增量,非遗漏

## 验证

- 新增 `tests/test_plugin_repo_url.py`(5 项):纯函数行为(含转义/path/version/round-trip)/ `PluginHelper` 委托结果一致 / `core/plugin` 改用 utils 不再经 `PluginHelper.{is_local,make_local}_repo_url` / util 无 app 依赖
- `test_plugin_repo_url` + `test_plugin_helper` = **66/66 通过**;py_compile 洁净;导入冒烟确认委托一致、`core/plugin` 用 utils

## 关联

base `v3-python`(已含 #3–#8)。S5 的第 1/2 刀;S5b 将彻底断开该边。
