### PR TITLE
refactor(plugin): plugin source seam 收尾 core/plugin 去 helper.plugin(S5b,叠在 #9 上)

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -25,9 +25,9 @@ from app.core.cache import fresh, async_fresh
 from app.core.config import settings
 from app.core.event import eventmanager
 from app.core.plugin_reporter import report_plugin_install
+from app.core.plugin_source import get_plugin_source
 from app.db.plugindata_oper import PluginDataOper
 from app.db.systemconfig_oper import SystemConfigOper
-from app.helper.plugin import PluginHelper
 from app.log import logger
 from app.schemas.types import EventType, SystemConfigKey
 from app.utils.crypto import RSAUtils
@@ -317,7 +317,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         # 监视插件目录
         plugin_paths = [str(settings.ROOT_PATH / "app" / "plugins")]
-        for local_repo_path in PluginHelper.get_local_repo_paths():
+        for local_repo_path in get_plugin_source().get_local_repo_paths():
             if local_repo_path.exists() and local_repo_path.is_dir():
                 plugin_paths.append(str(local_repo_path))
         logger.info(">>> 监控线程已启动，准备进入watch循环...")
@@ -445,7 +445,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         try:
             event_path = event_path.resolve()
-            for local_repo_path in PluginHelper.get_local_repo_paths():
+            for local_repo_path in get_plugin_source().get_local_repo_paths():
                 if not local_repo_path.exists() or not local_repo_path.is_dir():
                     continue
                 if not event_path.is_relative_to(local_repo_path):
@@ -463,7 +463,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 else:
                     continue
                 plugin_dir_name = relative_parts[1]
-                candidate = PluginHelper().get_local_plugin_candidate(
+                candidate = get_plugin_source().get_local_plugin_candidate(
                     pid=plugin_dir_name,
                     package_version=package_version,
                     repo_path=local_repo_path,
@@ -486,7 +486,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             logger.info(f"本地插件 {pid} 尚未安装，跳过自动同步和热重载")
             return False
 
-        candidate = candidate or PluginHelper().get_local_plugin_candidate(pid)
+        candidate = candidate or get_plugin_source().get_local_plugin_candidate(pid)
         if not candidate:
             return False
 
@@ -589,7 +589,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
         def install_plugin(plugin):
             start_time = time.time()
-            state, msg = PluginHelper().install(pid=plugin.id, repo_url=plugin.repo_url, force_install=True)
+            state, msg = get_plugin_source().install(pid=plugin.id, repo_url=plugin.repo_url, force_install=True)
             elapsed_time = time.time() - start_time
             if state:
                 report_plugin_install(plugin_id=plugin.id, repo_url=plugin.repo_url)
@@ -651,7 +651,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         安装插件中缺失或不兼容的依赖项
         """
-        pluginhelper = PluginHelper()
+        pluginhelper = get_plugin_source()
         # 第一步：获取需要安装的依赖项列表
         missing_dependencies = pluginhelper.find_missing_dependencies()
         if not missing_dependencies:
@@ -1312,7 +1312,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         plugins = []
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
-        local_candidates = PluginHelper().get_local_plugin_candidates()
+        local_candidates = get_plugin_source().get_local_plugin_candidates()
         if not local_candidates:
             return []
         for pid, plugin_info in local_candidates.items():
@@ -1386,7 +1386,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
         # 获取在线插件
         with fresh(force):
-            online_plugins = PluginHelper().get_plugins(market, package_version)
+            online_plugins = get_plugin_source().get_plugins(market, package_version)
         if online_plugins is None:
             logger.warning(
                 f"获取{package_version if package_version else ''}插件库失败：{market}，请检查 GitHub 网络连接")
@@ -1468,7 +1468,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         if not isinstance(plugin_info, dict):
             return None
 
-        plugin_info = PluginHelper.annotate_plugin_system_version(plugin_info.copy())
+        plugin_info = get_plugin_source().annotate_plugin_system_version(plugin_info.copy())
         # 如 package_version 为空，则需要判断插件是否兼容当前版本
         if not package_version:
             if plugin_info.get(settings.VERSION_FLAG) is not True:
@@ -1624,7 +1624,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
         # 获取在线插件
         async with async_fresh(force):
-            online_plugins = await PluginHelper().async_get_plugins(market, package_version)
+            online_plugins = await get_plugin_source().async_get_plugins(market, package_version)
         if online_plugins is None:
             logger.warning(
                 f"获取{package_version if package_version else ''}插件库失败：{market}，请检查 GitHub 网络连接")

--- a/app/core/plugin_source.py
+++ b/app/core/plugin_source.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+插件来源(plugin source)注入式 seam：解耦 core/plugin -> helper.plugin。
+
+PluginHelper（app/helper/plugin.py，2488 行：插件市场拉取 / 安装 / 依赖管理 / 本地仓库发现）
+是 helper 层重类。core/plugin 原先在模块顶层 `from app.helper.plugin import PluginHelper`
+并在 9 处直接调用,构成 core -> helper 的**顶层** import 反向依赖（import 期层级耦合）。
+
+此 seam 把"获取插件来源对象"抽象为可注入函数：
+  - 默认懒加载返回真实 PluginHelper 单例 —— 行为与原先字节一致,但把对 helper 的引用从
+    模块顶层 import **降级为函数内惰性 import**,从而消除顶层反向边(与 event.py 中惰性
+    导入 helper.message 同属"惰性即无 import 期环"的处理);
+  - 可经 set_plugin_source_provider 注入替代实现,为未来 Rust / 进程外插件宿主预留接入点
+    （strangler-fig 的插件来源边界）。
+
+注:这是 S5 的收尾刀(S5a 已先剥离无状态 URL 工具至 app.utils.plugin_repo)。
+本 seam 故意不在组合根注册 provider —— 默认值本身即生产行为,YAGNI:待第二实现(Rust 宿主)
+出现时再注册替代 provider。
+"""
+from typing import Any, Callable, Optional
+
+_provider: Optional[Callable[[], Any]] = None
+
+
+def set_plugin_source_provider(provider: Callable[[], Any]) -> None:
+    """
+    注入插件来源提供者（为未来替代实现预留；生产默认无需调用）。
+    """
+    global _provider
+    _provider = provider
+
+
+def get_plugin_source() -> Any:
+    """
+    获取插件来源对象。已注入 provider 时用之；否则懒加载返回真实 PluginHelper 单例。
+    """
+    if _provider is not None:
+        return _provider()
+    # 默认:懒加载真实 PluginHelper（WeakSingleton），避免在 core 顶层 import helper
+    from app.helper.plugin import PluginHelper
+    return PluginHelper()

--- a/tests/test_core_plugin_source.py
+++ b/tests/test_core_plugin_source.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+S5b 解耦回归测试：core/plugin 通过 plugin source seam 获取插件来源,
+不再在模块顶层 import app.helper.plugin.PluginHelper。
+
+验证：
+  1. 未注入 provider 时 get_plugin_source() 懒加载返回真实 PluginHelper 单例（行为不变）;
+  2. 注入 provider 后返回注入对象;
+  3. core/plugin.py 不再顶层 import helper.plugin / 引用 PluginHelper;
+  4. plugin_source seam 对 helper 的引用为惰性（函数内），模块顶层无 helper import。
+"""
+from pathlib import Path
+from unittest import TestCase
+
+import app.core.plugin_source as plugin_source
+from app.core.plugin_source import get_plugin_source, set_plugin_source_provider
+
+
+class CorePluginSourceSeamTest(TestCase):
+
+    def tearDown(self) -> None:
+        plugin_source._provider = None
+
+    def test_default_returns_real_plugin_helper(self):
+        """未注入 provider 时返回真实 PluginHelper 单例"""
+        plugin_source._provider = None
+        from app.helper.plugin import PluginHelper
+        source = get_plugin_source()
+        self.assertIsInstance(source, PluginHelper)
+
+    def test_injected_provider_is_used(self):
+        """注入 provider 后 get_plugin_source() 返回注入对象"""
+        sentinel = object()
+        set_plugin_source_provider(lambda: sentinel)
+        self.assertIs(get_plugin_source(), sentinel)
+
+    def test_core_plugin_no_top_level_helper_plugin_import(self):
+        """app/core/plugin.py 不再顶层 import helper.plugin / 引用 PluginHelper"""
+        import app.core.plugin as plugin
+        source = Path(plugin.__file__).read_text(encoding="utf-8")
+        for line in source.splitlines():
+            stripped = line.strip()
+            self.assertFalse(
+                stripped.startswith("from app.helper.plugin") or stripped.startswith("import app.helper.plugin"),
+                f"core/plugin.py 仍有 helper.plugin 导入: {line}",
+            )
+        self.assertNotIn("PluginHelper", source)
+        self.assertIn("from app.core.plugin_source import get_plugin_source", source)
+
+    def test_seam_has_no_top_level_helper_import(self):
+        """plugin_source seam 对 helper 的引用为惰性（缩进在函数内），顶层无 helper import"""
+        source = Path(plugin_source.__file__).read_text(encoding="utf-8")
+        for line in source.splitlines():
+            # 顶层 import 不缩进；惰性 import 在函数体内有缩进
+            if line.startswith("from app.helper") or line.startswith("import app.helper"):
+                self.fail(f"seam 存在顶层 helper import: {line}")
+        # 惰性 import 确实存在（缩进形式）
+        self.assertIn("from app.helper.plugin import PluginHelper", source)


### PR DESCRIPTION
## 背景

S5 收尾刀,**断开最后一条非惰性 `core→helper` 边** `core/plugin → helper.plugin`。

> ⚠️ **Stacked PR**:base 为 `refactor/s5a-plugin-repo-url`(#9),仅展示 S5b 自身改动。合并顺序:**先 #9,再本 PR**(#9 合入 v3-python 后本 PR 的 base 会自动回落到 v3-python)。

`PluginHelper` 是 **2488 行 helper 重类**(市场/安装/依赖/本地仓库)。S5a 已剥离 2 个纯 URL 工具;本 PR 处理剩余 **10 处调用 / 9 个有状态方法**(`get_local_repo_paths` `get_local_plugin_candidate(s)` `get_plugins` `async_get_plugins` `install` `find_missing_dependencies` `install_dependencies` `annotate_plugin_system_version`)。

## 设计(KISS + YAGNI)

不引入冗长的 9 方法 Protocol,而用 **lazy-real default** 的注入点:
- `get_plugin_source()` 默认懒加载返回**真实 PluginHelper 单例** → 行为字节一致,且把 helper 引用从**顶层 import 降级为函数内惰性 import**,消除顶层反向边(与 `event.py:706` 惰性 message 同属"惰性即无 import 期环")
- `set_plugin_source_provider()` 为未来 Rust / 进程外插件宿主预留注入点;**默认即生产行为,故组合根无需注册**(避免又一处 lifecycle.py 改动)
- Protocol 待第二实现(Rust 宿主)真正出现时再加(YAGNI)

## 改动

- 新增 `app/core/plugin_source.py`(顶层零 helper 依赖):`get_plugin_source` / `set_plugin_source_provider`
- `core/plugin.py`:删除 `from app.helper.plugin import PluginHelper`;10 处 `PluginHelper(...)` → `get_plugin_source().X(...)`

## 成果 / 验证

- **`grep '^from app.helper' app/core/*.py` 为空** —— core 层至此**无任何顶层 `core→helper` 反向依赖**(仅剩 `event.py:706` 与本 seam 的惰性引用,无 import 期环)
- 新增 `tests/test_core_plugin_source.py`(4):默认返回真实 PluginHelper / 注入生效 / core/plugin 无 PluginHelper 顶层 import / seam 顶层无 helper import
- `test_core_plugin_source` + `test_plugin_repo_url` + `test_plugin_helper` + `test_plugin_dashboard` + `test_metainfo` = **91/91 通过**;py_compile 洁净;冒烟确认默认返回真实单例且 `get_local_repo_paths()` 经 seam 正常工作
- 注:`test_plugin_endpoint` 因本地 venv 预先缺失 `jieba_next`(经 agent 链传染)无法 collect,与本改动无关
