### PR TITLE
refactor(api): download 提交 Chain 编排下沉至 app.service.download(S7h)

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -4,15 +4,17 @@ from fastapi import APIRouter, Depends, Body
 
 from app import schemas
 from app.chain.download import DownloadChain
-from app.chain.media import MediaChain
-from app.core.context import MediaInfo, Context, SubtitleInfo, TorrentInfo
-from app.core.metainfo import MetaInfo
+from app.core.context import SubtitleInfo
 from app.core.security import verify_token
 from app.db.models.user import User
 from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_user
 from app.helper.directory import DirectoryHelper
 from app.schemas.types import SystemConfigKey
+from app.service.download import (
+    add_download_with_media as _add_download_with_media,
+    recognize_and_download as _recognize_and_download,
+)
 
 router = APIRouter()
 
@@ -38,25 +40,12 @@ def download(
     """
     添加下载任务（含媒体信息）
     """
-    # 元数据
-    metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
-    # 媒体信息
-    mediainfo = MediaInfo()
-    mediainfo.from_dict(media_in.model_dump())
-    # 种子信息
-    torrentinfo = TorrentInfo()
-    torrentinfo.from_dict(torrent_in.model_dump())
-    # 手动下载始终使用选择的下载器
-    torrentinfo.site_downloader = downloader
-    # 上下文
-    context = Context(
-        meta_info=metainfo, media_info=mediainfo, torrent_info=torrentinfo
-    )
-    did = DownloadChain().download_single(
-        context=context,
-        username=current_user.name,
+    did = _add_download_with_media(
+        media_in=media_in,
+        torrent_in=torrent_in,
+        downloader=downloader,
         save_path=save_path,
-        source="Manual",
+        username=current_user.name,
     )
     if not did:
         return schemas.Response(success=False, message="任务添加失败")
@@ -78,37 +67,16 @@ def add(
     """
     添加下载任务（不含媒体信息）
     """
-    # 元数据
-    metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
-    # 媒体信息
-    if tmdbid or doubanid:
-        mediainfo = MediaChain().recognize_media(
-            meta=metainfo,
-            tmdbid=tmdbid,
-            doubanid=doubanid,
-        )
-    else:
-        mediainfo = MediaChain().recognize_by_meta(
-            metainfo,
-            obtain_images=False,
-        )
-    if not mediainfo:
-        return schemas.Response(success=False, message="无法识别媒体信息")
-    # 种子信息
-    torrentinfo = TorrentInfo()
-    torrentinfo.from_dict(torrent_in.model_dump())
-    # 上下文
-    context = Context(
-        meta_info=metainfo, media_info=mediainfo, torrent_info=torrentinfo
-    )
-
-    did = DownloadChain().download_single(
-        context=context,
-        username=current_user.name,
+    recognized, did = _recognize_and_download(
+        torrent_in=torrent_in,
+        tmdbid=tmdbid,
+        doubanid=doubanid,
         downloader=downloader,
         save_path=save_path,
-        source="Manual",
+        username=current_user.name,
     )
+    if not recognized:
+        return schemas.Response(success=False, message="无法识别媒体信息")
     if not did:
         return schemas.Response(success=False, message="任务添加失败")
     return schemas.Response(success=True, data={"download_id": did})

--- a/app/service/download.py
+++ b/app/service/download.py
@@ -1,0 +1,92 @@
+"""
+下载提交的 Chain 编排（service layer）。
+
+把「构建 Context → （可选）识别媒体 → 提交 DownloadChain」的编排从端点下沉到服务层：
+端点退化为薄 HTTP 适配层、不再 import MediaChain/MetaInfo；本层可通过 mock
+MediaChain/DownloadChain 单测，亦是后续 Rust 移植的稳定目标。
+"""
+from typing import Optional, Tuple
+
+from app import schemas
+from app.chain.download import DownloadChain
+from app.chain.media import MediaChain
+from app.core.context import Context, MediaInfo, TorrentInfo
+from app.core.metainfo import MetaInfo
+
+
+def add_download_with_media(
+    media_in: schemas.MediaInfo,
+    torrent_in: schemas.TorrentInfo,
+    downloader: Optional[str],
+    save_path: Optional[str],
+    username: str,
+) -> Optional[str]:
+    """
+    添加下载（含媒体信息）：构建上下文并提交 DownloadChain，返回 download_id 或 None。
+    """
+    # 元数据
+    metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
+    # 媒体信息
+    mediainfo = MediaInfo()
+    mediainfo.from_dict(media_in.model_dump())
+    # 种子信息
+    torrentinfo = TorrentInfo()
+    torrentinfo.from_dict(torrent_in.model_dump())
+    # 手动下载始终使用选择的下载器
+    torrentinfo.site_downloader = downloader
+    # 上下文
+    context = Context(
+        meta_info=metainfo, media_info=mediainfo, torrent_info=torrentinfo
+    )
+    return DownloadChain().download_single(
+        context=context,
+        username=username,
+        save_path=save_path,
+        source="Manual",
+    )
+
+
+def recognize_and_download(
+    torrent_in: schemas.TorrentInfo,
+    tmdbid: Optional[int],
+    doubanid: Optional[str],
+    downloader: Optional[str],
+    save_path: Optional[str],
+    username: str,
+) -> Tuple[bool, Optional[str]]:
+    """
+    添加下载（不含媒体信息）：识别媒体 → 构建上下文 → 提交 DownloadChain。
+
+    返回 (recognized, download_id)；recognized=False 表示识别失败。
+    """
+    # 元数据
+    metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
+    # 媒体信息
+    if tmdbid or doubanid:
+        mediainfo = MediaChain().recognize_media(
+            meta=metainfo,
+            tmdbid=tmdbid,
+            doubanid=doubanid,
+        )
+    else:
+        mediainfo = MediaChain().recognize_by_meta(
+            metainfo,
+            obtain_images=False,
+        )
+    if not mediainfo:
+        return False, None
+    # 种子信息
+    torrentinfo = TorrentInfo()
+    torrentinfo.from_dict(torrent_in.model_dump())
+    # 上下文
+    context = Context(
+        meta_info=metainfo, media_info=mediainfo, torrent_info=torrentinfo
+    )
+    did = DownloadChain().download_single(
+        context=context,
+        username=username,
+        downloader=downloader,
+        save_path=save_path,
+        source="Manual",
+    )
+    return True, did

--- a/tests/test_download_service.py
+++ b/tests/test_download_service.py
@@ -1,0 +1,149 @@
+"""
+S7h 抽取验证：app.service.download 的 Chain 编排单测（mock Chain）。
+
+把 download/add 端点的「构建 Context → 识别媒体 → 提交 DownloadChain」编排下沉到
+service 后，通过 monkeypatch MediaChain/DownloadChain 即可在 venv 内单测，无需真实
+下载器/媒体识别。
+"""
+from types import SimpleNamespace
+
+from app import schemas
+from app.core.context import MediaInfo
+from app.service import download as svc
+
+
+def _torrent(title="Some.Movie.2020", description=""):
+    return schemas.TorrentInfo(title=title, description=description)
+
+
+def _media():
+    return schemas.MediaInfo(title="Some Movie", year="2020")
+
+
+def _truthy_media():
+    mi = MediaInfo()
+    mi.tmdb_id = 999
+    return mi
+
+
+def test_add_download_with_media_success(monkeypatch):
+    captured = {}
+
+    def fake_download_single(**kwargs):
+        captured.update(kwargs)
+        return "did-123"
+
+    monkeypatch.setattr(
+        svc, "DownloadChain", lambda: SimpleNamespace(download_single=fake_download_single)
+    )
+    did = svc.add_download_with_media(
+        media_in=_media(),
+        torrent_in=_torrent(),
+        downloader="qb",
+        save_path="/dl",
+        username="alice",
+    )
+    assert did == "did-123"
+    assert captured["username"] == "alice"
+    assert captured["save_path"] == "/dl"
+    assert captured["source"] == "Manual"
+    # 选择的下载器写入 torrentinfo.site_downloader
+    assert captured["context"].torrent_info.site_downloader == "qb"
+
+
+def test_add_download_with_media_failure(monkeypatch):
+    monkeypatch.setattr(
+        svc, "DownloadChain", lambda: SimpleNamespace(download_single=lambda **kw: None)
+    )
+    did = svc.add_download_with_media(
+        media_in=_media(),
+        torrent_in=_torrent(),
+        downloader=None,
+        save_path=None,
+        username="bob",
+    )
+    assert did is None
+
+
+def test_recognize_and_download_recognize_fail(monkeypatch):
+    called = {"dl": False}
+
+    def fake_dl():
+        called["dl"] = True
+        return SimpleNamespace(download_single=lambda **kw: "x")
+
+    monkeypatch.setattr(
+        svc,
+        "MediaChain",
+        lambda: SimpleNamespace(
+            recognize_by_meta=lambda meta, obtain_images: None,
+            recognize_media=lambda meta, tmdbid, doubanid: None,
+        ),
+    )
+    monkeypatch.setattr(svc, "DownloadChain", fake_dl)
+    recognized, did = svc.recognize_and_download(
+        torrent_in=_torrent(),
+        tmdbid=None,
+        doubanid=None,
+        downloader=None,
+        save_path=None,
+        username="u",
+    )
+    assert recognized is False
+    assert did is None
+    assert called["dl"] is False  # 识别失败时不应提交下载
+
+
+def test_recognize_and_download_by_meta_success(monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "MediaChain",
+        lambda: SimpleNamespace(
+            recognize_by_meta=lambda meta, obtain_images: _truthy_media(),
+            recognize_media=lambda **kw: None,
+        ),
+    )
+    monkeypatch.setattr(
+        svc, "DownloadChain", lambda: SimpleNamespace(download_single=lambda **kw: "did-abc")
+    )
+    recognized, did = svc.recognize_and_download(
+        torrent_in=_torrent(),
+        tmdbid=None,
+        doubanid=None,
+        downloader="tr",
+        save_path="/x",
+        username="u",
+    )
+    assert recognized is True
+    assert did == "did-abc"
+
+
+def test_recognize_and_download_by_tmdbid_uses_recognize_media(monkeypatch):
+    calls = {}
+
+    def fake_recognize_media(meta, tmdbid, doubanid):
+        calls["tmdbid"] = tmdbid
+        return _truthy_media()
+
+    monkeypatch.setattr(
+        svc,
+        "MediaChain",
+        lambda: SimpleNamespace(
+            recognize_media=fake_recognize_media,
+            recognize_by_meta=lambda **kw: None,
+        ),
+    )
+    monkeypatch.setattr(
+        svc, "DownloadChain", lambda: SimpleNamespace(download_single=lambda **kw: "did-tmdb")
+    )
+    recognized, did = svc.recognize_and_download(
+        torrent_in=_torrent(),
+        tmdbid=123,
+        doubanid=None,
+        downloader=None,
+        save_path=None,
+        username="u",
+    )
+    assert recognized is True
+    assert did == "did-tmdb"
+    assert calls["tmdbid"] == 123  # tmdbid/doubanid 分支走 recognize_media


### PR DESCRIPTION
## 背景（S7 第二个「Chain→service」深抽）

继 S7f（dashboard）之后，将 download/add 端点的下载提交编排下沉到服务层。

`app/service/download.py`：
- `add_download_with_media` —— 含媒体信息：构建 Context + `DownloadChain().download_single`，返回 download_id 或 None。
- `recognize_and_download` —— 不含媒体信息：`tmdbid/doubanid` → `MediaChain().recognize_media`，否则 `recognize_by_meta`；识别失败返回 `(False, None)`，否则提交并返回 `(True, did)`。

## 端点退化为薄 HTTP 适配层

- 以同名 re-export 别名导入；`download`/`add` 两 handler 仅保留「调用 service + 把结果映射为 `schemas.Response`」（`add` 的两段失败语义——识别失败 vs 提交失败——由 `(recognized, did)` 元组在端点侧区分）。
- **端点卸下 `MediaChain` / `MetaInfo` 导入**；context 导入收敛为仅 `SubtitleInfo`（`MediaInfo`/`Context`/`TorrentInfo` 随抽出函数失效）。`DownloadChain`/`DirectoryHelper`/`SystemConfigOper` 仍被其他 handler 使用，保留。验证：端点不再有 `MediaChain`/`MetaInfo` 属性。
- `current`/`subtitle`/`start`/`stop`/`clients`/`paths`/`delete` 等 handler 未改动。

## 可测性（mock Chain）

新增 `tests/test_download_service.py` 5 例，`monkeypatch` `MediaChain`/`DownloadChain`：含媒体成功（校验 `site_downloader`/`source`/`username` 透传 + context）、含媒体失败返回 None、识别失败不提交下载、`recognize_by_meta` 成功、`tmdbid` 分支走 `recognize_media`。

## 验证

- `py_compile` 通过；fresh-interp 探针确认端点经别名委派且不再引用 `MediaChain`/`MetaInfo`。
- `test_download_service`（5）+ 既有 `test_download_paths_endpoint`（2）= **7 passed**。