### PR TITLE
refactor(api): storage 目录列举与递归重命名 Chain 编排下沉至 app.service.storage(S7i)

### DIFF
--- a/app/api/endpoints/storage.py
+++ b/app/api/endpoints/storage.py
@@ -1,26 +1,20 @@
-import fnmatch
-import math
-import re
-from pathlib import Path
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from starlette.responses import FileResponse, Response
 
 from app import schemas
-from app.chain.media import MediaChain
 from app.chain.storage import StorageChain
-from app.chain.transfer import TransferChain
-from app.core.config import settings
 from app.core.security import verify_token
 from app.db.models import User
 from app.db.user_oper import (
     get_current_active_superuser,
     get_current_active_superuser_async,
 )
-from app.helper.progress import ProgressHelper
-from app.schemas.types import ProgressKey
-from app.utils.string import StringUtils
+from app.service.storage import (
+    batch_recursive_rename as _batch_recursive_rename,
+    list_directory as _list_directory,
+)
 
 router = APIRouter()
 
@@ -101,16 +95,7 @@ def list_files(
     :param _: token
     :return: 所有目录和文件
     """
-    file_list = StorageChain().list_files(fileitem)
-    if file_list:
-        if keyword:
-            _pat = re.compile(fnmatch.translate(keyword), re.IGNORECASE)
-            file_list = [f for f in file_list if _pat.match(f.name or "")]
-        if sort == "name":
-            file_list.sort(key=lambda x: StringUtils.natural_sort_key(x.name or ""))
-        else:
-            file_list.sort(key=lambda x: x.modify_time or -math.inf, reverse=True)
-    return file_list
+    return _list_directory(fileitem, sort, keyword)
 
 
 @router.post("/mkdir", summary="创建目录", response_model=schemas.Response)
@@ -197,56 +182,11 @@ def rename(
     if not new_name:
         return schemas.Response(success=False, message="新名称为空")
 
-    # 重命名目录内文件
+    # 重命名目录内文件（递归智能识别命名）
     if recursive:
-        transferchain = TransferChain()
-        media_exts = settings.RMT_MEDIAEXT + settings.RMT_SUBEXT + settings.RMT_AUDIOEXT
-        # 递归修改目录内文件（智能识别命名）
-        sub_files: List[schemas.FileItem] = StorageChain().list_files(fileitem)
-        if sub_files:
-            # 开始进度
-            progress = ProgressHelper(ProgressKey.BatchRename)
-            progress.start()
-            total = len(sub_files)
-            handled = 0
-            for sub_file in sub_files:
-                handled += 1
-                progress.update(
-                    value=handled / total * 100, text=f"正在处理 {sub_file.name} ..."
-                )
-                if sub_file.type == "dir":
-                    continue
-                if not sub_file.extension:
-                    continue
-                if f".{sub_file.extension.lower()}" not in media_exts:
-                    continue
-                sub_path = Path(f"{fileitem.path}{sub_file.name}")
-                context = MediaChain().recognize_by_path(
-                    sub_path,
-                    obtain_images=False,
-                )
-                if not context or not context.media_info:
-                    progress.end()
-                    return schemas.Response(
-                        success=False, message=f"{sub_path.name} 未识别到媒体信息"
-                    )
-                new_path = transferchain.recommend_name(
-                    meta=context.meta_info, mediainfo=context.media_info
-                )
-                if not new_path:
-                    progress.end()
-                    return schemas.Response(
-                        success=False, message=f"{sub_path.name} 未识别到新名称"
-                    )
-                ret: schemas.Response = rename(
-                    fileitem=sub_file, new_name=Path(new_path).name, recursive=False
-                )
-                if not ret.success:
-                    progress.end()
-                    return schemas.Response(
-                        success=False, message=f"{sub_path.name} 重命名失败！"
-                    )
-            progress.end()
+        success, message = _batch_recursive_rename(fileitem)
+        if not success:
+            return schemas.Response(success=False, message=message)
     # 重命名自己
     result = StorageChain().rename_file(fileitem, new_name)
     if result:

--- a/app/service/storage.py
+++ b/app/service/storage.py
@@ -1,0 +1,89 @@
+"""
+存储端点的 Chain 编排（service layer）。
+
+把目录列举（StorageChain 取数 + 通配符过滤 + 排序）与递归智能重命名
+（StorageChain 列举 + MediaChain 识别 + TransferChain 推荐命名 + 逐个重命名 + 进度）
+从端点下沉到服务层：端点退化为薄 HTTP 适配层、不再 import
+MediaChain/TransferChain/ProgressHelper 等；本层可通过 mock Chain 单测。
+"""
+import fnmatch
+import math
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from app import schemas
+from app.chain.media import MediaChain
+from app.chain.storage import StorageChain
+from app.chain.transfer import TransferChain
+from app.core.config import settings
+from app.helper.progress import ProgressHelper
+from app.schemas.types import ProgressKey
+from app.utils.string import StringUtils
+
+
+def list_directory(
+    fileitem: schemas.FileItem,
+    sort: Optional[str] = "updated_at",
+    keyword: Optional[str] = None,
+) -> List[schemas.FileItem]:
+    """
+    列出目录下所有目录和文件：按 keyword 通配符（* ?）过滤，并按 name/时间排序。
+    """
+    file_list = StorageChain().list_files(fileitem)
+    if file_list:
+        if keyword:
+            _pat = re.compile(fnmatch.translate(keyword), re.IGNORECASE)
+            file_list = [f for f in file_list if _pat.match(f.name or "")]
+        if sort == "name":
+            file_list.sort(key=lambda x: StringUtils.natural_sort_key(x.name or ""))
+        else:
+            file_list.sort(key=lambda x: x.modify_time or -math.inf, reverse=True)
+    return file_list
+
+
+def batch_recursive_rename(fileitem: schemas.FileItem) -> Tuple[bool, str]:
+    """
+    递归修改目录内媒体文件（智能识别命名）。返回 (success, message)；
+    success=False 时 message 为失败原因。
+    """
+    transferchain = TransferChain()
+    media_exts = settings.RMT_MEDIAEXT + settings.RMT_SUBEXT + settings.RMT_AUDIOEXT
+    sub_files: List[schemas.FileItem] = StorageChain().list_files(fileitem)
+    if sub_files:
+        # 开始进度
+        progress = ProgressHelper(ProgressKey.BatchRename)
+        progress.start()
+        total = len(sub_files)
+        handled = 0
+        for sub_file in sub_files:
+            handled += 1
+            progress.update(
+                value=handled / total * 100, text=f"正在处理 {sub_file.name} ..."
+            )
+            if sub_file.type == "dir":
+                continue
+            if not sub_file.extension:
+                continue
+            if f".{sub_file.extension.lower()}" not in media_exts:
+                continue
+            sub_path = Path(f"{fileitem.path}{sub_file.name}")
+            context = MediaChain().recognize_by_path(
+                sub_path,
+                obtain_images=False,
+            )
+            if not context or not context.media_info:
+                progress.end()
+                return False, f"{sub_path.name} 未识别到媒体信息"
+            new_path = transferchain.recommend_name(
+                meta=context.meta_info, mediainfo=context.media_info
+            )
+            if not new_path:
+                progress.end()
+                return False, f"{sub_path.name} 未识别到新名称"
+            result = StorageChain().rename_file(sub_file, Path(new_path).name)
+            if not result:
+                progress.end()
+                return False, f"{sub_path.name} 重命名失败！"
+        progress.end()
+    return True, ""

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -1,0 +1,157 @@
+"""
+S7i 抽取验证：app.service.storage 的 Chain 编排单测（mock Chain）。
+
+目录列举（过滤+排序）与递归智能重命名编排下沉 service 后，通过 monkeypatch
+StorageChain/MediaChain/TransferChain/ProgressHelper 即可在 venv 内单测，无需真实
+存储/媒体识别/文件系统。
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.service import storage as svc
+
+
+def _fi(name, modify_time=0, ftype="file", extension=None, path="/d/"):
+    return SimpleNamespace(
+        name=name, modify_time=modify_time, type=ftype, extension=extension, path=path
+    )
+
+
+# ---------- list_directory ----------
+
+def test_list_directory_empty(monkeypatch):
+    monkeypatch.setattr(svc, "StorageChain", lambda: SimpleNamespace(list_files=lambda fi: []))
+    assert svc.list_directory(SimpleNamespace()) == []
+
+
+def test_list_directory_keyword_filter_case_insensitive(monkeypatch):
+    files = [_fi("a.mkv"), _fi("b.txt"), _fi("c.MKV")]
+    monkeypatch.setattr(
+        svc, "StorageChain", lambda: SimpleNamespace(list_files=lambda fi: list(files))
+    )
+    out = svc.list_directory(SimpleNamespace(), sort="name", keyword="*.mkv")
+    assert [f.name for f in out] == ["a.mkv", "c.MKV"]
+
+
+def test_list_directory_sort_time_desc(monkeypatch):
+    files = [_fi("old", modify_time=1), _fi("new", modify_time=5), _fi("mid", modify_time=3)]
+    monkeypatch.setattr(
+        svc, "StorageChain", lambda: SimpleNamespace(list_files=lambda fi: list(files))
+    )
+    out = svc.list_directory(SimpleNamespace(), sort="updated_at")
+    assert [f.name for f in out] == ["new", "mid", "old"]
+
+
+# ---------- batch_recursive_rename ----------
+
+@pytest.fixture
+def exts(monkeypatch):
+    monkeypatch.setattr(svc.settings, "RMT_MEDIAEXT", [".mkv"], raising=False)
+    monkeypatch.setattr(svc.settings, "RMT_SUBEXT", [], raising=False)
+    monkeypatch.setattr(svc.settings, "RMT_AUDIOEXT", [], raising=False)
+
+
+def _progress():
+    return SimpleNamespace(start=lambda: None, update=lambda **k: None, end=lambda: None)
+
+
+def _ctx():
+    return SimpleNamespace(media_info=SimpleNamespace(), meta_info=SimpleNamespace())
+
+
+def test_batch_no_subfiles(monkeypatch, exts):
+    monkeypatch.setattr(svc, "TransferChain", lambda: SimpleNamespace())
+    monkeypatch.setattr(svc, "StorageChain", lambda: SimpleNamespace(list_files=lambda fi: []))
+    ok, msg = svc.batch_recursive_rename(SimpleNamespace(path="/d/"))
+    assert ok is True
+    assert msg == ""
+
+
+def test_batch_recognize_fail(monkeypatch, exts):
+    sub = _fi("a.mkv", extension="mkv")
+    monkeypatch.setattr(svc, "TransferChain", lambda: SimpleNamespace(recommend_name=lambda **k: "x"))
+    monkeypatch.setattr(
+        svc, "StorageChain",
+        lambda: SimpleNamespace(list_files=lambda fi: [sub], rename_file=lambda *a: True),
+    )
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(recognize_by_path=lambda p, obtain_images: None),
+    )
+    monkeypatch.setattr(svc, "ProgressHelper", lambda key: _progress())
+    ok, msg = svc.batch_recursive_rename(SimpleNamespace(path="/d/"))
+    assert ok is False
+    assert "未识别到媒体信息" in msg
+
+
+def test_batch_recommend_fail(monkeypatch, exts):
+    sub = _fi("a.mkv", extension="mkv")
+    monkeypatch.setattr(
+        svc, "TransferChain",
+        lambda: SimpleNamespace(recommend_name=lambda meta, mediainfo: None),
+    )
+    monkeypatch.setattr(
+        svc, "StorageChain",
+        lambda: SimpleNamespace(list_files=lambda fi: [sub], rename_file=lambda *a: True),
+    )
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(recognize_by_path=lambda p, obtain_images: _ctx()),
+    )
+    monkeypatch.setattr(svc, "ProgressHelper", lambda key: _progress())
+    ok, msg = svc.batch_recursive_rename(SimpleNamespace(path="/d/"))
+    assert ok is False
+    assert "未识别到新名称" in msg
+
+
+def test_batch_rename_fail(monkeypatch, exts):
+    sub = _fi("a.mkv", extension="mkv")
+    monkeypatch.setattr(
+        svc, "TransferChain",
+        lambda: SimpleNamespace(recommend_name=lambda meta, mediainfo: "/new/Name.mkv"),
+    )
+    monkeypatch.setattr(
+        svc, "StorageChain",
+        lambda: SimpleNamespace(list_files=lambda fi: [sub], rename_file=lambda *a: False),
+    )
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(recognize_by_path=lambda p, obtain_images: _ctx()),
+    )
+    monkeypatch.setattr(svc, "ProgressHelper", lambda key: _progress())
+    ok, msg = svc.batch_recursive_rename(SimpleNamespace(path="/d/"))
+    assert ok is False
+    assert "重命名失败" in msg
+
+
+def test_batch_success_skips_dir_and_nonmedia(monkeypatch, exts):
+    subs = [
+        _fi("sub", ftype="dir"),
+        _fi("note.txt", extension="txt"),
+        _fi("m.mkv", extension="mkv"),
+    ]
+    renamed = []
+
+    def rf(sf, nn):
+        renamed.append((sf.name, nn))
+        return True
+
+    monkeypatch.setattr(
+        svc, "TransferChain",
+        lambda: SimpleNamespace(recommend_name=lambda meta, mediainfo: "/x/New.mkv"),
+    )
+    monkeypatch.setattr(
+        svc, "StorageChain",
+        lambda: SimpleNamespace(list_files=lambda fi: list(subs), rename_file=rf),
+    )
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(recognize_by_path=lambda p, obtain_images: _ctx()),
+    )
+    monkeypatch.setattr(svc, "ProgressHelper", lambda key: _progress())
+    ok, msg = svc.batch_recursive_rename(SimpleNamespace(path="/d/"))
+    assert ok is True
+    assert msg == ""
+    # 仅 .mkv 被重命名，使用推荐路径的 basename
+    assert renamed == [("m.mkv", "New.mkv")]


### PR DESCRIPTION
## 背景（S7 第三个「Chain→service」深抽）

storage 端点 17 个 Chain 调用中，多数 handler 是 StorageChain 薄透传；编排最重的两处下沉到服务层：
- `list_directory` —— `StorageChain().list_files` + fnmatch 通配符过滤（`*` `?`，大小写不敏感）+ name 自然排序 / 时间倒序。
- `batch_recursive_rename` —— `StorageChain().list_files` → `MediaChain().recognize_by_path` → `TransferChain().recommend_name` → 逐文件 `StorageChain().rename_file`，含 `ProgressHelper` 进度；返回 `(success, message)`。

## 端点退化为薄 HTTP 适配层

- 递归重命名原先在循环里回调端点 `rename(recursive=False)`（等价于 `StorageChain().rename_file` + Response），service 内**直接内联为 `StorageChain().rename_file`** 并以 `(success, message)` 元组上报，行为等价。
- 端点以同名 re-export 别名导入；`list_files`/`rename` 两 handler 仅保留「委派 + Response 映射」。
- **因此卸下 10 个导入**：`MediaChain`/`TransferChain`/`settings`/`ProgressHelper`/`ProgressKey`/`StringUtils`/`fnmatch`/`math`/`re`/`Path`。仅 `StorageChain` 保留（其余 11 个 handler 仍用）。验证：端点不再有这些属性、`StorageChain` 仍在、两别名与 service 函数 `is` 同一。
- 所有路由/签名/其它 handler（qrcode/auth_url/check/save/reset/mkdir/delete/download/image/usage/transtype + rename 自身）未改动。

## 可测性（mock Chain）

新增 `tests/test_storage_service.py` 8 例，`monkeypatch` `StorageChain`/`MediaChain`/`TransferChain`/`ProgressHelper` + `settings` 扩展名：
- list_directory：空目录 / 通配符大小写不敏感过滤 / 时间倒序排序。
- batch_recursive_rename：无子文件 / 识别失败 / 推荐失败 / 重命名失败 / 成功（跳过 dir 与非媒体、仅 `.mkv` 用推荐 basename 重命名）。

## 验证

- `py_compile` 通过；fresh-interp 探针确认端点经别名委派、卸下 10 导入、保留 StorageChain。
- `test_storage_service` = **8 passed**。