### PR TITLE
refactor(api): dashboard 统计 Chain 编排下沉至 app.service.dashboard(S7f)

### DIFF
--- a/app/api/endpoints/dashboard.py
+++ b/app/api/endpoints/dashboard.py
@@ -1,85 +1,22 @@
-from pathlib import Path
 from typing import Any, List, Optional, Annotated
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app import schemas
-from app.chain.dashboard import DashboardChain
-from app.chain.storage import StorageChain
 from app.core.security import verify_apitoken
 from app.db import get_db
 from app.db.models.transferhistory import TransferHistory
 from app.db.user_oper import get_current_active_superuser
-from app.helper.directory import DirectoryHelper
 from app.scheduler import Scheduler
+from app.service.dashboard import (
+    build_downloader as _build_downloader,
+    build_statistic as _build_statistic,
+    build_storage as _build_storage,
+)
 from app.utils.system import SystemUtils
 
 router = APIRouter()
-
-
-def _build_statistic(name: Optional[str] = None) -> schemas.Statistic:
-    """
-    构建媒体数量统计信息。
-    """
-    media_statistics: Optional[List[schemas.Statistic]] = (
-        DashboardChain().media_statistic(name)
-    )
-    if media_statistics:
-        # 汇总各媒体库统计信息
-        ret_statistic = schemas.Statistic()
-        has_episode_count = False
-        for media_statistic in media_statistics:
-            ret_statistic.movie_count += media_statistic.movie_count or 0
-            ret_statistic.tv_count += media_statistic.tv_count or 0
-            ret_statistic.user_count += media_statistic.user_count or 0
-            if media_statistic.episode_count is not None:
-                ret_statistic.episode_count += media_statistic.episode_count or 0
-                has_episode_count = True
-        if not has_episode_count:
-            # 所有媒体服务都未提供剧集统计时，返回 None 供前端展示“未获取”。
-            ret_statistic.episode_count = None
-        return ret_statistic
-    return schemas.Statistic()
-
-
-def _build_storage() -> schemas.Storage:
-    """
-    构建本地存储空间信息。
-    """
-    total, available = 0, 0
-    dirs = DirectoryHelper().get_dirs()
-    if not dirs:
-        return schemas.Storage(total_storage=total, used_storage=total - available)
-    storages = set([d.library_storage for d in dirs if d.library_storage])
-    for _storage in storages:
-        _usage = StorageChain().storage_usage(_storage)
-        if _usage:
-            total += _usage.total
-            available += _usage.available
-    return schemas.Storage(total_storage=total, used_storage=total - available)
-
-
-def _build_downloader(name: Optional[str] = None) -> schemas.DownloaderInfo:
-    """
-    构建下载器统计信息。
-    """
-    # 下载目录空间
-    download_dirs = DirectoryHelper().get_local_download_dirs()
-    _, free_space = SystemUtils.space_usage(
-        [Path(d.download_path) for d in download_dirs]
-    )
-    # 下载器信息
-    downloader_info = schemas.DownloaderInfo()
-    transfer_infos = DashboardChain().downloader_info(name)
-    if transfer_infos:
-        for transfer_info in transfer_infos:
-            downloader_info.download_speed += transfer_info.download_speed
-            downloader_info.upload_speed += transfer_info.upload_speed
-            downloader_info.download_size += transfer_info.download_size
-            downloader_info.upload_size += transfer_info.upload_size
-        downloader_info.free_space = free_space
-    return downloader_info
 
 
 @router.get("/statistic", summary="媒体数量统计", response_model=schemas.Statistic)

--- a/app/service/dashboard.py
+++ b/app/service/dashboard.py
@@ -1,0 +1,79 @@
+"""
+仪表盘统计的 Chain 编排 + 聚合逻辑（service layer）。
+
+把媒体数量 / 本地存储 / 下载器统计的「调用 Chain/Helper 取数 + 聚合」编排从端点
+下沉到服务层：端点退化为薄 HTTP 适配层、不再 import 任何 Chain；本层可通过 mock
+DashboardChain/StorageChain/DirectoryHelper 进行单测，亦是后续 Rust 移植的稳定目标。
+"""
+from pathlib import Path
+from typing import List, Optional
+
+from app import schemas
+from app.chain.dashboard import DashboardChain
+from app.chain.storage import StorageChain
+from app.helper.directory import DirectoryHelper
+from app.utils.system import SystemUtils
+
+
+def build_statistic(name: Optional[str] = None) -> schemas.Statistic:
+    """
+    构建媒体数量统计信息。
+    """
+    media_statistics: Optional[List[schemas.Statistic]] = (
+        DashboardChain().media_statistic(name)
+    )
+    if media_statistics:
+        # 汇总各媒体库统计信息
+        ret_statistic = schemas.Statistic()
+        has_episode_count = False
+        for media_statistic in media_statistics:
+            ret_statistic.movie_count += media_statistic.movie_count or 0
+            ret_statistic.tv_count += media_statistic.tv_count or 0
+            ret_statistic.user_count += media_statistic.user_count or 0
+            if media_statistic.episode_count is not None:
+                ret_statistic.episode_count += media_statistic.episode_count or 0
+                has_episode_count = True
+        if not has_episode_count:
+            # 所有媒体服务都未提供剧集统计时，返回 None 供前端展示“未获取”。
+            ret_statistic.episode_count = None
+        return ret_statistic
+    return schemas.Statistic()
+
+
+def build_storage() -> schemas.Storage:
+    """
+    构建本地存储空间信息。
+    """
+    total, available = 0, 0
+    dirs = DirectoryHelper().get_dirs()
+    if not dirs:
+        return schemas.Storage(total_storage=total, used_storage=total - available)
+    storages = set([d.library_storage for d in dirs if d.library_storage])
+    for _storage in storages:
+        _usage = StorageChain().storage_usage(_storage)
+        if _usage:
+            total += _usage.total
+            available += _usage.available
+    return schemas.Storage(total_storage=total, used_storage=total - available)
+
+
+def build_downloader(name: Optional[str] = None) -> schemas.DownloaderInfo:
+    """
+    构建下载器统计信息。
+    """
+    # 下载目录空间
+    download_dirs = DirectoryHelper().get_local_download_dirs()
+    _, free_space = SystemUtils.space_usage(
+        [Path(d.download_path) for d in download_dirs]
+    )
+    # 下载器信息
+    downloader_info = schemas.DownloaderInfo()
+    transfer_infos = DashboardChain().downloader_info(name)
+    if transfer_infos:
+        for transfer_info in transfer_infos:
+            downloader_info.download_speed += transfer_info.download_speed
+            downloader_info.upload_speed += transfer_info.upload_speed
+            downloader_info.download_size += transfer_info.download_size
+            downloader_info.upload_size += transfer_info.upload_size
+        downloader_info.free_space = free_space
+    return downloader_info

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -1,0 +1,104 @@
+"""
+S7f 抽取验证：app.service.dashboard 的 Chain 编排 + 聚合逻辑单测（mock Chain）。
+
+把端点里的 Chain 编排下沉到 service 层后，通过 monkeypatch DashboardChain /
+StorageChain / DirectoryHelper / SystemUtils 即可在 venv 内单测聚合逻辑，
+无需真实下载器/媒体库/磁盘。
+"""
+from types import SimpleNamespace
+
+from app import schemas
+from app.service import dashboard as svc
+
+
+# ---------- build_statistic ----------
+
+def test_build_statistic_aggregates_counts(monkeypatch):
+    stats = [
+        schemas.Statistic(movie_count=10, tv_count=20, episode_count=3, user_count=2),
+        schemas.Statistic(movie_count=1, tv_count=2, episode_count=6, user_count=1),
+    ]
+    monkeypatch.setattr(
+        svc, "DashboardChain", lambda: SimpleNamespace(media_statistic=lambda name: stats)
+    )
+    ret = svc.build_statistic()
+    assert ret.movie_count == 11
+    assert ret.tv_count == 22
+    assert ret.user_count == 3
+    assert ret.episode_count == 9
+
+
+def test_build_statistic_episode_none_when_all_missing(monkeypatch):
+    stats = [
+        schemas.Statistic(movie_count=10, tv_count=20, episode_count=None, user_count=2),
+        schemas.Statistic(movie_count=1, tv_count=2, episode_count=None, user_count=1),
+    ]
+    monkeypatch.setattr(
+        svc, "DashboardChain", lambda: SimpleNamespace(media_statistic=lambda name: stats)
+    )
+    ret = svc.build_statistic()
+    assert ret.movie_count == 11
+    assert ret.episode_count is None
+
+
+def test_build_statistic_empty_returns_blank(monkeypatch):
+    monkeypatch.setattr(
+        svc, "DashboardChain", lambda: SimpleNamespace(media_statistic=lambda name: None)
+    )
+    assert svc.build_statistic() == schemas.Statistic()
+
+
+# ---------- build_storage ----------
+
+def test_build_storage_sums_and_dedupes(monkeypatch):
+    # 两个目录同属一个 storage -> set 去重为一次 storage_usage 调用
+    dirs = [
+        SimpleNamespace(library_storage="local"),
+        SimpleNamespace(library_storage="local"),
+    ]
+    monkeypatch.setattr(
+        svc, "DirectoryHelper", lambda: SimpleNamespace(get_dirs=lambda: dirs)
+    )
+    monkeypatch.setattr(
+        svc,
+        "StorageChain",
+        lambda: SimpleNamespace(storage_usage=lambda s: SimpleNamespace(total=100, available=40)),
+    )
+    ret = svc.build_storage()
+    assert ret.total_storage == 100
+    assert ret.used_storage == 60  # total - available
+
+
+def test_build_storage_no_dirs(monkeypatch):
+    monkeypatch.setattr(
+        svc, "DirectoryHelper", lambda: SimpleNamespace(get_dirs=lambda: [])
+    )
+    ret = svc.build_storage()
+    assert ret.total_storage == 0
+    assert ret.used_storage == 0
+
+
+# ---------- build_downloader ----------
+
+def test_build_downloader_aggregates(monkeypatch):
+    infos = [
+        SimpleNamespace(download_speed=1.0, upload_speed=2.0, download_size=10, upload_size=20),
+        SimpleNamespace(download_speed=3.0, upload_speed=4.0, download_size=30, upload_size=40),
+    ]
+    monkeypatch.setattr(
+        svc,
+        "DirectoryHelper",
+        lambda: SimpleNamespace(
+            get_local_download_dirs=lambda: [SimpleNamespace(download_path="/tmp/dl")]
+        ),
+    )
+    monkeypatch.setattr(
+        svc, "DashboardChain", lambda: SimpleNamespace(downloader_info=lambda name: infos)
+    )
+    monkeypatch.setattr(svc.SystemUtils, "space_usage", staticmethod(lambda paths: (0, 999)))
+    ret = svc.build_downloader()
+    assert ret.download_speed == 4.0
+    assert ret.upload_speed == 6.0
+    assert ret.download_size == 40
+    assert ret.upload_size == 60
+    assert ret.free_space == 999

--- a/tests/test_ugreen_mediaserver.py
+++ b/tests/test_ugreen_mediaserver.py
@@ -169,7 +169,7 @@ class DashboardStatisticTest(unittest.TestCase):
             schemas.Statistic(movie_count=1, tv_count=2, episode_count=None, user_count=1),
         ]
         with patch(
-            "app.api.endpoints.dashboard.DashboardChain.media_statistic",
+            "app.service.dashboard.DashboardChain.media_statistic",
             return_value=mocked_stats,
         ):
             ret = dashboard_endpoint.statistic(name="ugreen", _=None)
@@ -186,7 +186,7 @@ class DashboardStatisticTest(unittest.TestCase):
             schemas.Statistic(movie_count=1, tv_count=2, episode_count=6, user_count=1),
         ]
         with patch(
-            "app.api.endpoints.dashboard.DashboardChain.media_statistic",
+            "app.service.dashboard.DashboardChain.media_statistic",
             return_value=mocked_stats,
         ):
             ret = dashboard_endpoint.statistic(name="all", _=None)


### PR DESCRIPTION
## 背景（S7 首个「Chain→service」深抽）

S7a-e 抽的是纯函数；本刀是更深一层：把 dashboard 端点中 **Chain 编排逻辑**（调用 Chain/Helper 取数 + 聚合）整体下沉到服务层。

`build_statistic` / `build_storage` / `build_downloader` 三个函数（媒体数量 / 本地存储 / 下载器统计）连同其内部的 `DashboardChain()` / `StorageChain()` / `DirectoryHelper()` 调用，整体迁入 `app/service/dashboard.py`。

## 端点退化为薄 HTTP 适配层

- 以同名 re-export 别名导入，6 处调用点零改动（`is` 同一性已验证）。
- **端点因此卸下全部 Chain 导入**：移除 `from app.chain.dashboard import DashboardChain`、`from app.chain.storage import StorageChain`、`from app.helper.directory import DirectoryHelper`、`from pathlib import Path`（均随抽出函数失效）。`SystemUtils`/`List`/`Optional` 仍被其他 handler 使用，保留。验证：端点不再有 `DashboardChain`/`StorageChain` 属性。

## 可测性（mock Chain）

- service 模块在 venv 内可导入；新增 `tests/test_dashboard_service.py` 7 例，通过 `monkeypatch` `DashboardChain`/`StorageChain`/`DirectoryHelper`/`SystemUtils` 单测聚合逻辑：计数汇总、剧集 `episode_count` None 语义、storage `set` 去重、下载器速率/大小累加、空输入。
- 既有 `tests/test_ugreen_mediaserver.py` 的 2 处 `mock.patch` 目标随调用点迁移（`app.api.endpoints.dashboard.DashboardChain` → `app.service.dashboard.DashboardChain`），断言不变。

## 验证

- `py_compile` 通过；fresh-interp 探针确认端点经别名委派且不再引用任何 Chain。
- `test_dashboard_service`（7）+ `test_ugreen_mediaserver`（7）= **14 passed**。