### PR TITLE
refactor(api): 搜索端点纯解析逻辑下沉至 app.service.search(S7b)

### DIFF
--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from typing import List, Any, Optional, AsyncIterator
 
 from fastapi import APIRouter, Depends, Body, Request
@@ -15,51 +14,17 @@ from app.core.security import verify_resource_token, verify_token
 from app.log import logger
 from app.schemas import MediaRecognizeConvertEventData
 from app.schemas.types import MediaType, ChainEventType
+from app.service.search import (
+    merge_append_event as _merge_append_event,
+    parse_media_type as _parse_media_type,
+    parse_site_list as _parse_site_list,
+    sse_event as _sse_event,
+)
 
 router = APIRouter()
 
 _SSE_APPEND_FLUSH_INTERVAL = 1
 _SSE_APPEND_MAX_ITEMS = 48
-
-
-def _parse_site_list(sites: Optional[str]) -> Optional[List[int]]:
-    """
-    解析站点ID列表
-    """
-    return [int(site) for site in sites.split(",") if site] if sites else None
-
-
-def _parse_media_type(mtype: Optional[str]) -> Optional[MediaType]:
-    """
-    解析媒体类型，兼容前端和 Agent 使用的 movie/tv 取值。
-    """
-    if not mtype:
-        return None
-    return MediaType.from_agent(mtype) or MediaType(mtype)
-
-
-def _sse_event(data: dict) -> str:
-    """
-    转换为SSE事件
-    """
-    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
-
-
-def _merge_append_event(pending_event: Optional[dict], event: dict) -> dict:
-    """
-    合并短时间内连续到达的 append 事件，降低前端刷新频率。
-    """
-    items = list(event.get("items") or [])
-    if not pending_event:
-        merged_event = dict(event)
-        merged_event["items"] = items
-        return merged_event
-
-    merged_event = dict(pending_event)
-    merged_event.update({key: value for key, value in event.items() if key != "items"})
-    merged_event["type"] = "append"
-    merged_event["items"] = [*(pending_event.get("items") or []), *items]
-    return merged_event
 
 
 async def _iter_batched_search_events(

--- a/app/service/search.py
+++ b/app/service/search.py
@@ -1,0 +1,51 @@
+"""
+搜索端点的纯协议/解析逻辑（service layer）。
+
+均为无副作用的纯函数：站点列表解析、媒体类型解析、SSE 事件格式化、
+append 事件合并。不依赖 Chain/DB，可独立单测。
+端点 app/api/endpoints/search.py 负责鉴权、Chain 调用与 SSE 流编排。
+"""
+import json
+from typing import List, Optional
+
+from app.schemas.types import MediaType
+
+
+def parse_site_list(sites: Optional[str]) -> Optional[List[int]]:
+    """
+    解析站点ID列表
+    """
+    return [int(site) for site in sites.split(",") if site] if sites else None
+
+
+def parse_media_type(mtype: Optional[str]) -> Optional[MediaType]:
+    """
+    解析媒体类型，兼容前端和 Agent 使用的 movie/tv 取值。
+    """
+    if not mtype:
+        return None
+    return MediaType.from_agent(mtype) or MediaType(mtype)
+
+
+def sse_event(data: dict) -> str:
+    """
+    转换为SSE事件
+    """
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+def merge_append_event(pending_event: Optional[dict], event: dict) -> dict:
+    """
+    合并短时间内连续到达的 append 事件，降低前端刷新频率。
+    """
+    items = list(event.get("items") or [])
+    if not pending_event:
+        merged_event = dict(event)
+        merged_event["items"] = items
+        return merged_event
+
+    merged_event = dict(pending_event)
+    merged_event.update({key: value for key, value in event.items() if key != "items"})
+    merged_event["type"] = "append"
+    merged_event["items"] = [*(pending_event.get("items") or []), *items]
+    return merged_event

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,0 +1,74 @@
+"""
+S7b 抽取验证：app.service.search 纯解析/格式化逻辑单测。
+
+这些函数原本埋在 919 行的 app/api/endpoints/search.py 中；抽出后不依赖 Chain，
+可在本地 venv 直接单测。
+"""
+import json
+
+from app.schemas.types import MediaType
+from app.service import search
+
+
+def test_parse_site_list_basic():
+    assert search.parse_site_list("1,2,3") == [1, 2, 3]
+
+
+def test_parse_site_list_filters_empty_segments():
+    # 末尾/中间空段应被过滤
+    assert search.parse_site_list("1,,2,") == [1, 2]
+
+
+def test_parse_site_list_none_and_empty():
+    assert search.parse_site_list(None) is None
+    assert search.parse_site_list("") is None
+
+
+def test_parse_media_type_frontend_and_agent_values():
+    assert search.parse_media_type("movie") == MediaType.MOVIE
+    assert search.parse_media_type("tv") == MediaType.TV
+    assert search.parse_media_type("电影") == MediaType.MOVIE
+    assert search.parse_media_type("电视剧") == MediaType.TV
+
+
+def test_parse_media_type_none():
+    assert search.parse_media_type(None) is None
+    assert search.parse_media_type("") is None
+
+
+def test_sse_event_format_and_unicode():
+    out = search.sse_event({"type": "ping", "msg": "中文"})
+    assert out.startswith("data: ")
+    assert out.endswith("\n\n")
+    # ensure_ascii=False：中文不转义
+    assert "中文" in out
+    # 负载是合法 JSON
+    payload = json.loads(out[len("data: "):].strip())
+    assert payload == {"type": "ping", "msg": "中文"}
+
+
+def test_merge_append_event_no_pending():
+    event = {"type": "append", "items": [1, 2]}
+    merged = search.merge_append_event(None, event)
+    assert merged["items"] == [1, 2]
+    # 返回的是副本，不污染入参
+    assert merged is not event
+
+
+def test_merge_append_event_missing_items_defaults_empty():
+    merged = search.merge_append_event(None, {"type": "append"})
+    assert merged["items"] == []
+
+
+def test_merge_append_event_concatenates_and_marks_append():
+    pending = {"type": "append", "items": [1, 2], "keyword": "a"}
+    event = {"type": "result", "items": [3], "keyword": "b"}
+    merged = search.merge_append_event(pending, event)
+    # items 拼接
+    assert merged["items"] == [1, 2, 3]
+    # 非 items 字段以新事件为准
+    assert merged["keyword"] == "b"
+    # 合并结果统一标记为 append
+    assert merged["type"] == "append"
+    # 不污染原 pending
+    assert pending["items"] == [1, 2]


### PR DESCRIPTION
## 背景（S7 服务层第 2 刀）

延续 S7a（MCP 协议下沉），将 919 行的 `app/api/endpoints/search.py` 中 4 个无副作用的纯函数下沉至 `app/service/search.py`：
- `parse_site_list` —— 站点 ID 列表解析
- `parse_media_type` —— 媒体类型解析（兼容前端 movie/tv 与中文取值）
- `sse_event` —— SSE 事件格式化（`ensure_ascii=False`）
- `merge_append_event` —— 连续 append 事件合并（非平凡 dict 合并逻辑）

## 契约保持（最小风险）

- 端点以**同名 re-export 别名**导入（`parse_xxx as _parse_xxx`），919 行端点内**全部调用点零改动**（`_parse_site_list`×7、`_parse_media_type`×3、`_sse_event`×2、`_merge_append_event`×1）。
- 外部 `tests/test_subtitle_search.py:3` 仍 `from app.api.endpoints.search import _parse_media_type`，经别名解析到 service 同一函数对象——已用 `is` 同一性断言验证（`ep._parse_media_type is svc.parse_media_type` 等 4 个全部成立）。
- 随 `_sse_event` 一并失效的 `import json` 一并移除；`MediaType` 仍被其他 handler（行 346/540/751）使用，导入保留。
- 端点唯一其他引用是 `apiv1.py:18` 的 `search.router`，未改动。service 不反向导入端点（无环；grep 命中仅为 docstring 注释提及路径）。

## 验证

- `py_compile` 通过；端点在本地 venv 可正常导入（其 Chain 依赖不触发 jieba_next 缺口）。
- fresh-interp 探针：端点导入成功 + 4 个别名与 service 函数 `is` 同一。
- 新增 `tests/test_search_service.py` 9 例纯单测；连同既有 `test_subtitle_search.py`（经 re-export 导入 `_parse_media_type`）= **23 passed**。