### PR TITLE
refactor(utils): 4 处反向边惰性化,打断 core↔utils import-time 循环(达成 0 环里程碑)

### DIFF
--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -16,7 +16,6 @@ from requests import Response, Session
 from urllib3.exceptions import InsecureRequestWarning
 from urllib.parse import unquote, quote
 
-from app.core.config import settings
 from app.log import logger
 
 urllib3.disable_warnings(InsecureRequestWarning)
@@ -290,6 +289,7 @@ class RequestUtils:
         if headers:
             self._headers = headers
         else:
+            from app.core.config import settings
             if ua and ua == settings.USER_AGENT:
                 caller_name = get_caller()
                 if caller_name:
@@ -868,6 +868,7 @@ class AsyncRequestUtils:
             # 过滤掉None值的headers
             self._headers = {k: v for k, v in headers.items() if v is not None}
         else:
+            from app.core.config import settings
             if ua and ua == settings.USER_AGENT:
                 caller_name = get_caller()
                 if caller_name:

--- a/app/utils/mixins.py
+++ b/app/utils/mixins.py
@@ -1,6 +1,5 @@
 import inspect
 
-from app.core.event import eventmanager, Event
 from app.log import logger
 from app.schemas.types import EventType
 
@@ -20,6 +19,9 @@ class ConfigReloadMixin:
         config_watch = getattr(cls, "CONFIG_WATCH", None)
         if not config_watch:
             return
+
+        # 惰性导入，避免 utils→core.event 顶层反向依赖（打断 core↔utils import-time 环）
+        from app.core.event import eventmanager, Event
 
         # 检查 on_config_changed 方法是否为异步
         is_async = inspect.iscoroutinefunction(cls.on_config_changed)

--- a/app/utils/rust_accel.py
+++ b/app/utils/rust_accel.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 
-from app.core.config import settings
 from app.log import logger
 
 try:
@@ -23,6 +22,7 @@ def is_config_enabled() -> bool:
     """
     判断系统配置是否允许使用 Rust 加速。
     """
+    from app.core.config import settings
     return bool(settings.RUST_ACCEL)
 
 

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -13,7 +13,6 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from anyio import Path as AsyncPath
 from cachetools import TTLCache
 
-from app.core.config import settings
 from app.log import logger
 from app.utils.coalesce import (
     CoalesceDecision,
@@ -443,6 +442,7 @@ class SecurityUtils:
         完全一致；签名的失效边界绑定在 `RESOURCE_SECRET_KEY` 上，进程重启
         或显式轮换密钥时所有旧签名一起作废。
         """
+        from app.core.config import settings
         return hmac.new(
             settings.RESOURCE_SECRET_KEY.encode("utf-8"),
             SecurityUtils._url_signature_payload(url, purpose),

--- a/tests/test_utils_core_cycle.py
+++ b/tests/test_utils_core_cycle.py
@@ -1,0 +1,93 @@
+"""
+S4c / 剩余 import 环回归：打断 core↔utils import-time 循环，令 utils 成为 core 的真叶子。
+
+原 4 条 utils→core 顶层反向边：
+  - app/utils/mixins.py     → app.core.event（eventmanager/Event）
+  - app/utils/security.py   → app.core.config.settings
+  - app/utils/rust_accel.py → app.core.config.settings
+  - app/utils/http.py       → app.core.config.settings
+与 core→utils 正向边（core/config.py:21-22、core/event.py:19-20）闭合成 import-time 环。
+
+修复 = 把这 4 条反向边降为函数级惰性导入（mixins 在 __init_subclass__ 的 CONFIG_WATCH
+分支内；其余在使用处），导入任一 utils 模块不再在 import-time 拉起 app.core；行为字节级不变。
+沿用 event.py:706 / search.py:381 / plugin_source.py:40 / helper/skill.py:42 的同款技术。
+"""
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+UTILS_DIR = REPO_DIR / "app" / "utils"
+
+
+def _top_level_import_modules(path: Path):
+    """仅返回模块顶层（非函数/类体内）的 import 目标模块名。"""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    mods = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mods.append(node.module)
+        elif isinstance(node, ast.Import):
+            mods.extend(alias.name for alias in node.names)
+    return mods
+
+
+# ---- (a) 源码结构契约：整个 utils 层顶层零 app.core（utils=叶子，milestone 守护） ----
+
+def test_no_utils_file_imports_core_at_top_level():
+    offenders = {}
+    for py in UTILS_DIR.rglob("*.py"):
+        bad = [m for m in _top_level_import_modules(py) if m.startswith("app.core")]
+        if bad:
+            offenders[py.name] = bad
+    assert not offenders, f"utils 顶层仍反向依赖 core: {offenders}"
+
+
+def test_lazy_core_imports_preserved():
+    """惰性导入仍在（确保只是降级而非误删）。"""
+    assert "from app.core.event import eventmanager" in (UTILS_DIR / "mixins.py").read_text(encoding="utf-8")
+    for name in ("rust_accel.py", "security.py", "http.py"):
+        assert "from app.core.config import settings" in (UTILS_DIR / name).read_text(encoding="utf-8")
+
+
+# ---- (b) 确定性证明：全新解释器 import 各 utils 模块不拉起 app.core ----
+
+def test_importing_utils_pulls_no_core():
+    mods = ["app.utils.rust_accel", "app.utils.security", "app.utils.http", "app.utils.mixins"]
+    code = (
+        "import sys\n"
+        f"for m in {mods!r}:\n"
+        "    __import__(m)\n"
+        "bad=[m for m in ('app.core.config','app.core.event') if m in sys.modules]\n"
+        "assert not bad, ('app.core leaked at import: %r' % bad)\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], cwd=str(REPO_DIR), capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+# ---- (c) 行为未变：惰性 settings / mixin 子类注册仍正常 ----
+
+def test_lazy_settings_resolves():
+    from app.utils import rust_accel
+    assert isinstance(rust_accel.is_config_enabled(), bool)
+    from app.utils.http import RequestUtils
+    r = RequestUtils(ua="probe-ua")
+    assert r._headers.get("User-Agent") == "probe-ua"
+    from app.utils.security import SecurityUtils
+    assert len(SecurityUtils._sign_url_payload("http://x/y", "image")) == 64
+
+
+def test_configreload_subclass_still_registers():
+    """带 CONFIG_WATCH 的子类在定义期仍能构建 handler（__init_subclass__ 惰性路径 + 闭包注解）。"""
+    from app.utils.mixins import ConfigReloadMixin
+
+    class _Probe(ConfigReloadMixin):
+        CONFIG_WATCH = {"PROXY"}
+
+        def on_config_changed(self):
+            return None
+
+    assert hasattr(_Probe, "handle_config_changed")


### PR DESCRIPTION
## 目标 / 里程碑
打断审计 5 个顶层 import 环中的**最后一个** `core↔utils`。**本 PR 合入后,审计列出的 5 个 import-time 环全部消除**(chain↔agent / agent↔helper / core↔helper / chain↔helper / core↔utils)。

## 环根(4 条 utils→core 顶层反向边)
`utils` 应为叶子层,却有 4 条反向边,与 core→utils 正向边(`core/config.py:21-22` import utils.system/url、`core/event.py:19-20` import utils.limit/singleton)闭合成 import-time 环:
| 文件 | 反向边 | 实际用法 |
|---|---|---|
| `utils/mixins.py:3` | `from app.core.event import eventmanager, Event` | `ConfigReloadMixin.__init_subclass__` 注册监听(子类定义期) |
| `utils/security.py:16` | `from app.core.config import settings` | `SecurityUtils._sign_url_payload` 读 RESOURCE_SECRET_KEY |
| `utils/rust_accel.py:3` | `from app.core.config import settings` | `is_config_enabled` 读 RUST_ACCEL |
| `utils/http.py:19` | `from app.core.config import settings` | `RequestUtils`/`AsyncRequestUtils.__init__` 读 USER_AGENT |

四处**全部为调用期使用**,无模块/类级使用。

## 方案(lazy 降级,技术同 event.py:706 / search.py:381 / plugin_source.py:40 / skill.py:42)
- `mixins.py`:顶层 import 移入 `__init_subclass__` 的 `CONFIG_WATCH` 守卫之后(仅带 CONFIG_WATCH 的子类定义时才需);`Event` 仅用于嵌套 wrapper 注解,经闭包解析。
- `security.py / rust_accel.py / http.py`:`settings` 移入各使用函数内。
公共 API(`SecurityUtils` / `RequestUtils` / rust_accel 函数 / `ConfigReloadMixin`)签名与行为**字节级不变**。

## 验证
- 结构契约:`app/utils/` 顶层 app.core 反向边 = **0** → utils 成为 core 的真叶子。
- 确定性探针:全新解释器 import `rust_accel/security/http/mixins` 各拉入 **0 个** `app.core.{config,event}`。
- 功能冒烟:`is_config_enabled()→True`、`RequestUtils(ua=)` UA 头正确、`_sign_url_payload` 返 64 字符 HMAC、带 CONFIG_WATCH 的同步/异步子类仍正常构建 handler(闭包注解 `event: Event` 解析无误)。
- 新增 `tests/test_utils_core_cycle.py`(5);ConfigReloadMixin 子类回归(redis/thread relocation)+ downloader/security + metainfo = **52 passed**。

## 进度
**5/5 import 环全部打断。** 剩余 core→db 顶层边 4 条(auth_bridge.py:11-12 / plugin.py:29-30,P1 收尾);下一步 S9(PluginManager god-object 迁出 core)、S8 step-1(TransferChain 内部拆分)。