### PR TITLE
refactor(core): auth_bridge 去除直接 core→db 依赖(P1 收尾)

### DIFF
--- a/app/core/auth_bridge.py
+++ b/app/core/auth_bridge.py
@@ -2,16 +2,17 @@ import secrets
 import threading
 import time
 from datetime import timedelta
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from app import schemas
 from app.core import security
 from app.core.auth_level import get_auth_level
 from app.core.config import settings
-from app.db.models.user import User
-from app.db.systemconfig_oper import SystemConfigOper
 from app.schemas.types import SystemConfigKey
 from app.utils.singleton import Singleton
+
+if TYPE_CHECKING:
+    from app.db.models.user import User
 
 
 class AuthTicketStore(metaclass=Singleton):
@@ -115,13 +116,15 @@ def consume_plugin_auth_ticket(ticket: str) -> Optional[dict[str, Any]]:
     return AuthTicketStore().consume(ticket)
 
 
-def build_token_response(user: User) -> schemas.Token:
+def build_token_response(user: "User") -> schemas.Token:
     """
     使用系统统一逻辑构造登录 Token 响应。
 
     :param user: 已认证的本地用户
     :return: 标准 Token 响应
     """
+    from app.db.systemconfig_oper import SystemConfigOper
+
     level = get_auth_level()
     show_wizard = (
         not SystemConfigOper().get(SystemConfigKey.SetupWizardState)

--- a/tests/test_auth_bridge_dedb.py
+++ b/tests/test_auth_bridge_dedb.py
@@ -1,0 +1,51 @@
+"""
+S1d / P1 收尾：移除 core/auth_bridge 的 2 条直接 core→db 顶层反向边。
+
+- `User`（仅用作类型注解）→ TYPE_CHECKING 块 + 引号前向引用；
+- `SystemConfigOper`（调用期使用）→ build_token_response 内函数级惰性导入。
+
+auth_bridge.py 自身顶层 app.db 清零。注意：导入 auth_bridge 仍会经其它 core
+依赖传递拉起 app.db —— 完整 core db-free 是跨多文件工程（plugin.py 剩余的 2 条
+core→db 边由 S9 把 PluginManager 迁出 core 时消除），本 PR 仅清本文件的直接边。
+"""
+import ast
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+AB = REPO_DIR / "app" / "core" / "auth_bridge.py"
+
+
+def _top_level_imports(path: Path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    mods = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            mods.append(node.module)
+        elif isinstance(node, ast.Import):
+            mods.extend(alias.name for alias in node.names)
+    return mods
+
+
+def test_auth_bridge_no_top_level_db_import():
+    bad = [m for m in _top_level_imports(AB) if m.startswith("app.db")]
+    assert not bad, f"auth_bridge 顶层不应直接 import app.db: {bad}"
+
+
+def test_user_is_type_only_and_systemconfig_lazy():
+    src = AB.read_text(encoding="utf-8")
+    # User 仅在 TYPE_CHECKING 下导入（类型专用，运行期不拉 db.models.user）
+    assert "if TYPE_CHECKING:" in src and "from app.db.models.user import User" in src
+    # SystemConfigOper 的导入必须在函数体内（缩进 = 惰性）
+    lines = [ln for ln in src.splitlines() if "from app.db.systemconfig_oper import SystemConfigOper" in ln]
+    assert lines and all(ln.startswith(" ") for ln in lines), lines
+
+
+def test_ticket_roundtrip_and_one_time():
+    """db-free 路径（票据存取）行为未变。"""
+    import app.core.auth_bridge as ab
+
+    assert callable(ab.build_token_response)  # 引号注解未破坏函数定义
+    ticket = ab.create_plugin_auth_ticket(user_id=7, provider_id="probe")
+    data = ab.consume_plugin_auth_ticket(ticket)
+    assert data and data["user_id"] == 7 and data["provider_id"] == "probe"
+    assert ab.consume_plugin_auth_ticket(ticket) is None  # 一次性票据


### PR DESCRIPTION
## 目标
继续 P1(core 反向依赖 db)收尾:清除 `core/auth_bridge.py` 的 2 条**直接** core→db 顶层反向边(审计列出的剩余 4 条直接边之 2)。

## 改动
| 符号 | 原用法 | 改法 |
|---|---|---|
| `User` | 仅 `build_token_response(user: User)` 类型注解 | 移入 `if TYPE_CHECKING:` + 引号前向引用 `user: "User"`(运行期不再 import db.models.user) |
| `SystemConfigOper` | `build_token_response` 内 `SystemConfigOper().get(...)` 调用期 | 函数级惰性导入 |

`build_token_response` 签名/行为字节级不变;`AuthTicketStore` / 票据函数零改动。

## 验证(逐文件结构契约 + db-free 冒烟)
- `auth_bridge.py` 顶层 `app.db` 边 = **0**(审计 core→db 直接边 **4→2**)。
- `build_token_response` 可调用(引号注解不破坏 def);惰性 `SystemConfigOper` 可解析;票据 create/consume 往返 + 一次性语义未变。
- 新增 `tests/test_auth_bridge_dedb.py`(3);`test_core_auth_level` + cycle 回归 + metainfo = **35 passed**。

## 诚实边界
导入 `auth_bridge` 仍会经其它 core 依赖**传递**拉起 `app.db`(downloadhistory/site/... models)——完整 core db-free 是跨多文件工程,本 PR 仅清本文件**直接**边。剩余 2 条直接边在 `plugin.py`(god-object),由 **S9** 把 `PluginManager` 迁出 core 时一并消除(届时 plugin→db 为合法层序)。