### PR TITLE
refactor(helper): image 惰性导入 chain,打断 chain↔helper import-time 循环

### DIFF
--- a/app/helper/image.py
+++ b/app/helper/image.py
@@ -4,8 +4,6 @@ from typing import Optional, List
 
 from PIL import Image
 
-from app.chain.mediaserver import MediaServerChain
-from app.chain.tmdb import TmdbChain
 from app.core.cache import cached, FileCache, AsyncFileCache
 from app.core.config import settings
 from app.log import logger
@@ -53,6 +51,7 @@ class WallpaperHelper(metaclass=Singleton):
         """
         获取TMDB每日壁纸
         """
+        from app.chain.tmdb import TmdbChain
         return TmdbChain().get_random_wallpager()
 
     @cached(maxsize=1, ttl=3600, skip_empty=True)
@@ -60,6 +59,7 @@ class WallpaperHelper(metaclass=Singleton):
         """
         获取7天的TMDB每日壁纸
         """
+        from app.chain.tmdb import TmdbChain
         return TmdbChain().get_trending_wallpapers(num)
 
     @cached(maxsize=1, ttl=3600)
@@ -100,6 +100,7 @@ class WallpaperHelper(metaclass=Singleton):
         """
         获取媒体服务器壁纸
         """
+        from app.chain.mediaserver import MediaServerChain
         return MediaServerChain().get_latest_wallpaper()
 
     @cached(maxsize=1, ttl=3600, skip_empty=True)
@@ -107,6 +108,7 @@ class WallpaperHelper(metaclass=Singleton):
         """
         获取媒体服务器壁纸列表
         """
+        from app.chain.mediaserver import MediaServerChain
         return MediaServerChain().get_latest_wallpapers(count=num)
 
     @cached(maxsize=1, ttl=3600)

--- a/tests/test_helper_image_chain_cycle.py
+++ b/tests/test_helper_image_chain_cycle.py
@@ -1,0 +1,59 @@
+"""
+S4b / 剩余 import 环回归:打断 chain↔helper import-time 循环。
+
+环根是 helper→chain 的反向边:`app/helper/image.py` 曾在模块顶层
+`from app.chain.mediaserver import MediaServerChain` / `from app.chain.tmdb import TmdbChain`,
+与 32 条合法的 chain→helper 正向边闭合成环
+(`chain/recommend.py:11 → helper/image.py → app.chain`)。
+
+修复 = 把这两个 import 降为 `WallpaperHelper` 四个方法内的函数级惰性导入
+(沿用 event.py:706 / search.py:381 / plugin_source.py:40 / helper/skill.py:42 的同款技术),
+导入 `app.helper.image` 不再在 import-time 拉起 `app.chain`，循环打断；行为字节级不变。
+
+本地 venv 存在预存的 jieba_next/zhconv 缺口，但 `app.helper.image` 不依赖它们，
+故子进程导入探针可稳定运行；另以源码结构契约做环境无关的双保险。
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+IMAGE_PY = REPO_DIR / "app" / "helper" / "image.py"
+
+
+# ---- (a) 源码结构契约：helper/image 顶层零 app.chain 引用 ----
+
+def test_image_has_no_top_level_chain_import():
+    """顶层 import 必然顶格；函数内惰性 import 有缩进。顶层不得出现 app.chain。"""
+    src = IMAGE_PY.read_text(encoding="utf-8")
+    for line in src.splitlines():
+        assert not line.startswith("from app.chain"), f"image.py 顶层不应 import chain: {line}"
+        assert not line.startswith("import app.chain"), f"image.py 顶层不应 import chain: {line}"
+
+
+def test_chain_classes_lazily_imported_in_methods():
+    """两个 Chain 仍在方法体内惰性导入（缩进），确保只是降级而非误删。"""
+    lines = IMAGE_PY.read_text(encoding="utf-8").splitlines()
+    tmdb = [ln for ln in lines if "from app.chain.tmdb import TmdbChain" in ln]
+    mediaserver = [ln for ln in lines if "from app.chain.mediaserver import MediaServerChain" in ln]
+    # 2 个 tmdb 方法 + 2 个 mediaserver 方法
+    assert len(tmdb) == 2 and all(ln.startswith(" ") for ln in tmdb), tmdb
+    assert len(mediaserver) == 2 and all(ln.startswith(" ") for ln in mediaserver), mediaserver
+
+
+# ---- (b) 确定性证明：全新解释器 import image 不拉起任何 app.chain ----
+
+def test_importing_image_pulls_no_chain():
+    code = (
+        "import sys, app.helper.image as im;"
+        "leaked=[m for m in sys.modules if m.startswith('app.chain')];"
+        "assert not leaked, ('app.chain leaked at import: %r' % leaked);"
+        "assert hasattr(im,'ImageHelper') and hasattr(im,'WallpaperHelper'),'classes missing';"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_DIR), capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout


### PR DESCRIPTION
## 目标
打断审计 5 个顶层 import 环中**仍存活**的 `chain↔helper`(S4 已断 chain↔agent,本 PR 为其同型姊妹)。

## 环根(唯一 helper→chain 反向边)
`app/helper/image.py` 顶层 `from app.chain.mediaserver import MediaServerChain` / `from app.chain.tmdb import TmdbChain`,与 32 条合法的 chain→helper 正向边闭合成环:
```
chain/recommend.py:11 → helper/image.py(顶层 import) → app.chain.{mediaserver,tmdb}
```
注:`recommend.py` 实际只需 `ImageHelper`(不碰 chain),却被 image.py 顶层的 chain 导入连累。

## 方案(lazy 降级,技术同 event.py:706 / search.py:381 / plugin_source.py:40 / skill.py:42)
两个 Chain **仅在** `WallpaperHelper` 的 4 个方法内**调用时实例化**(非定义期),故将顶层 import 降为函数级惰性导入:
- `get_tmdb_wallpaper` / `get_tmdb_wallpapers` → `TmdbChain`
- `get_mediaserver_wallpaper` / `get_mediaserver_wallpapers` → `MediaServerChain`

`ImageHelper` 不涉 chain,零改动。**行为字节级不变**(`cached` 装饰器、签名、返回值均不动)。

## 验证
- 确定性探针:全新解释器 `import app.helper.image` 拉入 **0 个** `app.chain` 模块,两类俱在。
- 全量 `app/helper/` 已无任何 helper→chain 顶层反向边 → `chain↔helper` import-time 环消除。
- 新增 `tests/test_helper_image_chain_cycle.py`(3:顶层零 chain 契约 / 4 处惰性导入仍在 / 子进程导入探针)。
- 回归:image 相邻(mediaserver 签名 + plex 查询 + security url 日志)+ metainfo 金丝雀 = **34 passed**。
- `test_agent_image_support` 的收集失败是预存 `jieba_next` env 缺口(其链经 app.agent,不经 image.py),非本 PR 回归。

## 进度
5 个原始 import 环:**chain↔agent / agent↔helper / core↔helper / chain↔helper 已断,剩 core↔utils**。