### PR TITLE
refactor(api): MFA 端点展示用纯映射下沉至 app.service.mfa(S7e)

### DIFF
--- a/app/api/endpoints/mfa.py
+++ b/app/api/endpoints/mfa.py
@@ -21,28 +21,15 @@ from app.db.user_oper import get_current_active_user, get_current_active_user_as
 from app.helper.passkey import PassKeyHelper
 from app.log import logger
 from app.schemas.types import SystemConfigKey
+from app.service.mfa import (
+    build_credential_list as _build_credential_list,
+    build_passkey_list as _build_passkey_list,
+)
 from app.utils.otp import OtpUtils
 
 router = APIRouter()
 
 # ==================== 辅助函数 ====================
-
-
-def _build_credential_list(passkeys: list[PassKey]) -> list[dict[str, Any]]:
-    """
-    构建凭证列表
-
-    :param passkeys: PassKey 列表
-    :return: 凭证字典列表
-    """
-    return (
-        [
-            {"credential_id": pk.credential_id, "transports": pk.transports}
-            for pk in passkeys
-        ]
-        if passkeys
-        else []
-    )
 
 
 def _extract_and_standardize_credential_id(credential: dict) -> str:
@@ -444,23 +431,7 @@ def passkey_list(
     try:
         passkeys = PassKey.get_by_user_id(db=None, user_id=current_user.id)
 
-        key_list = (
-            [
-                {
-                    "id": pk.id,
-                    "name": pk.name,
-                    "created_at": pk.created_at.isoformat() if pk.created_at else None,
-                    "last_used_at": pk.last_used_at.isoformat()
-                    if pk.last_used_at
-                    else None,
-                    "aaguid": pk.aaguid,
-                    "transports": pk.transports,
-                }
-                for pk in passkeys
-            ]
-            if passkeys
-            else []
-        )
+        key_list = _build_passkey_list(passkeys)
 
         return schemas.Response(success=True, data=key_list)
     except Exception as e:

--- a/app/service/mfa.py
+++ b/app/service/mfa.py
@@ -1,0 +1,45 @@
+"""
+MFA 端点的纯逻辑（service layer）：PassKey 凭证 / 列表的字典映射。
+
+均为无副作用的只读字段映射（对 PassKey 对象 duck-typed），不依赖 DB/helper，
+可独立单测。端点 app/api/endpoints/mfa.py 保留全部 OTP/PassKey 的鉴权与验证等
+安全关键逻辑，本模块仅承接展示用的纯映射。
+"""
+from typing import Any, List
+
+
+def build_credential_list(passkeys: list) -> List[dict]:
+    """
+    构建凭证列表（用于 WebAuthn 选项中的 existing_credentials）
+    """
+    return (
+        [
+            {"credential_id": pk.credential_id, "transports": pk.transports}
+            for pk in passkeys
+        ]
+        if passkeys
+        else []
+    )
+
+
+def build_passkey_list(passkeys: list) -> List[dict[str, Any]]:
+    """
+    构建 PassKey 详情列表（用于前端列表展示）
+    """
+    return (
+        [
+            {
+                "id": pk.id,
+                "name": pk.name,
+                "created_at": pk.created_at.isoformat() if pk.created_at else None,
+                "last_used_at": pk.last_used_at.isoformat()
+                if pk.last_used_at
+                else None,
+                "aaguid": pk.aaguid,
+                "transports": pk.transports,
+            }
+            for pk in passkeys
+        ]
+        if passkeys
+        else []
+    )

--- a/tests/test_mfa_service.py
+++ b/tests/test_mfa_service.py
@@ -1,0 +1,61 @@
+"""
+S7e 抽取验证：app.service.mfa 纯映射逻辑单测（PassKey 凭证/列表字典映射）。
+
+仅覆盖从 MFA 端点抽出的、无副作用的展示用映射；端点保留全部 OTP/PassKey 的
+鉴权与验证安全关键逻辑（未抽出、未改动）。
+"""
+from datetime import datetime
+from types import SimpleNamespace
+
+from app.service import mfa
+
+
+def _pk(**kw):
+    base = dict(
+        id=1,
+        name="key",
+        credential_id="cid",
+        transports="usb,nfc",
+        created_at=None,
+        last_used_at=None,
+        aaguid="ag",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_build_credential_list_empty_and_none():
+    assert mfa.build_credential_list([]) == []
+    assert mfa.build_credential_list(None) == []
+
+
+def test_build_credential_list_maps_fields():
+    out = mfa.build_credential_list([_pk(credential_id="abc", transports="usb")])
+    assert out == [{"credential_id": "abc", "transports": "usb"}]
+
+
+def test_build_passkey_list_empty_and_none():
+    assert mfa.build_passkey_list([]) == []
+    assert mfa.build_passkey_list(None) == []
+
+
+def test_build_passkey_list_maps_fields_and_dates():
+    pk = _pk(
+        id=7,
+        name="MyKey",
+        aaguid="aaa",
+        transports="usb",
+        created_at=datetime(2026, 6, 17, 22, 0, 0),
+        last_used_at=None,
+    )
+    out = mfa.build_passkey_list([pk])
+    assert out == [
+        {
+            "id": 7,
+            "name": "MyKey",
+            "created_at": "2026-06-17T22:00:00",
+            "last_used_at": None,
+            "aaguid": "aaa",
+            "transports": "usb",
+        }
+    ]


### PR DESCRIPTION
## 背景（S7 服务层第 5 刀，收尾 S7 纯 helper 抽取）

MFA 端点（OTP/PassKey/WebAuthn）绝大部分是 DB/helper/crypto 耦合的安全关键逻辑，**必须留在端点**。仅两个无副作用的只读字典映射可干净抽出：
- `build_credential_list` —— PassKey → WebAuthn `existing_credentials` 列表
- `build_passkey_list` —— PassKey → 前端列表展示项（含 `created_at`/`last_used_at` 的 `isoformat()` 与 null 处理）

下沉至 `app/service/mfa.py`（仅依赖 `typing`，duck-typed）。

## 安全保证（已过 security-reviewer）

- 端点以**同名 re-export 别名**导入，调用点零改动（`is` 同一性验证两别名指向 service 函数）。
- **全部鉴权/验证安全关键逻辑未抽出、未改动**：`OtpUtils.is_legal`、`PassKeyHelper.verify_authentication_response`/`verify_registration_response`、`security.verify_password`/`create_access_token`、`_extract_and_standardize_credential_id`/`_verify_passkey_and_update`/`_check_user_has_passkey`、所有 `PASSKEY_*` 门禁。
- **security-reviewer 子代理**对暂存 diff 逐行比对 `HEAD` 基线，判定 **PASS（无安全回归）**：鉴权决策路径字节一致；两个被移函数行为等价（字段映射/空值短路/isoformat 完全一致）；新模块纯 `typing` 无 I/O、无反序列化、无密钥处理、无攻击面；映射输出未新增泄露任何敏感字段（`credential_id`/`public_key`/`sign_count`/`hashed_password`/OTP 密钥均不在展示输出）。

## 验证

- `py_compile` 通过；端点本地 venv 可导入；fresh-interp 探针确认两别名与 service 函数 `is` 同一。
- 新增 `tests/test_mfa_service.py` 4 例（空/None 短路、字段映射、isoformat 日期+null）= **4 passed**。