### PR TITLE
refactor(chain): 经 agent_gateway 打断 chain↔agent import-time 循环(S4/P2)

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -5,7 +5,6 @@ import traceback
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
 from fastapi.concurrency import run_in_threadpool
@@ -54,7 +53,7 @@ from app.db.user_oper import UserOper
 from app.log import logger
 from app.schemas import AgentLLMProviderEventData, AgentTokensUsageEventData, Notification, NotificationType
 from app.schemas.message import ChannelCapabilityManager, ChannelCapability
-from app.schemas.types import ChainEventType, EventType, MessageChannel
+from app.schemas.types import ChainEventType, EventType, MessageChannel, ReplyMode
 from app.utils.identity import SYSTEM_INTERNAL_USER_ID
 
 
@@ -216,13 +215,7 @@ class _ThinkTagStripper:
             self.buffer = ""
 
 
-class ReplyMode(str, Enum):
-    """
-    Agent 最终回复处理模式。
-    """
-
-    DISPATCH = "dispatch"
-    CAPTURE_ONLY = "capture_only"
+# ReplyMode 已迁移至 app.schemas.types(打断 chain↔agent 循环 S4),此处经 import 顶层 re-export 保持 `from app.agent import ReplyMode` 向后兼容
 
 
 HEARTBEAT_SESSION_PREFIX = "__agent_heartbeat_"

--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -11,8 +11,13 @@ from pathlib import Path
 from typing import Any, Optional, Dict, Union, List, Tuple
 from urllib.parse import unquote, urlparse
 
-from app.agent import ReplyMode, agent_manager, prompt_manager
-from app.agent.llm import AgentCapabilityManager, LLMHelper
+from app.core.agent_gateway import (
+    get_agent_capability,
+    get_agent_llm,
+    get_agent_manager,
+    get_prompt_manager,
+)
+from app.schemas.types import ReplyMode
 from app.chain import ChainBase
 from app.chain.download import DownloadChain
 from app.chain.media import MediaChain
@@ -58,7 +63,7 @@ class MessageChain(ChainBase):
             return
         clear_task = None
         try:
-            clear_task = agent_manager.clear_session(session_id=session_id, user_id=str(userid))
+            clear_task = get_agent_manager().clear_session(session_id=session_id, user_id=str(userid))
             asyncio.run_coroutine_threadsafe(
                 clear_task,
                 global_vars.loop,
@@ -895,7 +900,7 @@ class MessageChain(ChainBase):
                 "doubanid": his.doubanid or "none",
                 "error_message": his.errmsg or "none",
             }
-            return prompt_manager.render_system_task_message(
+            return get_prompt_manager().render_system_task_message(
                 "manual_transfer_redo",
                 template_context=template_context,
             )
@@ -949,7 +954,7 @@ class MessageChain(ChainBase):
                 final_output = text_output or ""
 
             try:
-                await agent_manager.run_background_prompt(
+                await get_agent_manager().run_background_prompt(
                     message=redo_prompt,
                     session_prefix=f"__agent_manual_redo_{history_id}",
                     output_callback=_capture_output,
@@ -1082,7 +1087,7 @@ class MessageChain(ChainBase):
         if session_id:
             clear_task = None
             try:
-                clear_task = agent_manager.clear_session(
+                clear_task = get_agent_manager().clear_session(
                     session_id=session_id, user_id=str(userid)
                 )
                 asyncio.run_coroutine_threadsafe(
@@ -1129,7 +1134,7 @@ class MessageChain(ChainBase):
             session_id, _ = session_info
             try:
                 future = asyncio.run_coroutine_threadsafe(
-                    agent_manager.stop_current_task(session_id=session_id),
+                    get_agent_manager().stop_current_task(session_id=session_id),
                     global_vars.loop,
                 )
                 stopped = future.result(timeout=10)
@@ -1222,7 +1227,7 @@ class MessageChain(ChainBase):
             return
 
         session_id, _ = session_info
-        status = agent_manager.get_session_status(session_id=session_id)
+        status = get_agent_manager().get_session_status(session_id=session_id)
         self.post_message(
             Notification(
                 channel=channel,
@@ -1292,7 +1297,7 @@ class MessageChain(ChainBase):
             # 将可直接输入给 LLM 的附件统一转换为 data URL
             original_images = images
             all_files = list(files or [])
-            if images and LLMHelper.supports_image_input():
+            if images and get_agent_llm().supports_image_input():
                 images = self._download_attachments_to_data_urls(
                     images, channel, source
                 )
@@ -1364,7 +1369,7 @@ class MessageChain(ChainBase):
                 process_kwargs["has_audio_input"] = True
             # 在事件循环中处理
             asyncio.run_coroutine_threadsafe(
-                agent_manager.process_message(**process_kwargs),
+                get_agent_manager().process_message(**process_kwargs),
                 global_vars.loop,
             )
             return True
@@ -1384,7 +1389,7 @@ class MessageChain(ChainBase):
         """
         if not audio_refs:
             return None
-        if not AgentCapabilityManager.is_audio_input_available():
+        if not get_agent_capability().is_audio_input_available():
             logger.warning("音频输入能力未配置或未启用，跳过语音识别")
             return None
 
@@ -1491,7 +1496,7 @@ class MessageChain(ChainBase):
                     )
                     continue
 
-                transcript = AgentCapabilityManager.transcribe_audio(
+                transcript = get_agent_capability().transcribe_audio(
                     content=content, filename=filename
                 )
                 if transcript:

--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -378,10 +378,10 @@ class SearchChain(ChainBase):
         """
         通过统一后台提示词机制执行资源推荐。
         """
-        from app.agent import ReplyMode, agent_manager
-        from app.agent.prompt import prompt_manager
+        from app.core.agent_gateway import get_agent_manager, get_prompt_manager
+        from app.schemas.types import ReplyMode
 
-        prompt = prompt_manager.render_system_task_message(
+        prompt = get_prompt_manager().render_system_task_message(
             "search_recommend",
             template_context={"search_results": search_results_text},
         )
@@ -390,7 +390,7 @@ class SearchChain(ChainBase):
         def on_output(text: str):
             full_output[0] = text
 
-        await agent_manager.run_background_prompt(
+        await get_agent_manager().run_background_prompt(
             message=prompt,
             session_prefix="__agent_search_recommend",
             output_callback=on_output,

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union, Dict, Callable, Any
 
 from app import schemas
-from app.agent import ReplyMode, prompt_manager, agent_manager
+from app.core.agent_gateway import get_agent_manager, get_prompt_manager
+from app.schemas.types import ReplyMode
 from app.chain import ChainBase
 from app.chain.media import MediaChain
 from app.chain.storage import StorageChain
@@ -667,7 +668,7 @@ class FailedRetryScheduler:
     def _build_retry_transfer_prompt(self, history_ids: list[int]) -> str:
         """根据失败记录数量构建统一的重试整理后台任务提示词。"""
         task_type, template_context = self._build_retry_transfer_template_context(history_ids)
-        return prompt_manager.render_system_task_message(
+        return get_prompt_manager().render_system_task_message(
             task_type,
             template_context=template_context,
         )
@@ -715,7 +716,7 @@ class FailedRetryScheduler:
         )
 
         try:
-            await agent_manager.run_background_prompt(
+            await get_agent_manager().run_background_prompt(
                 message=self._build_retry_transfer_prompt(history_ids),
                 session_prefix="__agent_retry_transfer_batch",
                 reply_mode=ReplyMode.DISPATCH,

--- a/app/core/agent_gateway.py
+++ b/app/core/agent_gateway.py
@@ -1,0 +1,69 @@
+"""
+Agent 运行时网关 seam(S4 / P2)。
+
+供业务层 chain 在 **call-time** 反向调用 agent 层,从而把 `chain → app.agent`
+的依赖从模块顶层 import 降级为函数内惰性 import,打断 chain↔agent 的 import-time
+循环(agent 仍在顶层依赖 chain,是健康的编排方向,保持不变)。
+
+默认行为 = 惰性导入并返回真实的 agent 单例/类(与直接 import 字节一致);
+`set_*_provider` 为未来 Rust / 进程外 agent host 预留的注入点(测试亦可借此替换),
+默认不在 composition root 注册——默认即生产行为。
+"""
+from typing import Any, Callable, Optional
+
+_agent_manager_provider: Optional[Callable[[], Any]] = None
+_prompt_manager_provider: Optional[Callable[[], Any]] = None
+_agent_llm_provider: Optional[Callable[[], Any]] = None
+_agent_capability_provider: Optional[Callable[[], Any]] = None
+
+
+def set_agent_manager_provider(provider: Optional[Callable[[], Any]]) -> None:
+    global _agent_manager_provider
+    _agent_manager_provider = provider
+
+
+def set_prompt_manager_provider(provider: Optional[Callable[[], Any]]) -> None:
+    global _prompt_manager_provider
+    _prompt_manager_provider = provider
+
+
+def set_agent_llm_provider(provider: Optional[Callable[[], Any]]) -> None:
+    global _agent_llm_provider
+    _agent_llm_provider = provider
+
+
+def set_agent_capability_provider(provider: Optional[Callable[[], Any]]) -> None:
+    global _agent_capability_provider
+    _agent_capability_provider = provider
+
+
+def get_agent_manager() -> Any:
+    """返回 AgentManager 单例(会话/后台提示词调度)。"""
+    if _agent_manager_provider is not None:
+        return _agent_manager_provider()
+    from app.agent import agent_manager
+    return agent_manager
+
+
+def get_prompt_manager() -> Any:
+    """返回 prompt_manager 单例(系统/任务提示词渲染)。"""
+    if _prompt_manager_provider is not None:
+        return _prompt_manager_provider()
+    from app.agent.prompt import prompt_manager
+    return prompt_manager
+
+
+def get_agent_llm() -> Any:
+    """返回 LLMHelper 类(模型能力查询,如 supports_image_input)。"""
+    if _agent_llm_provider is not None:
+        return _agent_llm_provider()
+    from app.agent.llm import LLMHelper
+    return LLMHelper
+
+
+def get_agent_capability() -> Any:
+    """返回 AgentCapabilityManager 类(音频输入能力 / 转写)。"""
+    if _agent_capability_provider is not None:
+        return _agent_capability_provider()
+    from app.agent.llm import AgentCapabilityManager
+    return AgentCapabilityManager

--- a/app/helper/skill.py
+++ b/app/helper/skill.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urljoin, urlparse
 
-from app.agent.middleware.skills import _parse_skill_metadata
 from app.core.cache import cached, fresh
 from app.core.config import settings
 from app.log import logger
@@ -31,6 +30,17 @@ _OFFICIAL_SKILL_REPOS = {
     "vercel-labs/agent-skills",
     "NousResearch/hermes-agent",
 }
+
+
+def _parse_skill_metadata(content: str, skill_path: str, skill_id: str):
+    """惰性转发到 agent 层技能元数据解析器。
+
+    helper.skill 不在 import-time 反依赖 app.agent(打断 chain↔agent 循环 S4):
+    chain.skills → helper.skill 不再于导入期拉起整个 agent 栈;
+    解析逻辑仍归 app.agent.middleware.skills 所有(返回其 SkillMetadata 类型)。
+    """
+    from app.agent.middleware.skills import _parse_skill_metadata as _impl
+    return _impl(content, skill_path, skill_id)
 
 
 @dataclass

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -478,3 +478,13 @@ class ScrapingMetadata(NameValueEnum):
     DISC = "光盘图"
     CLEARART = "透明艺术图"
     LANDSCAPE = "横版缩略图"
+
+
+# Agent 最终回复处理模式
+class ReplyMode(str, Enum):
+    """
+    Agent 最终回复处理模式。
+    """
+
+    DISPATCH = "dispatch"
+    CAPTURE_ONLY = "capture_only"

--- a/tests/test_agent_gateway.py
+++ b/tests/test_agent_gateway.py
@@ -1,0 +1,95 @@
+"""
+S4 / P2 回归:agent_gateway seam 打断 chain↔agent import-time 循环。
+
+本地 venv 中 `import app.agent` 会拉起 langchain 并触发预存的 jieba_next 缺失,
+故 lazy-default 路径(真实单例)无法在此直接 import 验证;改以
+(a) provider 注入路径 + (b) 源码结构契约 两类断言覆盖。
+"""
+from pathlib import Path
+
+import pytest
+
+from app.core import agent_gateway
+
+APP_DIR = Path(__file__).resolve().parent.parent / "app"
+
+
+@pytest.fixture(autouse=True)
+def _reset_providers():
+    """每个用例后清空所有 provider,避免全局态泄漏到其它测试。"""
+    yield
+    agent_gateway.set_agent_manager_provider(None)
+    agent_gateway.set_prompt_manager_provider(None)
+    agent_gateway.set_agent_llm_provider(None)
+    agent_gateway.set_agent_capability_provider(None)
+
+
+# ---- (a) provider 注入路径:有 provider 时返回注入对象,不触发真实 agent import ----
+
+def test_get_agent_manager_returns_injected_provider():
+    sentinel = object()
+    agent_gateway.set_agent_manager_provider(lambda: sentinel)
+    assert agent_gateway.get_agent_manager() is sentinel
+
+
+def test_get_prompt_manager_returns_injected_provider():
+    sentinel = object()
+    agent_gateway.set_prompt_manager_provider(lambda: sentinel)
+    assert agent_gateway.get_prompt_manager() is sentinel
+
+
+def test_get_agent_llm_returns_injected_provider():
+    sentinel = object()
+    agent_gateway.set_agent_llm_provider(lambda: sentinel)
+    assert agent_gateway.get_agent_llm() is sentinel
+
+
+def test_get_agent_capability_returns_injected_provider():
+    sentinel = object()
+    agent_gateway.set_agent_capability_provider(lambda: sentinel)
+    assert agent_gateway.get_agent_capability() is sentinel
+
+
+def test_providers_independent():
+    """注入其一不影响其它访问器(仍为各自默认/None 判定)。"""
+    sentinel = object()
+    agent_gateway.set_prompt_manager_provider(lambda: sentinel)
+    assert agent_gateway.get_prompt_manager() is sentinel
+    # 其它三个未注入 —— 仍为 None provider(此处只断言访问器互不串扰)
+    assert agent_gateway._agent_manager_provider is None
+    assert agent_gateway._agent_llm_provider is None
+    assert agent_gateway._agent_capability_provider is None
+
+
+# ---- (b) 源码结构契约:import-time 循环已断 ----
+
+def test_gateway_has_no_top_level_agent_import():
+    """网关自身对 app.agent 的引用必须全部在函数体内(惰性),顶层零引用。"""
+    src = (APP_DIR / "core" / "agent_gateway.py").read_text(encoding="utf-8")
+    for line in src.splitlines():
+        # 顶层 import 必然顶格;函数内惰性 import 有缩进
+        assert not line.startswith("from app.agent"), f"网关顶层不应直接 import agent: {line}"
+        assert not line.startswith("import app.agent"), f"网关顶层不应直接 import agent: {line}"
+
+
+@pytest.mark.parametrize("rel", ["chain/transfer.py", "chain/message.py", "chain/search.py"])
+def test_chain_has_no_agent_import(rel):
+    """chain 三个回边文件不得再以任何形式 import app.agent(顶层或惰性均已改走网关)。"""
+    src = (APP_DIR / rel).read_text(encoding="utf-8")
+    offenders = [ln.strip() for ln in src.splitlines() if "from app.agent" in ln]
+    assert not offenders, f"{rel} 仍残留 chain→agent 直连: {offenders}"
+
+
+def test_replymode_importable_from_schemas_types():
+    from app.schemas.types import ReplyMode
+    assert issubclass(ReplyMode, str)
+    assert ReplyMode.DISPATCH.value == "dispatch"
+    assert ReplyMode.CAPTURE_ONLY.value == "capture_only"
+
+
+def test_agent_init_reexports_replymode():
+    """agent/__init__.py 仍以 shim 顶层 re-export ReplyMode,保 `from app.agent import ReplyMode` 兼容。"""
+    src = (APP_DIR / "agent" / "__init__.py").read_text(encoding="utf-8")
+    assert "from app.schemas.types import" in src and "ReplyMode" in src
+    # 旧的本地定义必须已移除,避免双源
+    assert "class ReplyMode" not in src


### PR DESCRIPTION
## 目标(S4 / 审计 P2 CRITICAL)

打断 `chain ↔ agent` 的 **import-time 循环**。`agent → chain` 是健康的编排方向(每个 agent tool 包一个 chain,~28 条顶层边),**保留不动**;真正的环源是 `chain → agent` 的回边。本 PR 移除 chain 包对 agent 包的**全部导入期依赖**。

## 改动

1. **ReplyMode 下沉**:纯 `str, Enum` 从 `app/agent/__init__.py` 迁至 `app/schemas/types.py`(与 `MessageChannel`/`EventType` 等共享枚举同处)。`agent/__init__.py` 顶层 `from app.schemas.types import ... ReplyMode` 作 **re-export shim** → `from app.agent import ReplyMode` 对 `api/endpoints/{agent,history}.py` 等外部引用零改动(api→agent 是健康方向,不在环内)。
2. **新增 `app/core/agent_gateway.py`** inject-provider seam(惰性真实默认,与 S5b `plugin_source` 同一范式):`get_agent_manager` / `get_prompt_manager` / `get_agent_llm` / `get_agent_capability`,无 provider 时惰性导入并返回真实单例/类(= 与直接 import **字节一致**),把 agent 导入从 chain 顶层降级到 call-time。`set_*_provider` 为未来 Rust / 进程外 agent host 预留;**不入 composition root**(默认即生产行为)。
3. **reroute chain 调用**:`chain/transfer.py`(3 处)、`chain/message.py`(11 处)、`chain/search.py`(3 处)改经网关访问器,移除顶层及惰性的 `from app.agent`。
4. **断间接回边**:`helper/skill.py` 的 `_parse_skill_metadata` 改为**同名惰性转发包装**,断开 `chain.skills → helper.skill → app.agent` 这条隐藏的 import-time 回边(原 `helper.skill` 顶层 `from app.agent.middleware.skills import ...` 会在导入期拉起整个 agent 栈)。解析逻辑仍归 agent 所有。

## 验证

- **环已断(终极证明)**:导入**全部 21 个 `app.chain.*` 子模块**后,`app.agent` **不在 `sys.modules`**(零失败)。
- `chain.transfer/message/search` 现可干净导入,连带绕开预存的 `jieba_next` 缺失阻塞 → **`test_data_cleanup_chain` 由此解锁(5 passed)**。
- 新增 `tests/test_agent_gateway.py`(11):provider 注入路径 + 源码结构契约(chain 无 `from app.agent`、网关顶层无 agent import、ReplyMode 双路可导入、旧 class 已移除)。
- downloader/metainfo 回归 **44 passed**;相邻 transfer/skills 回归 **39 passed**(2 个 error 为测试文件自身直接 `from app.agent import` 的预存 jieba 阻塞,git stash 到基线复现,**非本 PR 回归**)。
- **零行为变更**:同一单例,仅多一层访问器间接。

8 files changed, +212/-29。
