### PR TITLE
refactor(plugin): 12 个元数据访问器抽至 app.helper.plugin_metadata(S9c)

### DIFF
--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -26,6 +26,7 @@ from app.core.config import settings
 from app.core.event import eventmanager
 from app.core.plugin_reporter import report_plugin_install
 from app.core.plugin_source import get_plugin_source
+from app.helper import plugin_metadata
 from app.db.plugindata_oper import PluginDataOper
 from app.db.systemconfig_oper import SystemConfigOper
 from app.log import logger
@@ -735,401 +736,41 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         return plugin.get_state() if plugin else False
 
     def get_plugin_commands(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件命令
-        [{
-            "cmd": "/xx",
-            "event": EventType.xx,
-            "desc": "xxxx",
-            "data": {},
-            "pid": "",
-        }]
-        """
-        ret_commands = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_command") and ObjectUtils.check_method(plugin.get_command):
-                try:
-                    if not plugin.get_state():
-                        continue
-                    commands = plugin.get_command() or []
-                    for command in commands:
-                        command["pid"] = plugin_id
-                    ret_commands.extend(commands)
-                except Exception as e:
-                    logger.error(f"获取插件命令出错：{str(e)}")
-        return ret_commands
+        return plugin_metadata.get_plugin_commands(self._running_plugins, pid)
 
     def get_plugin_apis(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件API
-        [{
-            "path": "/xx",
-            "endpoint": self.xxx,
-            "methods": ["GET", "POST"],
-            "summary": "API名称",
-            "description": "API说明",
-            "allow_anonymous": false
-        }]
-        """
-        ret_apis = []
-        if pid:
-            plugins = {pid: self._running_plugins.get(pid)}
-        else:
-            plugins = self._running_plugins
-        for plugin_id, plugin in plugins.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_api") and ObjectUtils.check_method(plugin.get_api):
-                try:
-                    apis = plugin.get_api() or []
-                    for api in apis:
-                        api["path"] = f"/{plugin_id}{api['path']}"
-                        if not api.get("auth"):
-                            api["auth"] = "apikey"
-                    ret_apis.extend(apis)
-                except Exception as e:
-                    logger.error(f"获取插件 {plugin_id} API出错：{str(e)}")
-        return ret_apis
+        return plugin_metadata.get_plugin_apis(self._running_plugins, pid)
 
     def get_plugin_services(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件服务
-        [{
-            "id": "服务ID",
-            "name": "服务名称",
-            "trigger": "触发器：cron、interval、date、CronTrigger.from_crontab()",
-            "func": self.xxx,
-            "kwargs": {} # 定时器参数,
-            "func_kwargs": {} # 方法参数
-        }]
-        """
-        ret_services = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_service") and ObjectUtils.check_method(plugin.get_service):
-                try:
-                    if not plugin.get_state():
-                        continue
-                    services = plugin.get_service() or []
-                    ret_services.extend(services)
-                except Exception as e:
-                    logger.error(f"获取插件 {plugin_id} 服务出错：{str(e)}")
-        return ret_services
+        return plugin_metadata.get_plugin_services(self._running_plugins, pid)
 
     def get_plugin_modules(self, pid: Optional[str] = None) -> Dict[tuple, Dict[str, Any]]:
-        """
-        获取插件模块
-        {
-            plugin_id: {
-                method: function
-            }
-        }
-        """
-        ret_modules = {}
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_module") and ObjectUtils.check_method(plugin.get_module):
-                try:
-                    if not plugin.get_state():
-                        continue
-                    plugin_module = plugin.get_module() or []
-                    ret_modules[(plugin_id, plugin.get_name())] = plugin_module
-                except Exception as e:
-                    logger.error(f"获取插件 {plugin_id} 模块出错：{str(e)}")
-        return ret_modules
+        return plugin_metadata.get_plugin_modules(self._running_plugins, pid)
 
     def get_plugin_actions(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件动作
-        [{
-            "id": "动作ID",
-            "name": "动作名称",
-            "func": self.xxx,
-            "kwargs": {} # 需要附加传递的参数
-        }]
-        """
-        ret_actions = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_actions") and ObjectUtils.check_method(plugin.get_actions):
-                try:
-                    if not plugin.get_state():
-                        continue
-                    actions = plugin.get_actions()
-                    if actions:
-                        ret_actions.append({
-                            "plugin_id": plugin_id,
-                            "plugin_name": plugin.plugin_name,
-                            "actions": actions
-                        })
-                except Exception as e:
-                    logger.error(f"获取插件 {plugin_id} 动作出错：{str(e)}")
-        return ret_actions
+        return plugin_metadata.get_plugin_actions(self._running_plugins, pid)
 
     def get_plugin_agent_tools(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件智能体工具
-        [{
-            "plugin_id": "插件ID",
-            "plugin_name": "插件名称",
-            "tools": [ToolClass1, ToolClass2, ...]
-        }]
-        """
-        ret_tools = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_agent_tools") and ObjectUtils.check_method(plugin.get_agent_tools):
-                try:
-                    if not plugin.get_state():
-                        continue
-                    tools = plugin.get_agent_tools()
-                    if tools:
-                        ret_tools.append({
-                            "plugin_id": plugin_id,
-                            "plugin_name": plugin.plugin_name,
-                            "tools": tools
-                        })
-                except Exception as e:
-                    logger.error(f"获取插件 {plugin_id} 智能体工具出错：{str(e)}")
-        return ret_tools
+        return plugin_metadata.get_plugin_agent_tools(self._running_plugins, pid)
 
     @staticmethod
     def get_plugin_remote_entry(plugin_id: str, dist_path: str) -> str:
-        """
-        获取插件的远程入口地址
-        :param plugin_id: 插件 ID
-        :param dist_path: 插件的分发路径
-        :return: 远程入口地址
-        """
-        dist_path = dist_path.strip("/")
-        path = posixpath.join(
-            "plugin",
-            "file",
-            plugin_id.lower(),
-            dist_path,
-            "remoteEntry.js",
-        )
-        if not path.startswith("/"):
-            path = "/" + path
-        return path
+        return plugin_metadata.get_plugin_remote_entry(plugin_id, dist_path)
 
     def get_plugin_remotes(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        获取插件联邦组件列表
-        """
-        remotes = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if pid and pid != plugin_id:
-                continue
-            if hasattr(plugin, "get_render_mode"):
-                render_mode, dist_path = plugin.get_render_mode()
-                if render_mode != "vue":
-                    continue
-                remotes.append({
-                    "id": plugin_id,
-                    "url": self.get_plugin_remote_entry(plugin_id, dist_path),
-                    "name": plugin.plugin_name,
-                })
-        return remotes
+        return plugin_metadata.get_plugin_remotes(self._running_plugins, pid)
 
     def get_plugin_auth_providers(self) -> List[Dict[str, Any]]:
-        """
-        聚合插件声明的登录认证提供方。
-
-        :return: 插件认证入口列表
-        """
-        providers: List[Dict[str, Any]] = []
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if not plugin.get_state():
-                continue
-            if not hasattr(plugin, "get_auth_providers") or not ObjectUtils.check_method(plugin.get_auth_providers):
-                continue
-            try:
-                plugin_providers = plugin.get_auth_providers() or []
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 登录认证提供方出错：{str(e)}")
-                continue
-            render_mode = None
-            dist_path = None
-            if hasattr(plugin, "get_render_mode"):
-                render_mode, dist_path = plugin.get_render_mode()
-            for raw_provider in plugin_providers:
-                if not raw_provider or not isinstance(raw_provider, dict):
-                    continue
-                provider = raw_provider.copy()
-                provider["type"] = "plugin"
-                provider["plugin_id"] = plugin_id
-                provider.setdefault("id", f"plugin:{plugin_id}")
-                provider.setdefault("name", plugin.plugin_name)
-                provider.setdefault("enabled", True)
-                if render_mode == "vue" and dist_path:
-                    provider.setdefault("component", "AuthPage")
-                    provider["remote"] = {
-                        "id": plugin_id,
-                        "url": self.get_plugin_remote_entry(plugin_id, dist_path),
-                        "name": plugin.plugin_name,
-                    }
-                providers.append(provider)
-        return providers
+        return plugin_metadata.get_plugin_auth_providers(self._running_plugins)
 
     def get_plugin_sidebar_nav(self) -> List[Dict[str, Any]]:
-        """
-        聚合所有已启用 Vue 插件的侧栏导航项（get_sidebar_nav）。
-        """
-        valid_sections = {"start", "discovery", "subscribe", "organize", "system"}
-        valid_permissions = {"subscribe", "discovery", "search", "manage", "admin"}
-        items: List[Dict[str, Any]] = []
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if not plugin.get_state():
-                continue
-            if not hasattr(plugin, "get_sidebar_nav") or not ObjectUtils.check_method(plugin.get_sidebar_nav):
-                continue
-            if not hasattr(plugin, "get_render_mode"):
-                continue
-            render_mode, _ = plugin.get_render_mode()
-            if render_mode != "vue":
-                continue
-            try:
-                nav_list = plugin.get_sidebar_nav()
-                if not nav_list:
-                    continue
-                for raw in nav_list:
-                    if not raw or not isinstance(raw, dict):
-                        continue
-                    nav_key = str(raw.get("nav_key") or raw.get("key") or "main").strip()
-                    if not nav_key or any(c in nav_key for c in ["/", "?", "#", " "]):
-                        logger.warning(f"插件[{plugin_id}]侧栏项 nav_key 无效，已跳过: {nav_key!r}")
-                        continue
-                    title = raw.get("title") or plugin.plugin_name
-                    icon = raw.get("icon") or "mdi-puzzle"
-                    section = str(raw.get("section") or "system").lower()
-                    if section not in valid_sections:
-                        section = "system"
-                    perm = raw.get("permission")
-                    if perm is not None and str(perm) not in valid_permissions:
-                        perm = None
-                    else:
-                        perm = str(perm) if perm is not None else None
-                    order = raw.get("order", 0)
-                    try:
-                        order = int(order)
-                    except (TypeError, ValueError):
-                        order = 0
-                    items.append({
-                        "plugin_id": plugin_id,
-                        "nav_key": nav_key,
-                        "title": title,
-                        "icon": icon,
-                        "section": section,
-                        "permission": perm,
-                        "order": order,
-                    })
-            except Exception as e:
-                logger.error(f"获取插件[{plugin_id}]侧栏导航出错：{str(e)}")
-        items.sort(key=lambda x: (x["section"], x["order"], x["plugin_id"], x["nav_key"]))
-        return items
+        return plugin_metadata.get_plugin_sidebar_nav(self._running_plugins)
 
     def get_plugin_dashboard_meta(self) -> List[Dict[str, str]]:
-        """
-        获取所有插件仪表盘元信息
-        """
-        dashboard_meta = []
-        # 创建字典快照避免并发修改
-        running_plugins_snapshot = dict(self._running_plugins)
-        for plugin_id, plugin in running_plugins_snapshot.items():
-            if not hasattr(plugin, "get_dashboard") or not ObjectUtils.check_method(plugin.get_dashboard):
-                continue
-            try:
-                if not plugin.get_state():
-                    continue
-                # 如果是多仪表盘实现
-                if hasattr(plugin, "get_dashboard_meta") and ObjectUtils.check_method(plugin.get_dashboard_meta):
-                    meta = plugin.get_dashboard_meta()
-                    if meta:
-                        dashboard_meta.extend([{
-                            "id": plugin_id,
-                            "name": m.get("name"),
-                            "key": m.get("key"),
-                        } for m in meta if m])
-                else:
-                    dashboard_meta.append({
-                        "id": plugin_id,
-                        "name": plugin.plugin_name,
-                        "key": "",
-                    })
-            except Exception as e:
-                logger.error(f"获取插件[{plugin_id}]仪表盘元数据出错：{str(e)}")
-        return dashboard_meta
+        return plugin_metadata.get_plugin_dashboard_meta(self._running_plugins)
 
     def get_plugin_dashboard(self, pid: str, key: str, user_agent: str = None) -> Optional[schemas.PluginDashboard]:
-        """
-        获取插件仪表盘
-        """
-
-        def __get_params_count(func: Callable):
-            """
-            获取函数的参数信息
-            """
-            signature = inspect.signature(func)
-            return len(signature.parameters)
-
-        # 获取插件实例
-        plugin_instance = self.running_plugins.get(pid)
-        if not plugin_instance:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"插件 {pid} 不存在或未加载")
-
-        # 渲染模式
-        render_mode, _ = plugin_instance.get_render_mode()
-        # 获取插件仪表板
-        try:
-            # 检查方法的参数个数
-            params_count = __get_params_count(plugin_instance.get_dashboard)
-            if params_count > 1:
-                dashboard: Tuple = plugin_instance.get_dashboard(key=key, user_agent=user_agent)
-            elif params_count > 0:
-                dashboard: Tuple = plugin_instance.get_dashboard(user_agent=user_agent)
-            else:
-                dashboard: Tuple = plugin_instance.get_dashboard()
-        except Exception as e:
-            logger.error(f"插件 {pid} 调用方法 get_dashboard 出错: {str(e)}")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                                detail=f"插件 {pid} 调用方法 get_dashboard 出错: {str(e)}")
-        if dashboard is None:
-            return None
-        if not isinstance(dashboard, (tuple, list)) or len(dashboard) != 3:
-            logger.error(f"插件 {pid} 返回的仪表盘数据格式错误")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                                detail=f"插件 {pid} 返回的仪表盘数据格式错误")
-        cols, attrs, elements = dashboard
-        return schemas.PluginDashboard(
-            id=pid,
-            name=plugin_instance.plugin_name,
-            key=key,
-            render_mode=render_mode,
-            cols=cols or {},
-            attrs=attrs or {},
-            elements=elements
-        )
+        return plugin_metadata.get_plugin_dashboard(self._running_plugins, pid, key, user_agent)
 
     def get_plugin_attr(self, pid: str, attr: str) -> Any:
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -1,0 +1,416 @@
+"""插件元数据只读聚合访问器（S9c：自 PluginManager god-object 抽出）。
+
+这些访问器只读地遍历运行态插件字典（running_plugins）、调用各插件实例的 get_xxx 钩子
+方法并聚合结果，对 PluginManager 实例状态的唯一耦合就是 running_plugins 这一个字典。
+故抽到本独立模块为模块级函数（首参 running_plugins）；PluginManager 保留一行委托门面，
+使 api/agent/command/scheduler/chain 等大量调用方 PluginManager().get_plugin_xxx() 零改动。
+函数体逐字自原 PluginManager.get_plugin_* 方法迁出（仅 self._running_plugins → running_plugins），
+内部 dict() 快照语义不变，行为字节级一致。
+"""
+import inspect
+import posixpath
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+from starlette import status
+
+from app import schemas
+from app.log import logger
+from app.utils.object import ObjectUtils
+
+
+def get_plugin_commands(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件命令
+    [{
+        "cmd": "/xx",
+        "event": EventType.xx,
+        "desc": "xxxx",
+        "data": {},
+        "pid": "",
+    }]
+    """
+    ret_commands = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_command") and ObjectUtils.check_method(plugin.get_command):
+            try:
+                if not plugin.get_state():
+                    continue
+                commands = plugin.get_command() or []
+                for command in commands:
+                    command["pid"] = plugin_id
+                ret_commands.extend(commands)
+            except Exception as e:
+                logger.error(f"获取插件命令出错：{str(e)}")
+    return ret_commands
+
+def get_plugin_apis(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件API
+    [{
+        "path": "/xx",
+        "endpoint": self.xxx,
+        "methods": ["GET", "POST"],
+        "summary": "API名称",
+        "description": "API说明",
+        "allow_anonymous": false
+    }]
+    """
+    ret_apis = []
+    if pid:
+        plugins = {pid: running_plugins.get(pid)}
+    else:
+        plugins = running_plugins
+    for plugin_id, plugin in plugins.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_api") and ObjectUtils.check_method(plugin.get_api):
+            try:
+                apis = plugin.get_api() or []
+                for api in apis:
+                    api["path"] = f"/{plugin_id}{api['path']}"
+                    if not api.get("auth"):
+                        api["auth"] = "apikey"
+                ret_apis.extend(apis)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} API出错：{str(e)}")
+    return ret_apis
+
+def get_plugin_services(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件服务
+    [{
+        "id": "服务ID",
+        "name": "服务名称",
+        "trigger": "触发器：cron、interval、date、CronTrigger.from_crontab()",
+        "func": self.xxx,
+        "kwargs": {} # 定时器参数,
+        "func_kwargs": {} # 方法参数
+    }]
+    """
+    ret_services = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_service") and ObjectUtils.check_method(plugin.get_service):
+            try:
+                if not plugin.get_state():
+                    continue
+                services = plugin.get_service() or []
+                ret_services.extend(services)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 服务出错：{str(e)}")
+    return ret_services
+
+def get_plugin_modules(running_plugins, pid: Optional[str] = None) -> Dict[tuple, Dict[str, Any]]:
+    """
+    获取插件模块
+    {
+        plugin_id: {
+            method: function
+        }
+    }
+    """
+    ret_modules = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_module") and ObjectUtils.check_method(plugin.get_module):
+            try:
+                if not plugin.get_state():
+                    continue
+                plugin_module = plugin.get_module() or []
+                ret_modules[(plugin_id, plugin.get_name())] = plugin_module
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 模块出错：{str(e)}")
+    return ret_modules
+
+def get_plugin_actions(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件动作
+    [{
+        "id": "动作ID",
+        "name": "动作名称",
+        "func": self.xxx,
+        "kwargs": {} # 需要附加传递的参数
+    }]
+    """
+    ret_actions = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_actions") and ObjectUtils.check_method(plugin.get_actions):
+            try:
+                if not plugin.get_state():
+                    continue
+                actions = plugin.get_actions()
+                if actions:
+                    ret_actions.append({
+                        "plugin_id": plugin_id,
+                        "plugin_name": plugin.plugin_name,
+                        "actions": actions
+                    })
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 动作出错：{str(e)}")
+    return ret_actions
+
+def get_plugin_agent_tools(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件智能体工具
+    [{
+        "plugin_id": "插件ID",
+        "plugin_name": "插件名称",
+        "tools": [ToolClass1, ToolClass2, ...]
+    }]
+    """
+    ret_tools = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_agent_tools") and ObjectUtils.check_method(plugin.get_agent_tools):
+            try:
+                if not plugin.get_state():
+                    continue
+                tools = plugin.get_agent_tools()
+                if tools:
+                    ret_tools.append({
+                        "plugin_id": plugin_id,
+                        "plugin_name": plugin.plugin_name,
+                        "tools": tools
+                    })
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 智能体工具出错：{str(e)}")
+    return ret_tools
+
+def get_plugin_remote_entry(plugin_id: str, dist_path: str) -> str:
+    """
+    获取插件的远程入口地址
+    :param plugin_id: 插件 ID
+    :param dist_path: 插件的分发路径
+    :return: 远程入口地址
+    """
+    dist_path = dist_path.strip("/")
+    path = posixpath.join(
+        "plugin",
+        "file",
+        plugin_id.lower(),
+        dist_path,
+        "remoteEntry.js",
+    )
+    if not path.startswith("/"):
+        path = "/" + path
+    return path
+
+def get_plugin_remotes(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    获取插件联邦组件列表
+    """
+    remotes = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "get_render_mode"):
+            render_mode, dist_path = plugin.get_render_mode()
+            if render_mode != "vue":
+                continue
+            remotes.append({
+                "id": plugin_id,
+                "url": get_plugin_remote_entry(plugin_id, dist_path),
+                "name": plugin.plugin_name,
+            })
+    return remotes
+
+def get_plugin_auth_providers(running_plugins) -> List[Dict[str, Any]]:
+    """
+    聚合插件声明的登录认证提供方。
+
+    :return: 插件认证入口列表
+    """
+    providers: List[Dict[str, Any]] = []
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if not plugin.get_state():
+            continue
+        if not hasattr(plugin, "get_auth_providers") or not ObjectUtils.check_method(plugin.get_auth_providers):
+            continue
+        try:
+            plugin_providers = plugin.get_auth_providers() or []
+        except Exception as e:
+            logger.error(f"获取插件 {plugin_id} 登录认证提供方出错：{str(e)}")
+            continue
+        render_mode = None
+        dist_path = None
+        if hasattr(plugin, "get_render_mode"):
+            render_mode, dist_path = plugin.get_render_mode()
+        for raw_provider in plugin_providers:
+            if not raw_provider or not isinstance(raw_provider, dict):
+                continue
+            provider = raw_provider.copy()
+            provider["type"] = "plugin"
+            provider["plugin_id"] = plugin_id
+            provider.setdefault("id", f"plugin:{plugin_id}")
+            provider.setdefault("name", plugin.plugin_name)
+            provider.setdefault("enabled", True)
+            if render_mode == "vue" and dist_path:
+                provider.setdefault("component", "AuthPage")
+                provider["remote"] = {
+                    "id": plugin_id,
+                    "url": get_plugin_remote_entry(plugin_id, dist_path),
+                    "name": plugin.plugin_name,
+                }
+            providers.append(provider)
+    return providers
+
+def get_plugin_sidebar_nav(running_plugins) -> List[Dict[str, Any]]:
+    """
+    聚合所有已启用 Vue 插件的侧栏导航项（get_sidebar_nav）。
+    """
+    valid_sections = {"start", "discovery", "subscribe", "organize", "system"}
+    valid_permissions = {"subscribe", "discovery", "search", "manage", "admin"}
+    items: List[Dict[str, Any]] = []
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if not plugin.get_state():
+            continue
+        if not hasattr(plugin, "get_sidebar_nav") or not ObjectUtils.check_method(plugin.get_sidebar_nav):
+            continue
+        if not hasattr(plugin, "get_render_mode"):
+            continue
+        render_mode, _ = plugin.get_render_mode()
+        if render_mode != "vue":
+            continue
+        try:
+            nav_list = plugin.get_sidebar_nav()
+            if not nav_list:
+                continue
+            for raw in nav_list:
+                if not raw or not isinstance(raw, dict):
+                    continue
+                nav_key = str(raw.get("nav_key") or raw.get("key") or "main").strip()
+                if not nav_key or any(c in nav_key for c in ["/", "?", "#", " "]):
+                    logger.warning(f"插件[{plugin_id}]侧栏项 nav_key 无效，已跳过: {nav_key!r}")
+                    continue
+                title = raw.get("title") or plugin.plugin_name
+                icon = raw.get("icon") or "mdi-puzzle"
+                section = str(raw.get("section") or "system").lower()
+                if section not in valid_sections:
+                    section = "system"
+                perm = raw.get("permission")
+                if perm is not None and str(perm) not in valid_permissions:
+                    perm = None
+                else:
+                    perm = str(perm) if perm is not None else None
+                order = raw.get("order", 0)
+                try:
+                    order = int(order)
+                except (TypeError, ValueError):
+                    order = 0
+                items.append({
+                    "plugin_id": plugin_id,
+                    "nav_key": nav_key,
+                    "title": title,
+                    "icon": icon,
+                    "section": section,
+                    "permission": perm,
+                    "order": order,
+                })
+        except Exception as e:
+            logger.error(f"获取插件[{plugin_id}]侧栏导航出错：{str(e)}")
+    items.sort(key=lambda x: (x["section"], x["order"], x["plugin_id"], x["nav_key"]))
+    return items
+
+def get_plugin_dashboard_meta(running_plugins) -> List[Dict[str, str]]:
+    """
+    获取所有插件仪表盘元信息
+    """
+    dashboard_meta = []
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if not hasattr(plugin, "get_dashboard") or not ObjectUtils.check_method(plugin.get_dashboard):
+            continue
+        try:
+            if not plugin.get_state():
+                continue
+            # 如果是多仪表盘实现
+            if hasattr(plugin, "get_dashboard_meta") and ObjectUtils.check_method(plugin.get_dashboard_meta):
+                meta = plugin.get_dashboard_meta()
+                if meta:
+                    dashboard_meta.extend([{
+                        "id": plugin_id,
+                        "name": m.get("name"),
+                        "key": m.get("key"),
+                    } for m in meta if m])
+            else:
+                dashboard_meta.append({
+                    "id": plugin_id,
+                    "name": plugin.plugin_name,
+                    "key": "",
+                })
+        except Exception as e:
+            logger.error(f"获取插件[{plugin_id}]仪表盘元数据出错：{str(e)}")
+    return dashboard_meta
+
+def get_plugin_dashboard(running_plugins, pid: str, key: str, user_agent: str = None) -> Optional[schemas.PluginDashboard]:
+    """
+    获取插件仪表盘
+    """
+
+    def __get_params_count(func: Callable):
+        """
+        获取函数的参数信息
+        """
+        signature = inspect.signature(func)
+        return len(signature.parameters)
+
+    # 获取插件实例
+    plugin_instance = running_plugins.get(pid)
+    if not plugin_instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"插件 {pid} 不存在或未加载")
+
+    # 渲染模式
+    render_mode, _ = plugin_instance.get_render_mode()
+    # 获取插件仪表板
+    try:
+        # 检查方法的参数个数
+        params_count = __get_params_count(plugin_instance.get_dashboard)
+        if params_count > 1:
+            dashboard: Tuple = plugin_instance.get_dashboard(key=key, user_agent=user_agent)
+        elif params_count > 0:
+            dashboard: Tuple = plugin_instance.get_dashboard(user_agent=user_agent)
+        else:
+            dashboard: Tuple = plugin_instance.get_dashboard()
+    except Exception as e:
+        logger.error(f"插件 {pid} 调用方法 get_dashboard 出错: {str(e)}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"插件 {pid} 调用方法 get_dashboard 出错: {str(e)}")
+    if dashboard is None:
+        return None
+    if not isinstance(dashboard, (tuple, list)) or len(dashboard) != 3:
+        logger.error(f"插件 {pid} 返回的仪表盘数据格式错误")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail=f"插件 {pid} 返回的仪表盘数据格式错误")
+    cols, attrs, elements = dashboard
+    return schemas.PluginDashboard(
+        id=pid,
+        name=plugin_instance.plugin_name,
+        key=key,
+        render_mode=render_mode,
+        cols=cols or {},
+        attrs=attrs or {},
+        elements=elements
+    )

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -1,0 +1,79 @@
+"""
+S9c 回归：PluginManager 的 12 个只读元数据聚合访问器抽至 app.helper.plugin_metadata。
+
+这些访问器对 PluginManager 实例状态的唯一耦合是 _running_plugins 一个字典，故抽成
+模块级函数（首参 running_plugins），PluginManager 保留一行委托门面 → api/agent/command/
+scheduler/chain 等大量调用方 PluginManager().get_plugin_xxx() 零改动。
+
+函数体逐字迁出（仅 self._running_plugins → running_plugins，dict() 快照语义不变），
+可用 fake 插件直接做**行为单测**证明等价。
+"""
+import inspect
+
+from app.helper import plugin_metadata
+from app.helper.plugin_manager import PluginManager
+
+NAMES = [
+    "get_plugin_commands", "get_plugin_apis", "get_plugin_services", "get_plugin_modules",
+    "get_plugin_actions", "get_plugin_agent_tools", "get_plugin_remote_entry", "get_plugin_remotes",
+    "get_plugin_auth_providers", "get_plugin_sidebar_nav", "get_plugin_dashboard_meta", "get_plugin_dashboard",
+]
+
+
+class _FakePlugin:
+    def get_state(self):
+        return True
+
+    def get_command(self):
+        return [{"cmd": "/x", "desc": "d"}]
+
+    def get_service(self):
+        return [{"id": "s1", "name": "svc"}]
+
+    def get_api(self):
+        return [{"path": "/ping", "endpoint": None, "methods": ["GET"]}]
+
+
+class _DisabledPlugin:
+    def get_state(self):
+        return False
+
+    def get_command(self):
+        return [{"cmd": "/y"}]
+
+
+# ---- (a) 结构契约：12 门面委托、12 函数就位 ----
+
+def test_facades_and_functions_present():
+    for n in NAMES:
+        assert hasattr(PluginManager, n), f"PluginManager 缺门面 {n}"
+        assert hasattr(plugin_metadata, n), f"plugin_metadata 缺函数 {n}"
+
+
+def test_facade_delegates_to_module():
+    src = inspect.getsource(PluginManager.get_plugin_commands)
+    assert "plugin_metadata.get_plugin_commands(self._running_plugins" in src
+
+
+# ---- (b) 行为单测：聚合 / pid 注入 / get_state 过滤 / pid 过滤 ----
+
+def test_get_plugin_commands_aggregates_and_injects_pid():
+    rp = {"FakeP": _FakePlugin()}
+    assert plugin_metadata.get_plugin_commands(rp, None) == [{"cmd": "/x", "desc": "d", "pid": "FakeP"}]
+
+
+def test_get_plugin_services_aggregates():
+    rp = {"FakeP": _FakePlugin()}
+    assert plugin_metadata.get_plugin_services(rp, None) == [{"id": "s1", "name": "svc"}]
+
+
+def test_get_plugin_apis_prefixes_path():
+    rp = {"FakeP": _FakePlugin()}
+    apis = plugin_metadata.get_plugin_apis(rp, None)
+    assert apis[0]["path"] == "/FakeP/ping"          # 路径加插件前缀
+    assert apis[0]["auth"] == "apikey"                # 默认 auth
+
+
+def test_disabled_plugin_skipped_and_pid_filter():
+    assert plugin_metadata.get_plugin_commands({"Off": _DisabledPlugin()}, None) == []  # get_state=False 跳过
+    assert plugin_metadata.get_plugin_commands({"FakeP": _FakePlugin()}, "OTHER") == []  # pid 不匹配


### PR DESCRIPTION
## 背景(S9-decompose 第 2 切片)
继 S9b(Cloner 簇)后,抽取 workflow 测绘的 **Metadata 簇**:PluginManager god-object 中 12 个**只读**元数据聚合访问器。它们对实例状态的**唯一耦合是 `_running_plugins` 一个字典**(grep 确认不触碰 _config_key/_plugins/DB)。

## 改动
12 个方法抽到新模块 `app/helper/plugin_metadata.py` 为模块级函数(首参 `running_plugins`):
`get_plugin_commands / apis / services / modules / actions / agent_tools / remote_entry / remotes / auth_providers / sidebar_nav / dashboard_meta / dashboard`

- 函数体**逐字迁出**(机械转换 `self._running_plugins` → `running_plugins`,内部 `dict()` 快照语义不变);docstring 中的 `self.xxx` 示例文本保留。
- **PluginManager 保留 12 个一行委托门面**(签名与原方法完全一致)→ `api/agent/command/scheduler/chain` 等大量调用方 `PluginManager().get_plugin_xxx()` **零改动**。
- contract-safe:workflow 已证 PluginManager 不被任何插件 monkey-patch / 私有符号深探。
- `plugin_manager.py` **1803 → 1444 行**(god-object 累计 2026 → 1444)。

## 验证(read-only 访问器 → 可 fake-插件行为单测)
- py_compile;探针:12 门面均委托 `plugin_metadata.X(self._running_plugins, ...)`、12 函数就位。
- **行为单测**(fake 插件):commands/services 聚合、apis 路径加前缀 + 默认 auth、**pid 注入**、**get_state=False 跳过**、**pid 过滤**。
- 新增 `tests/test_plugin_metadata.py`(7);dashboard/cloner/plugin/transfer-carve/cycle/metainfo = **105 passed**。
- 过程中 `test_plugin_dashboard`(走 get_plugin_dashboard 门面)**捕获了 Callable/Tuple 漏 import 并修正** —— 印证既有行为测试对抽取的覆盖有效。

## 后续 S9-decompose 切片
Market 簇 2 个纯 @staticmethod → `plugin_market.py`;有状态 lifecycle/monitor 核心永久保留 PluginManager。