### PR TITLE
refactor(api): OpenAI/Anthropic 兼容端点纯逻辑下沉至 service 层(S7d)

### DIFF
--- a/app/api/endpoints/anthropic.py
+++ b/app/api/endpoints/anthropic.py
@@ -19,33 +19,14 @@ from app.api.openai_utils import (
 from app.core.config import settings
 from app.core.security import anthropic_api_key_header
 from app.schemas.types import MessageChannel
+from app.service.anthropic import (
+    anthropic_error_response as _anthropic_error_response,
+    check_auth as _check_auth,
+)
 
 router = APIRouter()
 
 SESSION_PREFIX = "anthropic:"
-
-
-def _anthropic_error_response(
-    message: str,
-    status_code: int,
-    error_type: str = "invalid_request_error",
-) -> JSONResponse:
-    return JSONResponse(
-        status_code=status_code,
-        content=schemas.AnthropicErrorResponse(
-            error=schemas.AnthropicErrorDetail(type=error_type, message=message)
-        ).model_dump(),
-    )
-
-
-def _check_auth(api_key: Optional[str]) -> Optional[JSONResponse]:
-    if not api_key or api_key != settings.API_TOKEN:
-        return _anthropic_error_response(
-            "invalid x-api-key",
-            401,
-            error_type="authentication_error",
-        )
-    return None
 
 
 async def _stream_anthropic_response(

--- a/app/api/endpoints/openai.py
+++ b/app/api/endpoints/openai.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import time
 import uuid
 from typing import AsyncIterator, List, Optional, Tuple
@@ -19,6 +18,11 @@ from app.agent import MoviePilotAgent, StreamingHandler
 from app.core.config import settings
 from app.core.security import openai_bearer_scheme
 from app.schemas.types import MessageChannel
+from app.service.openai import (
+    check_auth as _check_auth,
+    error_response as _error_response,
+    sse_payload as _sse_payload,
+)
 
 router = APIRouter()
 
@@ -115,10 +119,6 @@ class _OpenAIStreamingHandler(StreamingHandler):
         return True, final_text
 
 
-def _sse_payload(data: dict) -> str:
-    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
-
-
 async def _stream_response(
     agent: _CollectingMoviePilotAgent,
     prompt: str,
@@ -210,45 +210,6 @@ async def _stream_response(
                 pass
         elif finished:
             await task
-
-
-def _error_response(
-    message: str,
-    status_code: int,
-    error_type: str = "invalid_request_error",
-    code: Optional[str] = None,
-) -> JSONResponse:
-    return JSONResponse(
-        status_code=status_code,
-        content=schemas.OpenAIErrorResponse(
-            error=schemas.OpenAIErrorDetail(
-                message=message,
-                type=error_type,
-                code=code,
-            )
-        ).model_dump(),
-        headers={"WWW-Authenticate": "Bearer"},
-    )
-
-
-def _check_auth(
-    credentials: Optional[HTTPAuthorizationCredentials],
-) -> Optional[JSONResponse]:
-    if not credentials or credentials.scheme.lower() != "bearer":
-        return _error_response(
-            "Invalid bearer token.",
-            401,
-            error_type="authentication_error",
-            code="invalid_api_key",
-        )
-    if credentials.credentials != settings.API_TOKEN:
-        return _error_response(
-            "Invalid bearer token.",
-            401,
-            error_type="authentication_error",
-            code="invalid_api_key",
-        )
-    return None
 
 
 @router.get(

--- a/app/service/anthropic.py
+++ b/app/service/anthropic.py
@@ -1,0 +1,35 @@
+"""
+Anthropic 兼容端点的纯逻辑（service layer）。
+
+错误响应构造与 x-api-key 鉴权校验。均为确定性的纯函数，不依赖 Chain/agent，
+可独立单测。端点 app/api/endpoints/anthropic.py 负责 agent 流式编排与路由。
+"""
+from typing import Optional
+
+from fastapi.responses import JSONResponse
+
+from app import schemas
+from app.core.config import settings
+
+
+def anthropic_error_response(
+    message: str,
+    status_code: int,
+    error_type: str = "invalid_request_error",
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=schemas.AnthropicErrorResponse(
+            error=schemas.AnthropicErrorDetail(type=error_type, message=message)
+        ).model_dump(),
+    )
+
+
+def check_auth(api_key: Optional[str]) -> Optional[JSONResponse]:
+    if not api_key or api_key != settings.API_TOKEN:
+        return anthropic_error_response(
+            "invalid x-api-key",
+            401,
+            error_type="authentication_error",
+        )
+    return None

--- a/app/service/openai.py
+++ b/app/service/openai.py
@@ -1,0 +1,58 @@
+"""
+OpenAI 兼容端点的纯逻辑（service layer）。
+
+SSE 负载格式化、错误响应构造、Bearer 鉴权校验。均为确定性的纯函数，
+不依赖 Chain/agent，可独立单测。端点 app/api/endpoints/openai.py 负责
+agent 流式编排与路由。
+"""
+import json
+from typing import Optional
+
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app import schemas
+from app.core.config import settings
+
+
+def sse_payload(data: dict) -> str:
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+def error_response(
+    message: str,
+    status_code: int,
+    error_type: str = "invalid_request_error",
+    code: Optional[str] = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=schemas.OpenAIErrorResponse(
+            error=schemas.OpenAIErrorDetail(
+                message=message,
+                type=error_type,
+                code=code,
+            )
+        ).model_dump(),
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def check_auth(
+    credentials: Optional[HTTPAuthorizationCredentials],
+) -> Optional[JSONResponse]:
+    if not credentials or credentials.scheme.lower() != "bearer":
+        return error_response(
+            "Invalid bearer token.",
+            401,
+            error_type="authentication_error",
+            code="invalid_api_key",
+        )
+    if credentials.credentials != settings.API_TOKEN:
+        return error_response(
+            "Invalid bearer token.",
+            401,
+            error_type="authentication_error",
+            code="invalid_api_key",
+        )
+    return None

--- a/tests/test_anthropic_service.py
+++ b/tests/test_anthropic_service.py
@@ -1,0 +1,41 @@
+"""
+S7d 抽取验证：app.service.anthropic 纯逻辑单测（错误响应 / x-api-key 鉴权）。
+
+端点 app/api/endpoints/anthropic.py 经 openai 端点 import app.agent，触发 jieba_next
+缺口，在本环境不可导入；抽出到 agent-free 的 service 后可在 venv 直接覆盖。
+"""
+import json
+
+from app.core.config import settings
+from app.service import anthropic as svc
+
+
+def _body(resp):
+    return json.loads(resp.body)
+
+
+def test_anthropic_error_response_shape():
+    resp = svc.anthropic_error_response("bad", 400, error_type="invalid_request_error")
+    assert resp.status_code == 400
+    body = _body(resp)
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["message"] == "bad"
+
+
+def test_check_auth_missing_key():
+    resp = svc.check_auth(None)
+    assert resp is not None
+    assert resp.status_code == 401
+    assert _body(resp)["error"]["type"] == "authentication_error"
+
+
+def test_check_auth_wrong_key(monkeypatch):
+    monkeypatch.setattr(settings, "API_TOKEN", "right", raising=False)
+    resp = svc.check_auth("wrong")
+    assert resp is not None
+    assert resp.status_code == 401
+
+
+def test_check_auth_valid_returns_none(monkeypatch):
+    monkeypatch.setattr(settings, "API_TOKEN", "right", raising=False)
+    assert svc.check_auth("right") is None

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,0 +1,62 @@
+"""
+S7d 抽取验证：app.service.openai 纯逻辑单测（SSE 负载 / 错误响应 / Bearer 鉴权）。
+
+端点 app/api/endpoints/openai.py 因 import app.agent 触发 jieba_next 缺口，在本环境
+不可导入；抽出到 agent-free 的 service 后这些（含安全相关的鉴权）逻辑可在 venv 直接覆盖。
+"""
+import json
+
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.core.config import settings
+from app.service import openai as svc
+
+
+def _body(resp):
+    return json.loads(resp.body)
+
+
+def test_sse_payload_format_and_unicode():
+    out = svc.sse_payload({"a": "中文"})
+    assert out.startswith("data: ")
+    assert out.endswith("\n\n")
+    assert "中文" in out
+    assert json.loads(out[len("data: "):].strip()) == {"a": "中文"}
+
+
+def test_error_response_shape():
+    resp = svc.error_response("boom", 400, error_type="invalid_request_error", code="x")
+    assert resp.status_code == 400
+    assert resp.headers["WWW-Authenticate"] == "Bearer"
+    body = _body(resp)
+    assert body["error"]["message"] == "boom"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "x"
+
+
+def test_check_auth_missing_credentials():
+    resp = svc.check_auth(None)
+    assert resp is not None
+    assert resp.status_code == 401
+    assert _body(resp)["error"]["code"] == "invalid_api_key"
+
+
+def test_check_auth_wrong_scheme():
+    creds = HTTPAuthorizationCredentials(scheme="Basic", credentials="whatever")
+    resp = svc.check_auth(creds)
+    assert resp is not None
+    assert resp.status_code == 401
+
+
+def test_check_auth_wrong_token(monkeypatch):
+    monkeypatch.setattr(settings, "API_TOKEN", "right-token", raising=False)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong-token")
+    resp = svc.check_auth(creds)
+    assert resp is not None
+    assert resp.status_code == 401
+
+
+def test_check_auth_valid_returns_none(monkeypatch):
+    monkeypatch.setattr(settings, "API_TOKEN", "right-token", raising=False)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="right-token")
+    assert svc.check_auth(creds) is None


### PR DESCRIPTION
## 背景（S7 服务层第 4 刀）

延续 S7a-c，将两个 LLM 兼容端点（OpenAI/Anthropic）中无副作用的纯函数下沉到服务层：

**`app/service/openai.py`**
- `sse_payload` —— SSE 负载格式化
- `error_response` —— OpenAI 错误响应（`schemas.OpenAIErrorResponse` + `WWW-Authenticate: Bearer`）
- `check_auth` —— Bearer 鉴权（比对 `settings.API_TOKEN`）

**`app/service/anthropic.py`**
- `anthropic_error_response` —— Anthropic 错误响应
- `check_auth` —— x-api-key 鉴权

## 契约保持

- 两端点均以**同名 re-export 别名**导入，全部调用点零改动（openai 17 处、anthropic 5 处）。
- openai 端点随 `sse_payload` 一并失效的 `import json` 一并移除（AST 校验 `json` 不再绑定，端点内无 `json.` 引用）。
- anthropic 端点对 openai 端点的 `MODEL_ID`/`_CollectingMoviePilotAgent` 引用、两端各自的 `_stream_*` 流式编排与路由均保持不变。
- 无源码模块 import 这些私有 helper（grep 命中均为 `__set_and_check_auth_level`/`_create_error_response` 等子串误配；`test_agent_tool_streaming.py` 仅 import `_OpenAIStreamingHandler`，未触及）。

## 价值：安全相关鉴权逻辑获得 venv 覆盖

两端点因 `import app.agent` 触发 `app.utils.jieba` → `jieba_next` 缺口，在本环境**不可导入**，其中含安全相关的鉴权校验此前在 venv **无有效覆盖**。service 模块 agent-free（验证 `app.agent` 不在 `sys.modules`），脱离 agent 后可独立单测。

## 验证

- `py_compile` 全通过；AST 名称绑定校验两端点别名均在位、被移除符号无悬空、`json` 在 openai 已解绑而 anthropic 仍保留（其流式仍用 json）。
- 新增 `tests/test_openai_service.py`（6）+ `tests/test_anthropic_service.py`（4）= **10 passed**：SSE 格式与中文 / 错误响应结构 + headers / 缺失凭据 / 错误 scheme / 错误 token / 正确 token 放行。
- 端点端到端 import-smoke 因 pre-existing jieba_next 缺口留待 CI。