### PR TITLE
refactor(api): LLM 错误脱敏逻辑下沉至 app.service.llm(S7c)

### DIFF
--- a/app/api/endpoints/llm.py
+++ b/app/api/endpoints/llm.py
@@ -1,4 +1,3 @@
-import re
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, Body, Depends, Request
@@ -19,6 +18,7 @@ from app.db.user_oper import (
     get_current_active_user_async,
 )
 from app.log import logger
+from app.service.llm import sanitize_llm_test_error as _sanitize_llm_test_error
 
 router = APIRouter()
 
@@ -46,37 +46,6 @@ class LlmProviderAuthStartRequest(BaseModel):
 
     provider: str
     method: str
-
-
-def _sanitize_llm_test_error(message: str, api_key: Optional[str] = None) -> str:
-    """
-    清理错误信息中的敏感字段，避免回显密钥。
-    """
-    if not message:
-        return "LLM 没有返回任何内容"
-
-    sanitized = message
-    if api_key:
-        sanitized = sanitized.replace(api_key, "***")
-    sanitized = re.sub(
-        r"(?i)(api[_-]?key\s*[:=]\s*)([^\s,;]+)",
-        r"\1***",
-        sanitized,
-    )
-    sanitized = re.sub(
-        r"(?i)authorization\s*:\s*bearer\s+[^\s,;]+",
-        "Authorization: ***",
-        sanitized,
-    )
-
-    normalized_message = sanitized.lower().replace("_", "").replace(" ", "")
-    if "str" in normalized_message and "modeldump" in normalized_message:
-        return (
-            "服务返回内容不是兼容的模型响应，"
-            "请检查基础地址是否填写为 API Base URL，不要填写网页地址或完整的 "
-            "chat/completions 路径"
-        )
-    return sanitized
 
 
 @router.get("/models", summary="获取LLM模型列表", response_model=schemas.Response)

--- a/app/service/llm.py
+++ b/app/service/llm.py
@@ -1,0 +1,39 @@
+"""
+LLM 端点的纯逻辑（service layer）。
+
+错误信息脱敏：从 LLM 测试调用的异常文本中抹去 API 密钥 / Bearer 令牌，
+避免敏感凭据经由错误响应回显。纯函数，不依赖 Chain/DB/agent，可独立单测。
+"""
+import re
+from typing import Optional
+
+
+def sanitize_llm_test_error(message: str, api_key: Optional[str] = None) -> str:
+    """
+    清理错误信息中的敏感字段，避免回显密钥。
+    """
+    if not message:
+        return "LLM 没有返回任何内容"
+
+    sanitized = message
+    if api_key:
+        sanitized = sanitized.replace(api_key, "***")
+    sanitized = re.sub(
+        r"(?i)(api[_-]?key\s*[:=]\s*)([^\s,;]+)",
+        r"\1***",
+        sanitized,
+    )
+    sanitized = re.sub(
+        r"(?i)authorization\s*:\s*bearer\s+[^\s,;]+",
+        "Authorization: ***",
+        sanitized,
+    )
+
+    normalized_message = sanitized.lower().replace("_", "").replace(" ", "")
+    if "str" in normalized_message and "modeldump" in normalized_message:
+        return (
+            "服务返回内容不是兼容的模型响应，"
+            "请检查基础地址是否填写为 API Base URL，不要填写网页地址或完整的 "
+            "chat/completions 路径"
+        )
+    return sanitized

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,52 @@
+"""
+S7c 抽取验证：app.service.llm.sanitize_llm_test_error 脱敏逻辑单测。
+
+该函数为安全相关（防止 API 密钥/Bearer 令牌经错误响应回显），原埋在
+app/api/endpoints/llm.py，其端点级测试 test_llm_endpoint_error_messages.py 在本
+环境因 jieba_next 缺口收集失败；抽出到不依赖 agent 的 service 后可在 venv 直接覆盖。
+"""
+from app.service import llm
+
+
+def test_empty_message_returns_placeholder():
+    assert llm.sanitize_llm_test_error("") == "LLM 没有返回任何内容"
+    assert llm.sanitize_llm_test_error(None) == "LLM 没有返回任何内容"
+
+
+def test_redacts_literal_api_key():
+    out = llm.sanitize_llm_test_error("请求失败 key=sk-abc123 无效", api_key="sk-abc123")
+    assert "sk-abc123" not in out
+    assert "***" in out
+
+
+def test_redacts_api_key_assignment_pattern():
+    out = llm.sanitize_llm_test_error("error: api_key=supersecret found")
+    assert "supersecret" not in out
+    assert "api_key=***" in out
+
+
+def test_redacts_api_key_dash_colon_pattern():
+    out = llm.sanitize_llm_test_error("API-KEY: topsecret")
+    assert "topsecret" not in out
+    assert "***" in out
+
+
+def test_redacts_authorization_bearer():
+    out = llm.sanitize_llm_test_error("Authorization: Bearer tok_987654")
+    assert "tok_987654" not in out
+    assert "Authorization: ***" in out
+
+
+def test_model_dump_heuristic_returns_friendly_message():
+    out = llm.sanitize_llm_test_error("'str' object has no attribute 'model_dump'")
+    assert "API Base URL" in out
+    assert "model_dump" not in out
+
+
+def test_plain_message_unchanged():
+    msg = "连接超时，请稍后重试"
+    assert llm.sanitize_llm_test_error(msg) == msg
+
+
+def test_api_key_none_does_not_crash():
+    assert llm.sanitize_llm_test_error("just a message", api_key=None) == "just a message"


### PR DESCRIPTION
## 背景（S7 服务层第 3 刀）

延续 S7a（MCP）/S7b（search），将 `app/api/endpoints/llm.py` 中**安全相关**的纯函数 `sanitize_llm_test_error` 下沉至 `app/service/llm.py`。该函数从 LLM 测试调用的异常文本中抹去 API 密钥 / `Authorization: Bearer` 令牌，避免敏感凭据经由错误响应回显。

## 契约保持

- 端点以同名 re-export 别名导入（`sanitize_llm_test_error as _sanitize_llm_test_error`），唯一调用点（原 315 行，现 284 行）零改动。
- 随函数一并失效的 `import re` 一并移除（AST 校验：端点不再绑定/引用 `re`）。
- 端点唯一其他引用是 `apiv1.py:24` 的 `llm.router`，未改动；无源码模块 import 该私有函数（grep）。

## 价值：把无覆盖的安全逻辑变成可测

`sanitize_llm_test_error` 是安全关键，但此前在本地 venv **无有效覆盖**——其端点级测试 `tests/test_llm_endpoint_error_messages.py` 因端点 `from app.agent.llm import ...` 触发 `app.utils.jieba` → `jieba_next` 缺口而**收集失败**（pre-existing，与本改动无关）。抽出到不依赖 agent 的 service 模块后，脱敏逻辑可独立单测。

## 验证

- `py_compile` 通过；`app.service.llm` 导入后 `app.agent` **不在** `sys.modules`（service 确为 agent-free）。
- 新增 `tests/test_llm_service.py` 8 例：空消息占位 / 字面密钥脱敏 / `api_key=` 赋值模式 / `API-KEY:` 模式 / `Authorization: Bearer` 令牌 / `model_dump` 启发式回退友好提示 / 普通消息不变 / `api_key=None` 不崩 —— **8 passed**。
- 端点本身因 pre-existing jieba_next 缺口在本环境不可导入，端到端 import-smoke 留待 CI。