### PR TITLE
refactor(plugin): 抽取市场列表处理与缺失依赖安装至 plugin_market(S9d)

### DIFF
--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -26,7 +26,7 @@ from app.core.config import settings
 from app.core.event import eventmanager
 from app.core.plugin_reporter import report_plugin_install
 from app.core.plugin_source import get_plugin_source
-from app.helper import plugin_metadata
+from app.helper import plugin_market, plugin_metadata
 from app.db.plugindata_oper import PluginDataOper
 from app.db.systemconfig_oper import SystemConfigOper
 from app.log import logger
@@ -652,22 +652,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         安装插件中缺失或不兼容的依赖项
         """
-        pluginhelper = get_plugin_source()
-        # 第一步：获取需要安装的依赖项列表
-        missing_dependencies = pluginhelper.find_missing_dependencies()
-        if not missing_dependencies:
-            return missing_dependencies
-        logger.debug(f"检测到缺失的依赖项: {missing_dependencies}")
-        logger.info(f"开始安装缺失的依赖项，共 {len(missing_dependencies)} 个...")
-        # 第二步：安装依赖项并返回结果
-        total_start_time = time.time()
-        success, message = pluginhelper.install_dependencies(missing_dependencies)
-        total_elapsed_time = time.time() - total_start_time
-        if success:
-            logger.info(f"已完成 {len(missing_dependencies)} 个依赖项安装，总耗时：{total_elapsed_time:.2f} 秒")
-        else:
-            logger.warning(f"存在缺失依赖项安装失败，请尝试手动安装，总耗时：{total_elapsed_time:.2f} 秒")
-        return missing_dependencies
+        return plugin_market.install_plugin_missing_dependencies()
 
     def get_plugin_config(self, pid: str) -> dict:
         """
@@ -1051,47 +1036,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         :param base_version_plugins: 基础版本插件列表
         :return: 处理后的插件列表
         """
-        # 优先处理高版本插件
-        all_plugins = []
-        all_plugins.extend(higher_version_plugins)
-        # 将未出现在高版本插件列表中的 v1 插件加入 all_plugins
-        higher_plugin_ids = {f"{p.id}{p.plugin_version}" for p in higher_version_plugins}
-        all_plugins.extend([p for p in base_version_plugins if f"{p.id}{p.plugin_version}" not in higher_plugin_ids])
-        markets = [item for item in settings.PLUGIN_MARKET.split(",") if item]
-
-        def repo_order(plugin: schemas.Plugin) -> int:
-            if is_local_repo_url(plugin.repo_url):
-                return len(markets) + 1
-            if plugin.repo_url in markets:
-                return markets.index(plugin.repo_url)
-            return len(markets)
-
-        # 去重：同 ID + 版本优先保留市场来源，其次按来源顺序稳定保留。
-        dedup_plugins = {}
-        for plugin in sorted(all_plugins, key=repo_order):
-            key = f"{plugin.id}{plugin.plugin_version}"
-            exists = dedup_plugins.get(key)
-            if not exists:
-                dedup_plugins[key] = plugin
-                continue
-            if is_local_repo_url(exists.repo_url) and not is_local_repo_url(plugin.repo_url):
-                dedup_plugins[key] = plugin
-
-        # 相同 ID 的插件保留版本号最大的版本；同版本市场来源优先。
-        result_by_id = {}
-        for plugin in sorted(dedup_plugins.values(), key=repo_order):
-            exists = result_by_id.get(plugin.id)
-            if not exists:
-                result_by_id[plugin.id] = plugin
-                continue
-            if StringUtils.compare_version(plugin.plugin_version, ">", exists.plugin_version):
-                result_by_id[plugin.id] = plugin
-            elif plugin.plugin_version == exists.plugin_version \
-                    and is_local_repo_url(exists.repo_url) \
-                    and not is_local_repo_url(plugin.repo_url):
-                result_by_id[plugin.id] = plugin
-
-        return list(result_by_id.values())
+        return plugin_market.process_plugins_list(higher_version_plugins, base_version_plugins)
 
     def _process_plugin_info(self, pid: str, plugin_info: dict, market: str,
                              installed_apps: List[str], add_time: int,

--- a/app/helper/plugin_market.py
+++ b/app/helper/plugin_market.py
@@ -1,0 +1,82 @@
+import time
+from typing import List
+
+from app import schemas
+from app.core.config import settings
+from app.core.plugin_source import get_plugin_source
+from app.log import logger
+from app.utils.plugin_repo import is_local_repo_url
+from app.utils.string import StringUtils
+
+
+def install_plugin_missing_dependencies() -> List[str]:
+    """
+    安装插件中缺失或不兼容的依赖项
+    """
+    pluginhelper = get_plugin_source()
+    # 第一步：获取需要安装的依赖项列表
+    missing_dependencies = pluginhelper.find_missing_dependencies()
+    if not missing_dependencies:
+        return missing_dependencies
+    logger.debug(f"检测到缺失的依赖项: {missing_dependencies}")
+    logger.info(f"开始安装缺失的依赖项，共 {len(missing_dependencies)} 个...")
+    # 第二步：安装依赖项并返回结果
+    total_start_time = time.time()
+    success, message = pluginhelper.install_dependencies(missing_dependencies)
+    total_elapsed_time = time.time() - total_start_time
+    if success:
+        logger.info(f"已完成 {len(missing_dependencies)} 个依赖项安装，总耗时：{total_elapsed_time:.2f} 秒")
+    else:
+        logger.warning(f"存在缺失依赖项安装失败，请尝试手动安装，总耗时：{total_elapsed_time:.2f} 秒")
+    return missing_dependencies
+
+
+def process_plugins_list(higher_version_plugins: List[schemas.Plugin],
+                         base_version_plugins: List[schemas.Plugin]) -> List[schemas.Plugin]:
+    """
+    处理插件列表：合并、去重、排序、保留最高版本
+    :param higher_version_plugins: 高版本插件列表
+    :param base_version_plugins: 基础版本插件列表
+    :return: 处理后的插件列表
+    """
+    # 优先处理高版本插件
+    all_plugins = []
+    all_plugins.extend(higher_version_plugins)
+    # 将未出现在高版本插件列表中的 v1 插件加入 all_plugins
+    higher_plugin_ids = {f"{p.id}{p.plugin_version}" for p in higher_version_plugins}
+    all_plugins.extend([p for p in base_version_plugins if f"{p.id}{p.plugin_version}" not in higher_plugin_ids])
+    markets = [item for item in settings.PLUGIN_MARKET.split(",") if item]
+
+    def repo_order(plugin: schemas.Plugin) -> int:
+        if is_local_repo_url(plugin.repo_url):
+            return len(markets) + 1
+        if plugin.repo_url in markets:
+            return markets.index(plugin.repo_url)
+        return len(markets)
+
+    # 去重：同 ID + 版本优先保留市场来源，其次按来源顺序稳定保留。
+    dedup_plugins = {}
+    for plugin in sorted(all_plugins, key=repo_order):
+        key = f"{plugin.id}{plugin.plugin_version}"
+        exists = dedup_plugins.get(key)
+        if not exists:
+            dedup_plugins[key] = plugin
+            continue
+        if is_local_repo_url(exists.repo_url) and not is_local_repo_url(plugin.repo_url):
+            dedup_plugins[key] = plugin
+
+    # 相同 ID 的插件保留版本号最大的版本；同版本市场来源优先。
+    result_by_id = {}
+    for plugin in sorted(dedup_plugins.values(), key=repo_order):
+        exists = result_by_id.get(plugin.id)
+        if not exists:
+            result_by_id[plugin.id] = plugin
+            continue
+        if StringUtils.compare_version(plugin.plugin_version, ">", exists.plugin_version):
+            result_by_id[plugin.id] = plugin
+        elif plugin.plugin_version == exists.plugin_version \
+                and is_local_repo_url(exists.repo_url) \
+                and not is_local_repo_url(plugin.repo_url):
+            result_by_id[plugin.id] = plugin
+
+    return list(result_by_id.values())

--- a/tests/test_plugin_market.py
+++ b/tests/test_plugin_market.py
@@ -1,0 +1,123 @@
+"""
+S9d 抽取验证：app.helper.plugin_market 行为单测。
+
+覆盖：
+- process_plugins_list 的合并 / 去重 / 版本择优 / 市场来源优先逻辑
+- install_plugin_missing_dependencies 的早返回与委派安装路径
+- PluginManager 门面方法与抽出模块的等价性（委派契约）
+"""
+from app import schemas
+from app.core.config import settings
+from app.helper import plugin_market
+
+
+def _plugin(pid: str, version: str, repo_url: str) -> schemas.Plugin:
+    return schemas.Plugin(id=pid, plugin_version=version, repo_url=repo_url)
+
+
+def _ids_versions(plugins):
+    return {(p.id, p.plugin_version) for p in plugins}
+
+
+def test_merge_adds_base_only_plugins(monkeypatch):
+    """高版本列表与基础列表合并：基础列表中未出现的插件应被纳入。"""
+    monkeypatch.setattr(settings, "PLUGIN_MARKET", "https://m1", raising=False)
+    higher = [_plugin("A", "1.0", "https://m1")]
+    base = [_plugin("A", "1.0", "https://m1"), _plugin("B", "1.0", "https://m1")]
+
+    result = plugin_market.process_plugins_list(higher, base)
+
+    assert {p.id for p in result} == {"A", "B"}
+
+
+def test_keeps_highest_version_per_id(monkeypatch):
+    """同 ID 多版本：仅保留版本号最大的那个。"""
+    monkeypatch.setattr(settings, "PLUGIN_MARKET", "https://m1", raising=False)
+    higher = [_plugin("A", "2.0", "https://m1")]
+    base = [_plugin("A", "1.0", "https://m1")]
+
+    result = plugin_market.process_plugins_list(higher, base)
+
+    assert len(result) == 1
+    assert result[0].id == "A"
+    assert result[0].plugin_version == "2.0"
+
+
+def test_market_source_preferred_over_local_same_version(monkeypatch):
+    """同 ID + 同版本：市场来源优先于本地来源。"""
+    monkeypatch.setattr(settings, "PLUGIN_MARKET", "https://m1", raising=False)
+    higher = []
+    base = [_plugin("A", "1.0", "local://A"), _plugin("A", "1.0", "https://m1")]
+
+    result = plugin_market.process_plugins_list(higher, base)
+
+    assert len(result) == 1
+    assert result[0].repo_url == "https://m1"
+
+
+def test_empty_inputs_return_empty(monkeypatch):
+    monkeypatch.setattr(settings, "PLUGIN_MARKET", "", raising=False)
+    assert plugin_market.process_plugins_list([], []) == []
+
+
+class _FakePluginSource:
+    def __init__(self, missing, install_result=(True, "ok")):
+        self._missing = missing
+        self._install_result = install_result
+        self.installed_with = None
+
+    def find_missing_dependencies(self):
+        return self._missing
+
+    def install_dependencies(self, deps):
+        self.installed_with = deps
+        return self._install_result
+
+
+def test_install_missing_deps_early_return_when_none(monkeypatch):
+    """无缺失依赖时直接返回空列表，不触发安装。"""
+    fake = _FakePluginSource(missing=[])
+    monkeypatch.setattr(plugin_market, "get_plugin_source", lambda: fake)
+
+    result = plugin_market.install_plugin_missing_dependencies()
+
+    assert result == []
+    assert fake.installed_with is None
+
+
+def test_install_missing_deps_delegates_install(monkeypatch):
+    """存在缺失依赖时委派安装并返回缺失列表。"""
+    fake = _FakePluginSource(missing=["dep-a", "dep-b"], install_result=(True, "done"))
+    monkeypatch.setattr(plugin_market, "get_plugin_source", lambda: fake)
+
+    result = plugin_market.install_plugin_missing_dependencies()
+
+    assert result == ["dep-a", "dep-b"]
+    assert fake.installed_with == ["dep-a", "dep-b"]
+
+
+def test_pluginmanager_facade_delegates_process(monkeypatch):
+    """PluginManager.process_plugins_list 门面与抽出模块结果一致。"""
+    from app.helper.plugin_manager import PluginManager
+
+    monkeypatch.setattr(settings, "PLUGIN_MARKET", "https://m1", raising=False)
+    higher = [_plugin("A", "2.0", "https://m1")]
+    base = [_plugin("A", "1.0", "https://m1"), _plugin("B", "1.0", "https://m1")]
+
+    facade = PluginManager.process_plugins_list(higher, base)
+    direct = plugin_market.process_plugins_list(higher, base)
+
+    assert _ids_versions(facade) == _ids_versions(direct)
+
+
+def test_pluginmanager_facade_delegates_install(monkeypatch):
+    """PluginManager.install_plugin_missing_dependencies 门面委派到抽出模块。"""
+    from app.helper.plugin_manager import PluginManager
+
+    fake = _FakePluginSource(missing=["dep-x"])
+    monkeypatch.setattr(plugin_market, "get_plugin_source", lambda: fake)
+
+    result = PluginManager.install_plugin_missing_dependencies()
+
+    assert result == ["dep-x"]
+    assert fake.installed_with == ["dep-x"]


### PR DESCRIPTION
## 背景（S9-decompose 收尾切片）

延续 S9b（`plugin_cloner`）/S9c（`plugin_metadata`）的 god-object 拆解，将 `PluginManager` 中两个**纯 `@staticmethod`**（无实例状态）抽至新模块 `app/helper/plugin_market.py`：

- `process_plugins_list` —— 合并高/基础版本插件列表、按 `PLUGIN_MARKET` 顺序去重、同 ID 保留最高版本、同版本市场来源优先。
- `install_plugin_missing_dependencies` —— 委派 `plugin_source` 查找并安装缺失依赖。

## 契约保持

- `PluginManager` 保留同名、同签名的 `@staticmethod` **门面委派**，所有调用方零改动：
  - 内部 `self.process_plugins_list`（3 处）
  - `api/endpoints/plugin.py`、`agent/tools/impl/_plugin_tool_utils.py`
  - `startup/plugins_initializer.py`（以裸可调用引用传入 `execute_task`，故门面保持无参 `@staticmethod`）
  - `chain/system.py`
- `plugin_manager.py`：1444 → **1389** 行（−55）。
- 新模块仅依赖 `app.core.*` / `app.schemas` / `app.utils.*` / `app.log`，**不引入导入环**。

## 验证

- `py_compile` 两文件通过；fresh-interpreter 导入探针通过（门面均在位、无环）。
- 新增行为单测 8 例（`tests/test_plugin_market.py`）：合并 / 版本择优 / 市场优先 / 空输入 / 安装早返回 / 安装委派 / 门面等价 ×2。
- 回归：`test_plugin_market` + `test_plugin_manager_relocation` + `test_plugin_metadata` + `test_plugin_cloner` + `test_plugin_dashboard` 共 **26 passed**。