### PR TITLE
refactor(transfer): __handle_transfer 抽出 3 个无早返回子块为私有 helper(S8a)

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1604,75 +1604,13 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     return False, f"{task.fileitem.name} 已在整理队列中"
 
             # 获取集数据
-            if task.mediainfo.type == MediaType.TV and not task.episodes_info:
-                # 判断注意season为0的情况
-                season_num = task.mediainfo.season
-                if season_num is None and task.meta.season_seq:
-                    if task.meta.season_seq.isdigit():
-                        season_num = int(task.meta.season_seq)
-                # 默认值1
-                if season_num is None:
-                    season_num = 1
-                task.episodes_info = TmdbChain().tmdb_episodes(
-                    tmdbid=task.mediainfo.tmdb_id,
-                    season=season_num,
-                    episode_group=task.mediainfo.episode_group,
-                )
+            self._resolve_episodes_info(task)
 
-            # 查询整理目标目录
-            if not task.target_directory:
-                if task.target_path:
-                    # 指定目标路径，`手动整理`场景下使用，忽略源目录匹配，使用指定目录匹配
-                    task.target_directory = DirectoryHelper().get_dir(
-                        media=task.mediainfo,
-                        dest_path=task.target_path,
-                        target_storage=task.target_storage,
-                    )
-                else:
-                    # 启用源目录匹配时，根据源目录匹配下载目录，否则按源目录同盘优先原则，如无源目录，则根据媒体信息获取目标目录
-                    task.target_directory = DirectoryHelper().get_dir(
-                        media=task.mediainfo,
-                        storage=task.fileitem.storage,
-                        src_path=Path(task.fileitem.path),
-                        target_storage=task.target_storage,
-                    )
-            if not task.target_storage and task.target_directory:
-                task.target_storage = task.target_directory.library_storage
+            # 查询整理目标目录与目标存储
+            self._resolve_target_directory(task)
 
-            # 正在处理
-            self.jobview.running_task(task)
-
-            # 广播事件，请示额外的源存储支持
-            source_oper = None
-            source_event_data = StorageOperSelectionEventData(
-                storage=task.fileitem.storage,
-            )
-            source_event = eventmanager.send_event(
-                ChainEventType.StorageOperSelection, source_event_data
-            )
-            # 使用事件返回的上下文数据
-            if source_event and source_event.event_data:
-                source_event_data: StorageOperSelectionEventData = (
-                    source_event.event_data
-                )
-                if source_event_data.storage_oper:
-                    source_oper = source_event_data.storage_oper
-
-            # 广播事件，请示额外的目标存储支持
-            target_oper = None
-            target_event_data = StorageOperSelectionEventData(
-                storage=task.target_storage,
-            )
-            target_event = eventmanager.send_event(
-                ChainEventType.StorageOperSelection, target_event_data
-            )
-            # 使用事件返回的上下文数据
-            if target_event and target_event.event_data:
-                target_event_data: StorageOperSelectionEventData = (
-                    target_event.event_data
-                )
-                if target_event_data.storage_oper:
-                    target_oper = target_event_data.storage_oper
+            # 标记运行中，并广播事件请示额外的源/目标存储操作器
+            source_oper, target_oper = self._select_storage_opers(task)
 
             # 执行整理
             transferinfo: TransferInfo = self.transfer(
@@ -1705,6 +1643,93 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             # 移除已完成的任务
             self.jobview.try_remove_job(task)
             self.__finish_scrape_batch_task(task)
+
+    def _resolve_episodes_info(self, task: TransferTask) -> None:
+        """获取集数据：TV 且缺失 episodes_info 时从 TMDB 拉取。
+
+        S8a：自 __handle_transfer 抽出的无早返回子块，行为字节级不变。
+        """
+        if task.mediainfo.type == MediaType.TV and not task.episodes_info:
+            # 判断注意season为0的情况
+            season_num = task.mediainfo.season
+            if season_num is None and task.meta.season_seq:
+                if task.meta.season_seq.isdigit():
+                    season_num = int(task.meta.season_seq)
+            # 默认值1
+            if season_num is None:
+                season_num = 1
+            task.episodes_info = TmdbChain().tmdb_episodes(
+                tmdbid=task.mediainfo.tmdb_id,
+                season=season_num,
+                episode_group=task.mediainfo.episode_group,
+            )
+
+    def _resolve_target_directory(self, task: TransferTask) -> None:
+        """查询整理目标目录与目标存储。
+
+        S8a：自 __handle_transfer 抽出的无早返回子块，行为字节级不变。
+        """
+        if not task.target_directory:
+            if task.target_path:
+                # 指定目标路径，`手动整理`场景下使用，忽略源目录匹配，使用指定目录匹配
+                task.target_directory = DirectoryHelper().get_dir(
+                    media=task.mediainfo,
+                    dest_path=task.target_path,
+                    target_storage=task.target_storage,
+                )
+            else:
+                # 启用源目录匹配时，根据源目录匹配下载目录，否则按源目录同盘优先原则，如无源目录，则根据媒体信息获取目标目录
+                task.target_directory = DirectoryHelper().get_dir(
+                    media=task.mediainfo,
+                    storage=task.fileitem.storage,
+                    src_path=Path(task.fileitem.path),
+                    target_storage=task.target_storage,
+                )
+        if not task.target_storage and task.target_directory:
+            task.target_storage = task.target_directory.library_storage
+
+    def _select_storage_opers(self, task: TransferTask) -> Tuple[Any, Any]:
+        """标记任务运行中，并广播事件请示额外的源/目标存储操作器。
+
+        S8a：自 __handle_transfer 抽出的无早返回子块，行为字节级不变；
+        返回 (source_oper, target_oper) 供 __handle_transfer 传入 transfer()。
+        """
+        # 正在处理
+        self.jobview.running_task(task)
+
+        # 广播事件，请示额外的源存储支持
+        source_oper = None
+        source_event_data = StorageOperSelectionEventData(
+            storage=task.fileitem.storage,
+        )
+        source_event = eventmanager.send_event(
+            ChainEventType.StorageOperSelection, source_event_data
+        )
+        # 使用事件返回的上下文数据
+        if source_event and source_event.event_data:
+            source_event_data: StorageOperSelectionEventData = (
+                source_event.event_data
+            )
+            if source_event_data.storage_oper:
+                source_oper = source_event_data.storage_oper
+
+        # 广播事件，请示额外的目标存储支持
+        target_oper = None
+        target_event_data = StorageOperSelectionEventData(
+            storage=task.target_storage,
+        )
+        target_event = eventmanager.send_event(
+            ChainEventType.StorageOperSelection, target_event_data
+        )
+        # 使用事件返回的上下文数据
+        if target_event and target_event.event_data:
+            target_event_data: StorageOperSelectionEventData = (
+                target_event.event_data
+            )
+            if target_event_data.storage_oper:
+                target_oper = target_event_data.storage_oper
+
+        return source_oper, target_oper
 
     def get_queue_tasks(self) -> List[TransferJob]:
         """

--- a/tests/test_transfer_handle_carve.py
+++ b/tests/test_transfer_handle_carve.py
@@ -1,0 +1,49 @@
+"""
+S8a 契约守护：__handle_transfer 的 7 块中 3 个无早返回子块被抽成私有 helper
+（_resolve_episodes_info / _resolve_target_directory / _select_storage_opers），
+入口方法保持薄编排 + 同序调用 + 原 try/finally。
+
+本测试守护 P5 CRITICAL 的 monkey-patch 契约：p115strmhelper 通过 name-mangled
+类属性 `TransferChain._TransferChain__handle_transfer` 存/换/复原补丁（patch/transfer_chain.py
+:53/:64/:85）。因此入口**符号名、签名、返回契约**必须永远稳定——任何未来重构若
+改名/改签名/移出 TransferChain，本测试立即失败，避免静默掐断 115 接管。
+
+注：__handle_transfer 的完整行为需真实 downloader/media/DB 集成测试覆盖（见
+tests/test_transfer_*）；本文件只断言「抽取后入口契约与结构」不变，不替代行为测试。
+"""
+import inspect
+
+from app.chain.transfer import TransferChain
+
+MANGLED = "_TransferChain__handle_transfer"
+
+
+def test_handle_transfer_mangled_symbol_present():
+    """p115 补丁目标符号必须存在于 TransferChain 类上。"""
+    assert hasattr(TransferChain, MANGLED), (
+        f"name-mangled 入口符号 {MANGLED} 丢失 → p115strmhelper 补丁的 save/install/restore 会 AttributeError"
+    )
+
+
+def test_handle_transfer_signature_stable():
+    """签名必须保持 (self, task, callback=None)，callback 默认 None。"""
+    sig = inspect.signature(getattr(TransferChain, MANGLED))
+    params = list(sig.parameters)
+    assert params == ["self", "task", "callback"], f"签名形参变了: {params}"
+    assert sig.parameters["callback"].default is None, "callback 默认值不再是 None"
+
+
+def test_extracted_helpers_present():
+    """3 个抽出的无早返回 helper 必须就位（单下划线、非 name-mangled）。"""
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers"):
+        assert hasattr(TransferChain, h), f"抽出的 helper 缺失: {h}"
+
+
+def test_handle_transfer_keeps_finally_cleanup():
+    """入口方法必须保留 try/finally 清理（try_remove_job + __finish_scrape_batch_task）。"""
+    src = inspect.getsource(getattr(TransferChain, MANGLED))
+    assert "finally:" in src, "__handle_transfer 丢失 finally"
+    assert "try_remove_job" in src and "__finish_scrape_batch_task" in src, "finally 清理动作被改动"
+    # 入口编排仍按序调用 3 个 helper
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers"):
+        assert h in src, f"入口未调用 helper: {h}"


### PR DESCRIPTION
## 背景(S8 / P5 CRITICAL)
`TransferChain.__handle_transfer`(transfer.py:1485,224 行)是 god-method,也是 p115strmhelper 插件 monkey-patch 的目标(name-mangled `_TransferChain__handle_transfer`,patch/transfer_chain.py :53/:64/:85 存/换/复原)。经 4 路并行 workflow 测绘契约后,S8 拆成多步;**本 PR 是最安全的首切 S8a**。

## 改动:3 个**无早返回**子块 verbatim 抽成私有 helper
| helper | 原行 | 通信方式 |
|---|---|---|
| `_resolve_episodes_info(task)` | 集数据(TV) | 仅改 task.episodes_info |
| `_resolve_target_directory(task)` | 目标目录/存储 | 仅改 task.target_directory/target_storage |
| `_select_storage_opers(task)` | 运行标记 + 2×StorageOperSelection 事件 | 返回 (source_oper, target_oper) |

入口 `__handle_transfer` 保持薄编排:同序调用 3 helper + 原 try/finally(`try_remove_job` + `__finish_scrape_batch_task` 内联不动)。

## 为什么只切这 3 块(契约保留)
- 这 3 块**无早返回**、仅经 `task` 变更或简单返回通信 → verbatim extract-method **行为字节级不变**。
- **入口契约逐字保留**:`_TransferChain__handle_transfer` 符号名、签名 `(self, task, callback=None) -> Optional[Tuple[bool,str]]`、返回契约、唯一 worker chokepoint(transfer.py:1436/2841)全部不变 → p115 补丁的 save/install/restore 不受影响。
- 3 个 helper 用**单下划线**(非 name-mangled),p115 补丁整体替换方法体、不引用任何 helper → **零插件影响**。

## 验证
- py_compile;探针确认 `_TransferChain__handle_transfer` 在、签名不变、3 helper 就位。
- transfer 测试套件 **51 passed / 1 jieba-failed**,与改动前**基线逐字一致**(零回归);含 test_transfer_preview(走 __handle_transfer)。
- 新增 `tests/test_transfer_handle_carve.py`(4):**契约守护**——锁定 mangled 入口符号 + 签名 + finally + 3 helper,未来任何改动若破坏 p115 契约立即失败。

## 边界(诚实声明)
本环境无 downloader/media/DB 集成测试,故**只切无早返回的安全块**。含早返回 / 紧耦合的块 **1(识别失败通知重试)/2(SCRAP_FOLLOW_TMDB)/3(队列去重)/7(transfer+callback)** 与 **TransferService 抽取**(队列+线程+计数器 —— p115 深探 `jobview`/`_success_target_files`/`task_lock`,须留驻实例)留待有集成测试的 **S8b / step-2**。