### PR TITLE
refactor(downloader): torrent_files 归一化为 DownloaderFile,消除契约层下载器 SDK 泄漏(S2)

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Optional, Any, Tuple, List, Set, Union, Dict
 
 from fastapi.concurrency import run_in_threadpool
-from qbittorrentapi import TorrentFilesList
-from transmission_rpc import File
 
 from app.core.cache import FileCache, AsyncFileCache, fresh, async_fresh
 from app.core.config import settings
@@ -30,6 +28,7 @@ from app.schemas import (
     TransferInfo,
     ExistMediaInfo,
     DownloaderTorrent,
+    DownloaderFile,
     CommingMessage,
     Notification,
     WebhookEventInfo,
@@ -1410,7 +1409,7 @@ class ChainBase(metaclass=ABCMeta):
 
     def torrent_files(
             self, tid: str, downloader: Optional[str] = None
-    ) -> Optional[Union[TorrentFilesList, List[File]]]:
+    ) -> Optional[List[DownloaderFile]]:
         """
         获取种子文件
         :param tid:  种子Hash

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -3270,9 +3270,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             if not torrent_files:
                 return False
 
-            if not isinstance(torrent_files, list):
-                torrent_files = torrent_files.data
-
             # 检查是否有媒体文件未被屏蔽且存在
             save_path = torrents[0].path.parent
             for file in torrent_files:

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Set, Tuple, Optional, Union, List, Dict
 
-from qbittorrentapi import TorrentFilesList
 from torrentool.torrent import Torrent
 
 from app import schemas
@@ -578,14 +577,26 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
             return None
         return server.stop_torrents(ids=hashs)
 
-    def torrent_files(self, tid: str, downloader: Optional[str] = None) -> Optional[TorrentFilesList]:
+    def torrent_files(self, tid: str, downloader: Optional[str] = None) -> "Optional[List[schemas.DownloaderFile]]":
         """
-        获取种子文件列表
+        获取种子文件列表（归一化为 DownloaderFile，不再泄漏 qbittorrentapi 的 SDK 类型）
         """
         server: Qbittorrent = self.get_instance(downloader)
         if not server:
             return None
-        return server.get_files(tid=tid)
+        files = server.get_files(tid=tid)
+        if files is None:
+            return None
+        return [
+            schemas.DownloaderFile(
+                name=getattr(f, "name", None),
+                size=getattr(f, "size", None),
+                progress=getattr(f, "progress", None),
+                priority=getattr(f, "priority", None),
+                index=getattr(f, "index", idx),
+            )
+            for idx, f in enumerate(files)
+        ]
 
     def downloader_info(self, downloader: Optional[str] = None) -> Optional[List[schemas.DownloaderInfo]]:
         """

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Set, Tuple, Optional, Union, List, Dict
 
 from torrentool.torrent import Torrent
-from transmission_rpc import File
 
 from app import schemas
 from app.core.cache import FileCache
@@ -610,15 +609,31 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
             return None
         return server.stop_torrents(ids=hashs)
 
-    def torrent_files(self, tid: str, downloader: Optional[str] = None) -> Optional[List[File]]:
+    def torrent_files(self, tid: str, downloader: Optional[str] = None) -> "Optional[List[schemas.DownloaderFile]]":
         """
-        获取种子文件列表
+        获取种子文件列表（归一化为 DownloaderFile，不再泄漏 transmission_rpc 的 SDK 类型）
         """
         # 获取下载器
         server: Transmission = self.get_instance(downloader)
         if not server:
             return None
-        return server.get_files(tid=tid)
+        files = server.get_files(tid=tid)
+        if files is None:
+            return None
+        result: List[schemas.DownloaderFile] = []
+        for idx, f in enumerate(files):
+            size = getattr(f, "size", None)
+            completed = getattr(f, "completed", None)
+            progress = (completed / size) if (size and completed is not None) else None
+            priority = getattr(f, "priority", None)
+            result.append(schemas.DownloaderFile(
+                name=getattr(f, "name", None),
+                size=size,
+                progress=progress,
+                priority=priority if isinstance(priority, int) else None,
+                index=getattr(f, "id", idx),
+            ))
+        return result
 
     def downloader_info(self, downloader: Optional[str] = None) -> Optional[List[schemas.DownloaderInfo]]:
         """

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -41,6 +41,22 @@ class DownloaderTorrent(BaseModel):
     left_time: Optional[str] = None
 
 
+class DownloaderFile(BaseModel):
+    """
+    下载器种子文件信息（归一化，屏蔽 qBittorrent / Transmission 等下载器 SDK 的文件对象差异）
+    """
+    # 文件在种子内的相对路径/名称（qB、tr 一致）
+    name: Optional[str] = None
+    # 文件大小（字节）
+    size: Optional[int] = None
+    # 下载进度 0~1（qB 原生 progress；tr 由 completed/size 计算）
+    progress: Optional[float] = 0.0
+    # 文件优先级（下载器原生取值，语义随下载器；0 通常表示不下载）
+    priority: Optional[int] = None
+    # 文件在种子中的索引/ID（qB 为 index，tr 为 id；用于设置文件优先级等）
+    index: Optional[int] = None
+
+
 class TransferTorrent(DownloaderTorrent):
     """
     待转移任务信息

--- a/tests/test_downloader_file_normalization.py
+++ b/tests/test_downloader_file_normalization.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+S2 解耦回归测试：下载器 torrent_files() 归一化为 schemas.DownloaderFile,
+不再向契约层(ChainBase)泄漏 qbittorrentapi / transmission_rpc 的 SDK 文件类型。
+
+验证：
+  1. DownloaderFile schema 基本构造/默认值;
+  2. qBittorrent 模块 torrent_files() 把 SDK 文件对象转为 DownloaderFile（含字段映射）;
+  3. Transmission 模块 torrent_files() 同上（progress 由 completed/size 计算,index 取 id）;
+  4. 契约层不再泄漏:app/chain/__init__.py 不再 import 下载器 SDK,返回类型为 DownloaderFile;
+     两个下载器模块不再 import SDK 文件类型。
+"""
+from pathlib import Path
+from unittest import TestCase
+
+from app import schemas
+from app.modules.qbittorrent import QbittorrentModule
+from app.modules.transmission import TransmissionModule
+
+
+class _FakeQbFile:
+    """模拟 qbittorrentapi 的 TorrentFile（属性可访问）"""
+    def __init__(self, name, size, progress, priority, index):
+        self.name = name
+        self.size = size
+        self.progress = progress
+        self.priority = priority
+        self.index = index
+
+
+class _FakeTrFile:
+    """模拟 transmission_rpc 的 File（completed/size + id）"""
+    def __init__(self, name, size, completed, priority, id):
+        self.name = name
+        self.size = size
+        self.completed = completed
+        self.priority = priority
+        self.id = id
+
+
+class _FakeServer:
+    def __init__(self, files):
+        self._files = files
+
+    def get_files(self, tid):
+        return self._files
+
+
+class DownloaderFileNormalizationTest(TestCase):
+
+    def test_schema_defaults(self):
+        f = schemas.DownloaderFile()
+        self.assertIsNone(f.name)
+        self.assertIsNone(f.size)
+        self.assertEqual(f.progress, 0.0)
+        f2 = schemas.DownloaderFile(name="a/b.mkv", size=100, progress=0.5, priority=1, index=2)
+        self.assertEqual(f2.name, "a/b.mkv")
+        self.assertEqual(f2.size, 100)
+
+    def test_qbittorrent_torrent_files_normalized(self):
+        mod = QbittorrentModule.__new__(QbittorrentModule)  # 绕过 __init__,避免连接下载器
+        mod.get_instance = lambda downloader=None: _FakeServer([_FakeQbFile("a/b.mkv", 100, 0.5, 1, 0)])
+        files = QbittorrentModule.torrent_files(mod, tid="hash")
+        self.assertIsInstance(files, list)
+        self.assertIsInstance(files[0], schemas.DownloaderFile)
+        self.assertEqual(files[0].name, "a/b.mkv")
+        self.assertEqual(files[0].size, 100)
+        self.assertEqual(files[0].progress, 0.5)
+        self.assertEqual(files[0].priority, 1)
+        self.assertEqual(files[0].index, 0)
+
+    def test_qbittorrent_torrent_files_none_when_no_server(self):
+        mod = QbittorrentModule.__new__(QbittorrentModule)
+        mod.get_instance = lambda downloader=None: None
+        self.assertIsNone(QbittorrentModule.torrent_files(mod, tid="hash"))
+
+    def test_transmission_torrent_files_normalized(self):
+        mod = TransmissionModule.__new__(TransmissionModule)
+        mod.get_instance = lambda downloader=None: _FakeServer([_FakeTrFile("x.mkv", 200, 100, 1, 3)])
+        files = TransmissionModule.torrent_files(mod, tid="hash")
+        self.assertIsInstance(files, list)
+        self.assertIsInstance(files[0], schemas.DownloaderFile)
+        self.assertEqual(files[0].name, "x.mkv")
+        self.assertEqual(files[0].size, 200)
+        self.assertEqual(files[0].progress, 0.5)  # completed/size = 100/200
+        self.assertEqual(files[0].index, 3)  # 取自 id
+
+    def test_contract_no_sdk_leak(self):
+        import app.chain as chain_pkg
+        chain_src = Path(chain_pkg.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("qbittorrentapi", chain_src)
+        self.assertNotIn("transmission_rpc", chain_src)
+        self.assertIn("Optional[List[DownloaderFile]]", chain_src)
+        # 两个模块不再 import SDK 文件类型
+        import app.modules.qbittorrent as q
+        import app.modules.transmission as t
+        self.assertNotIn("import TorrentFilesList", Path(q.__file__).read_text(encoding="utf-8"))
+        self.assertNotIn("transmission_rpc import File", Path(t.__file__).read_text(encoding="utf-8"))


### PR DESCRIPTION
## 背景

消除下载器 SDK 泄漏到契约层。`ChainBase.torrent_files()`(插件可见的契约方法)原返回 `Optional[Union[qbittorrentapi.TorrentFilesList, List[transmission_rpc.File]]]`,把第三方下载器 SDK 类型暴露到 chain/插件层。

立项调研结论:泄漏**高度集中** —— 这是 chain 层下载器契约里**唯一**泄漏 SDK 的方法(`download`→tuple、`list_torrents`→`DownloaderTorrent` schema 均已归一化)。本 PR 照搬 `list_torrents → DownloaderTorrent`(经 `__build_torrent` 转换)的既有先例。

## 改动(6 文件)

- 新增 `schemas.DownloaderFile`(`name/size/progress/priority/index`)
- `qbittorrent`/`transmission` 模块 `torrent_files()` 把各自 SDK 文件对象转为 `List[DownloaderFile]`(**SDK 知识下沉进模块**,qB 的 `.data` 解包、tr 的 `completed/size→progress`、`id→index` 都在模块内处理)
- `ChainBase.torrent_files()` 返回 `-> Optional[List[DownloaderFile]]`,**删除 `chain/__init__.py` 的 `qbittorrentapi`/`transmission_rpc` import**
- `chain/transfer.py` 删除针对 qB `TorrentFilesList.data` 的 `isinstance/.data` 兼容判断(现恒为 list)
- 模块返回注解用**前向引用字符串**,规避导入期对晚初始化 schema 求值(`DownloaderFile` 源于 `.transfer`,晚于 `.download` 的 `DownloaderInfo`)

## ⚠️ 契约变更说明(给插件作者)

`chain.torrent_files()` 返回类型由下载器 SDK 对象改为 `List[schemas.DownloaderFile]`。
- **常规用法不破坏**:`DownloaderFile` 保留两 SDK 的公共属性名 `.name` / `.size` / `.progress` / `.priority`,`for f in files: f.name / f.size` 照常工作。
- **可能受影响**:若外部市场插件读取 **SDK 专属属性**(如 qB 的 `.availability`/`.piece_range`、tr 的 `.selected`),需改用归一化字段。仓库内已验证 **0 插件消费**、唯一内部消费者 `transfer.py` 仅读 `.name`。
- 未加弃用垫片(YAGNI):公共属性名保留即覆盖常规用法,SDK 专属属性属长尾,以本说明为迁移指引。

## 验证

- 新增 `tests/test_downloader_file_normalization.py`(5):schema 默认值 / qB 转换字段映射 / tr 转换(progress=completed/size、index=id)/ 无下载器返回 None / 契约层无 SDK import 且返回类型为 DownloaderFile
- `test_downloader_file_normalization` + `test_downloader_path_mapping` + `test_download_chain` + `test_metainfo` = **45/45 通过**;py_compile 洁净;全仓 grep 确认 `torrent_files()` 唯一调用方已更新、无残留 SDK 引用
- 注:`test_data_cleanup_chain` 因本地 venv 预先缺失 `jieba_next` 无法 collect,与本改动无关

## 关联

base `v3-python`。审计 S2(原标"破坏契约大迁移")经立项重定为单 PR、低破坏风险。
