### PR TITLE
refactor(api): history 端点纯逻辑下沉至 app.service.history(S7g)

### DIFF
--- a/app/api/endpoints/history.py
+++ b/app/api/endpoints/history.py
@@ -23,69 +23,16 @@ from app.db.user_oper import (
 )
 from app.helper.progress import ProgressHelper
 from app.schemas.types import EventType
+from app.service.history import (
+    build_batch_manual_redo_template_context,
+    build_manual_redo_template_context,
+    format_manual_redo_record_context,
+    glob_to_like as _glob_to_like,
+    normalize_history_ids,
+)
 from app.utils.jieba import cut as jieba_cut
 
 router = APIRouter()
-
-
-def normalize_history_ids(history_ids: list[int]) -> list[int]:
-    """对输入的历史记录 ID 列表进行规范化处理，去除重复项并保持原有顺序。"""
-    normalized_ids: list[int] = []
-    for history_id in history_ids:
-        if history_id not in normalized_ids:
-            normalized_ids.append(history_id)
-    return normalized_ids
-
-
-def build_manual_redo_template_context(
-    history: TransferHistory,
-) -> dict[str, int | str]:
-    """仅负责把整理历史对象映射成 System Tasks 需要的模板变量。"""
-    src_fileitem = history.src_fileitem or {}
-    source_path = src_fileitem.get("path") if isinstance(src_fileitem, dict) else ""
-    source_path = source_path or history.src or ""
-    season_episode = f"{history.seasons or ''}{history.episodes or ''}".strip()
-    return {
-        "history_id": history.id,
-        "current_status": "success" if history.status else "failed",
-        "recognized_title": history.title or "unknown",
-        "media_type": history.type or "unknown",
-        "category": history.category or "unknown",
-        "year": history.year or "unknown",
-        "season_episode": season_episode or "unknown",
-        "source_path": source_path or "unknown",
-        "source_storage": history.src_storage or "local",
-        "destination_path": history.dest or "unknown",
-        "destination_storage": history.dest_storage or "unknown",
-        "transfer_mode": history.mode or "unknown",
-        "tmdbid": history.tmdbid or "none",
-        "doubanid": history.doubanid or "none",
-        "error_message": history.errmsg or "none",
-    }
-
-
-def format_manual_redo_record_context(history: Any) -> str:
-    """把单条整理记录格式化为批量任务可直接消费的上下文块。"""
-    context = build_manual_redo_template_context(history)
-    return "\n".join(
-        [
-            f"Record #{context['history_id']}:",
-            f"- Current status: {context['current_status']}",
-            f"- Current recognized title: {context['recognized_title']}",
-            f"- Media type: {context['media_type']}",
-            f"- Category: {context['category']}",
-            f"- Year: {context['year']}",
-            f"- Season/Episode: {context['season_episode']}",
-            f"- Source path: {context['source_path']}",
-            f"- Source storage: {context['source_storage']}",
-            f"- Destination path: {context['destination_path']}",
-            f"- Destination storage: {context['destination_storage']}",
-            f"- Transfer mode: {context['transfer_mode']}",
-            f"- Current TMDB ID: {context['tmdbid']}",
-            f"- Current Douban ID: {context['doubanid']}",
-            f"- Error message: {context['error_message']}",
-        ]
-    )
 
 
 def build_manual_redo_prompt(history: Any) -> str:
@@ -94,19 +41,6 @@ def build_manual_redo_prompt(history: Any) -> str:
         "manual_transfer_redo",
         template_context=build_manual_redo_template_context(history),
     )
-
-
-def build_batch_manual_redo_template_context(
-    histories: list[Any],
-) -> dict[str, int | str]:
-    """仅负责把多条整理历史对象映射成批量 System Tasks 需要的模板变量。"""
-    return {
-        "history_ids_csv": ", ".join(str(history.id) for history in histories),
-        "history_count": len(histories),
-        "records_context": "\n\n".join(
-            format_manual_redo_record_context(history) for history in histories
-        ),
-    }
 
 
 def build_batch_manual_redo_prompt(histories: list[Any]) -> str:
@@ -233,14 +167,6 @@ async def delete_download_history(
     """
     await DownloadHistory.async_delete(db, history_in.id)
     return schemas.Response(success=True)
-
-
-def _glob_to_like(pattern: str) -> str:
-    """
-    将 glob 通配符模式转换为 SQL LIKE 模式（使用 \\ 作为转义字符）
-    """
-    result = pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return result.replace("*", "%").replace("?", "_")
 
 
 @router.get("/transfer", summary="查询整理记录", response_model=schemas.Response)

--- a/app/service/history.py
+++ b/app/service/history.py
@@ -1,0 +1,87 @@
+"""
+history 端点的纯逻辑（service layer）。
+
+历史记录 ID 规范化、手动/批量 AI 整理的模板上下文构造、glob→SQL LIKE 转义。
+均为无副作用的纯函数（对 TransferHistory 对象 duck-typed），不依赖 Chain/agent/DB，
+可独立单测。端点 app/api/endpoints/history.py 保留 prompt_manager 渲染与异步任务编排。
+"""
+from typing import Any
+
+
+def normalize_history_ids(history_ids: list[int]) -> list[int]:
+    """对输入的历史记录 ID 列表进行规范化处理，去除重复项并保持原有顺序。"""
+    normalized_ids: list[int] = []
+    for history_id in history_ids:
+        if history_id not in normalized_ids:
+            normalized_ids.append(history_id)
+    return normalized_ids
+
+
+def build_manual_redo_template_context(history: Any) -> dict[str, int | str]:
+    """仅负责把整理历史对象映射成 System Tasks 需要的模板变量。"""
+    src_fileitem = history.src_fileitem or {}
+    source_path = src_fileitem.get("path") if isinstance(src_fileitem, dict) else ""
+    source_path = source_path or history.src or ""
+    season_episode = f"{history.seasons or ''}{history.episodes or ''}".strip()
+    return {
+        "history_id": history.id,
+        "current_status": "success" if history.status else "failed",
+        "recognized_title": history.title or "unknown",
+        "media_type": history.type or "unknown",
+        "category": history.category or "unknown",
+        "year": history.year or "unknown",
+        "season_episode": season_episode or "unknown",
+        "source_path": source_path or "unknown",
+        "source_storage": history.src_storage or "local",
+        "destination_path": history.dest or "unknown",
+        "destination_storage": history.dest_storage or "unknown",
+        "transfer_mode": history.mode or "unknown",
+        "tmdbid": history.tmdbid or "none",
+        "doubanid": history.doubanid or "none",
+        "error_message": history.errmsg or "none",
+    }
+
+
+def format_manual_redo_record_context(history: Any) -> str:
+    """把单条整理记录格式化为批量任务可直接消费的上下文块。"""
+    context = build_manual_redo_template_context(history)
+    return "\n".join(
+        [
+            f"Record #{context['history_id']}:",
+            f"- Current status: {context['current_status']}",
+            f"- Current recognized title: {context['recognized_title']}",
+            f"- Media type: {context['media_type']}",
+            f"- Category: {context['category']}",
+            f"- Year: {context['year']}",
+            f"- Season/Episode: {context['season_episode']}",
+            f"- Source path: {context['source_path']}",
+            f"- Source storage: {context['source_storage']}",
+            f"- Destination path: {context['destination_path']}",
+            f"- Destination storage: {context['destination_storage']}",
+            f"- Transfer mode: {context['transfer_mode']}",
+            f"- Current TMDB ID: {context['tmdbid']}",
+            f"- Current Douban ID: {context['doubanid']}",
+            f"- Error message: {context['error_message']}",
+        ]
+    )
+
+
+def build_batch_manual_redo_template_context(
+    histories: list[Any],
+) -> dict[str, int | str]:
+    """仅负责把多条整理历史对象映射成批量 System Tasks 需要的模板变量。"""
+    return {
+        "history_ids_csv": ", ".join(str(history.id) for history in histories),
+        "history_count": len(histories),
+        "records_context": "\n\n".join(
+            format_manual_redo_record_context(history) for history in histories
+        ),
+    }
+
+
+def glob_to_like(pattern: str) -> str:
+    """
+    将 glob 通配符模式转换为 SQL LIKE 模式（使用 \\ 作为转义字符）
+    """
+    result = pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return result.replace("*", "%").replace("?", "_")

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -1,0 +1,99 @@
+"""
+S7g 抽取验证：app.service.history 纯逻辑单测。
+
+history 端点因 import app.agent / app.utils.jieba 触发 jieba_next 缺口，在本环境
+不可导入，这些逻辑（含安全相关的 glob→SQL LIKE 转义）此前无 venv 覆盖；
+抽出到不依赖 agent 的 service 后可在 venv 直接覆盖。
+"""
+from types import SimpleNamespace
+
+from app.service import history as svc
+
+
+def _h(**kw):
+    base = dict(
+        id=1,
+        status=True,
+        title="T",
+        type="电影",
+        category="C",
+        year="2020",
+        seasons="",
+        episodes="",
+        src="/src",
+        src_fileitem=None,
+        src_storage="local",
+        dest="/dest",
+        dest_storage="local",
+        mode="copy",
+        tmdbid=1,
+        doubanid=2,
+        errmsg=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_normalize_history_ids_dedup_preserves_order():
+    assert svc.normalize_history_ids([3, 1, 3, 2, 1]) == [3, 1, 2]
+
+
+def test_normalize_history_ids_empty():
+    assert svc.normalize_history_ids([]) == []
+
+
+def test_build_manual_redo_template_context_basic():
+    h = _h(id=7, status=True, title="Foo", seasons="S01", episodes="E02", src="/a/b")
+    ctx = svc.build_manual_redo_template_context(h)
+    assert ctx["history_id"] == 7
+    assert ctx["current_status"] == "success"
+    assert ctx["recognized_title"] == "Foo"
+    assert ctx["season_episode"] == "S01E02"
+    assert ctx["source_path"] == "/a/b"
+
+
+def test_build_manual_redo_template_context_src_fileitem_dict_preferred():
+    h = _h(src_fileitem={"path": "/from/item"}, src="/fallback")
+    ctx = svc.build_manual_redo_template_context(h)
+    assert ctx["source_path"] == "/from/item"
+
+
+def test_build_manual_redo_template_context_failed_and_defaults():
+    h = _h(status=False, title=None, type=None, tmdbid=None, errmsg="boom")
+    ctx = svc.build_manual_redo_template_context(h)
+    assert ctx["current_status"] == "failed"
+    assert ctx["recognized_title"] == "unknown"
+    assert ctx["media_type"] == "unknown"
+    assert ctx["tmdbid"] == "none"
+    assert ctx["error_message"] == "boom"
+
+
+def test_format_manual_redo_record_context():
+    h = _h(id=5, status=True, title="Bar")
+    out = svc.format_manual_redo_record_context(h)
+    assert out.startswith("Record #5:")
+    assert "- Current recognized title: Bar" in out
+
+
+def test_build_batch_template_context():
+    hs = [_h(id=1), _h(id=2)]
+    ctx = svc.build_batch_manual_redo_template_context(hs)
+    assert ctx["history_ids_csv"] == "1, 2"
+    assert ctx["history_count"] == 2
+    assert "Record #1:" in ctx["records_context"]
+    assert "Record #2:" in ctx["records_context"]
+    assert "\n\n" in ctx["records_context"]
+
+
+def test_glob_to_like_escapes_and_maps():
+    # * -> %, ? -> _
+    assert svc.glob_to_like("a*b?c") == "a%b_c"
+    # 字面 % 和 _ 被转义
+    assert svc.glob_to_like("50%_x") == "50\\%\\_x"
+    # 字面反斜杠被转义
+    assert svc.glob_to_like("a\\b") == "a\\\\b"
+
+
+def test_glob_to_like_escape_then_map_order():
+    # 字面 %（转义）与 glob *（映射）共存：先转义字面、再映射通配
+    assert svc.glob_to_like("%*") == "\\%%"


### PR DESCRIPTION
## 背景（S7 服务层第 7 刀）

将 history 端点中 5 个无副作用的纯函数下沉到 `app/service/history.py`：
- `normalize_history_ids` —— 历史 ID 去重保序
- `build_manual_redo_template_context` —— 整理历史 → AI 模板上下文（对 TransferHistory duck-typed）
- `format_manual_redo_record_context` —— 单条记录 → 批量上下文块
- `build_batch_manual_redo_template_context` —— 多条 → 批量模板上下文
- `glob_to_like` —— glob 通配符 → SQL LIKE（转义 `\` `%` `_`，映射 `*`→`%` `?`→`_`，**安全相关**）

## 契约保持

- 端点以原名导入 4 个上下文/规范化函数 + `glob_to_like as _glob_to_like` 别名，全部调用点零改动（69/95/107/116/267/382）。
- 保留 `build_manual_redo_prompt` / `build_batch_manual_redo_prompt`（调用 `prompt_manager.render_system_task_message`，使用导入回来的上下文构造器）—— 外部 `tests/test_history_batch_ai_redo_prompt.py`（从端点导入 `build_batch_manual_redo_prompt`）不受影响。
- AST 校验：5 个被移函数在端点内 `bound=True / locally_defined=False`，2 个保留的 prompt 构造器仍本地定义。

## 价值：jieba-blocked 端点的逻辑获得 venv 覆盖

history 端点因 `import app.agent` / `app.utils.jieba` 触发 `jieba_next` 缺口在本环境**不可导入**，含安全相关的 SQL LIKE 转义此前**无 venv 覆盖**。service 模块 agent/jieba-free。

## 验证

- `py_compile` 通过；新增 `tests/test_history_service.py` 9 例 = **9 passed**（去重保序 / 模板默认值 / `src_fileitem` 优先 / 批量上下文 / `glob_to_like` 转义+映射顺序）。
- 端点端到端 import-smoke 因 pre-existing jieba_next 缺口留待 CI。