### PR TITLE
refactor(api): media 搜索与刮削 Chain 编排下沉至 app.service.media(S7j)

### DIFF
--- a/app/api/endpoints/media.py
+++ b/app/api/endpoints/media.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import List, Any, Union, Annotated, Optional
+from typing import List, Any, Annotated, Optional
 
 from fastapi import APIRouter, Depends
 
@@ -16,6 +15,10 @@ from app.db.user_oper import get_current_active_user, get_current_active_superus
 from app.schemas import MediaType, MediaRecognizeConvertEventData
 from app.schemas.category import CategoryConfig
 from app.schemas.types import ChainEventType
+from app.service.media import (
+    scrape_path as _scrape_path,
+    search_media as _search_media,
+)
 
 router = APIRouter()
 
@@ -98,37 +101,7 @@ async def search(
     """
     模糊搜索媒体/人物信息列表 media：媒体信息，person：人物信息
     """
-
-    def __get_source(obj: Union[schemas.MediaInfo, schemas.MediaPerson, dict]):
-        """
-        获取对象属性
-        """
-        if isinstance(obj, dict):
-            return obj.get("source")
-        return obj.source
-
-    media_chain = MediaChain()
-    if type == "media":
-        _, medias = await media_chain.async_search(title=title)
-        result = [media.to_dict() for media in medias] if medias else []
-    elif type == "collection":
-        collections = await media_chain.async_search_collections(name=title)
-        result = (
-            [collection.to_dict() for collection in collections] if collections else []
-        )
-    else:  # person
-        persons = await media_chain.async_search_persons(name=title)
-        result = [person.model_dump() for person in persons] if persons else []
-
-    if not result:
-        return []
-
-    # 排序和分页
-    setting_order = settings.SEARCH_SOURCE.split(",") if settings.SEARCH_SOURCE else []
-    sort_order = {source: index for index, source in enumerate(setting_order)}
-
-    sorted_result = sorted(result, key=lambda x: sort_order.get(__get_source(x), 4))
-    return sorted_result[(page - 1) * count : page * count]
+    return await _search_media(title=title, type=type, page=page, count=count)
 
 
 @router.post(
@@ -142,24 +115,8 @@ def scrape(
     """
     刮削媒体信息
     """
-    if not fileitem or not fileitem.path:
-        return schemas.Response(success=False, message="刮削路径无效")
-    chain = MediaChain()
-    # 识别媒体信息
-    context = chain.recognize_by_path(fileitem.path, obtain_images=True)
-    if not context or not context.media_info:
-        return schemas.Response(success=False, message="刮削失败，无法识别媒体信息")
-    if storage == "local":
-        if not Path(fileitem.path).exists():
-            return schemas.Response(success=False, message="刮削路径不存在")
-    # 手动刮削 (暂时使用同步版本，可以后续优化为异步)
-    chain.scrape_metadata(
-        fileitem=fileitem,
-        meta=context.meta_info,
-        mediainfo=context.media_info,
-        overwrite=True,
-    )
-    return schemas.Response(success=True, message=f"{fileitem.path} 刮削完成")
+    success, message = _scrape_path(fileitem, storage)
+    return schemas.Response(success=success, message=message)
 
 
 @router.get(

--- a/app/service/media.py
+++ b/app/service/media.py
@@ -1,0 +1,80 @@
+"""
+媒体端点的 Chain 编排（service layer）。
+
+模糊搜索（MediaChain 按 media/collection/person 分支检索 + 按 SEARCH_SOURCE 排序 +
+分页）与刮削（MediaChain 识别 + 本地路径校验 + scrape_metadata）。从端点下沉到服务层：
+端点退化为薄 HTTP 适配层；本层可通过 mock MediaChain 单测。
+"""
+from pathlib import Path
+from typing import List, Tuple, Union
+
+from app import schemas
+from app.chain.media import MediaChain
+from app.core.config import settings
+
+
+def _get_source(obj: Union[schemas.MediaInfo, schemas.MediaPerson, dict]):
+    """
+    获取对象的 source 属性（兼容 dict 与模型对象）。
+    """
+    if isinstance(obj, dict):
+        return obj.get("source")
+    return obj.source
+
+
+async def search_media(
+    title: str,
+    type: str = "media",
+    page: int = 1,
+    count: int = 8,
+) -> List[dict]:
+    """
+    模糊搜索媒体/合集/人物信息：按 SEARCH_SOURCE 配置排序并分页。
+    media：媒体信息，collection：合集，person：人物信息。
+    """
+    media_chain = MediaChain()
+    if type == "media":
+        _, medias = await media_chain.async_search(title=title)
+        result = [media.to_dict() for media in medias] if medias else []
+    elif type == "collection":
+        collections = await media_chain.async_search_collections(name=title)
+        result = (
+            [collection.to_dict() for collection in collections] if collections else []
+        )
+    else:  # person
+        persons = await media_chain.async_search_persons(name=title)
+        result = [person.model_dump() for person in persons] if persons else []
+
+    if not result:
+        return []
+
+    # 排序和分页
+    setting_order = settings.SEARCH_SOURCE.split(",") if settings.SEARCH_SOURCE else []
+    sort_order = {source: index for index, source in enumerate(setting_order)}
+
+    sorted_result = sorted(result, key=lambda x: sort_order.get(_get_source(x), 4))
+    return sorted_result[(page - 1) * count : page * count]
+
+
+def scrape_path(fileitem: schemas.FileItem, storage: str = "local") -> Tuple[bool, str]:
+    """
+    刮削媒体信息：识别媒体 → 本地路径校验 → scrape_metadata。返回 (success, message)。
+    """
+    if not fileitem or not fileitem.path:
+        return False, "刮削路径无效"
+    chain = MediaChain()
+    # 识别媒体信息
+    context = chain.recognize_by_path(fileitem.path, obtain_images=True)
+    if not context or not context.media_info:
+        return False, "刮削失败，无法识别媒体信息"
+    if storage == "local":
+        if not Path(fileitem.path).exists():
+            return False, "刮削路径不存在"
+    # 手动刮削 (暂时使用同步版本，可以后续优化为异步)
+    chain.scrape_metadata(
+        fileitem=fileitem,
+        meta=context.meta_info,
+        mediainfo=context.media_info,
+        overwrite=True,
+    )
+    return True, f"{fileitem.path} 刮削完成"

--- a/tests/test_media_service.py
+++ b/tests/test_media_service.py
@@ -1,0 +1,126 @@
+"""
+S7j 抽取验证：app.service.media 的 Chain 编排单测（mock Chain）。
+
+模糊搜索（分支检索 + SEARCH_SOURCE 排序 + 分页）与刮削（识别 + 路径校验 +
+scrape_metadata）下沉 service 后，通过 monkeypatch MediaChain/settings 即可在 venv
+内单测，无需真实媒体识别/磁盘。search_media 为 async，测试中用 asyncio.run 驱动。
+"""
+import asyncio
+from types import SimpleNamespace
+
+from app.service import media as svc
+
+
+class _Media:
+    def __init__(self, source, key):
+        self.source = source
+        self._key = key
+
+    def to_dict(self):
+        return {"source": self.source, "key": self._key}
+
+
+def test_search_media_sort_by_search_source_and_paginate(monkeypatch):
+    async def fake_search(title):
+        return None, [_Media("douban", 1), _Media("themoviedb", 2), _Media("douban", 3)]
+
+    monkeypatch.setattr(svc, "MediaChain", lambda: SimpleNamespace(async_search=fake_search))
+    monkeypatch.setattr(svc.settings, "SEARCH_SOURCE", "themoviedb,douban", raising=False)
+
+    out = asyncio.run(svc.search_media(title="x", type="media", page=1, count=2))
+    # themoviedb(order 0) 在前，其后是 douban(order 1)，分页取前 2
+    assert [r["key"] for r in out] == [2, 1]
+
+
+def test_search_media_page_2(monkeypatch):
+    async def fake_search(title):
+        return None, [_Media("douban", 1), _Media("themoviedb", 2), _Media("douban", 3)]
+
+    monkeypatch.setattr(svc, "MediaChain", lambda: SimpleNamespace(async_search=fake_search))
+    monkeypatch.setattr(svc.settings, "SEARCH_SOURCE", "themoviedb,douban", raising=False)
+
+    out = asyncio.run(svc.search_media(title="x", type="media", page=2, count=2))
+    # 排序后第 3 个：douban(key 3)
+    assert [r["key"] for r in out] == [3]
+
+
+def test_search_media_empty(monkeypatch):
+    async def fake_search(title):
+        return None, []
+
+    monkeypatch.setattr(svc, "MediaChain", lambda: SimpleNamespace(async_search=fake_search))
+    monkeypatch.setattr(svc.settings, "SEARCH_SOURCE", "", raising=False)
+    out = asyncio.run(svc.search_media(title="x", type="media"))
+    assert out == []
+
+
+def test_search_media_person_uses_model_dump(monkeypatch):
+    person = SimpleNamespace(model_dump=lambda: {"source": "themoviedb", "name": "P"})
+
+    async def fake_persons(name):
+        return [person]
+
+    monkeypatch.setattr(
+        svc, "MediaChain", lambda: SimpleNamespace(async_search_persons=fake_persons)
+    )
+    monkeypatch.setattr(svc.settings, "SEARCH_SOURCE", "themoviedb", raising=False)
+    out = asyncio.run(svc.search_media(title="p", type="person"))
+    assert out == [{"source": "themoviedb", "name": "P"}]
+
+
+# ---------- scrape_path ----------
+
+def test_scrape_path_invalid():
+    assert svc.scrape_path(None)[0] is False
+    ok, msg = svc.scrape_path(SimpleNamespace(path=""))
+    assert ok is False
+    assert "刮削路径无效" in msg
+
+
+def test_scrape_path_recognize_fail(monkeypatch):
+    fi = SimpleNamespace(path="/x/m.mkv")
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(recognize_by_path=lambda p, obtain_images: None),
+    )
+    ok, msg = svc.scrape_path(fi, storage="rclone")  # 非 local 跳过 Path.exists
+    assert ok is False
+    assert "无法识别媒体信息" in msg
+
+
+def test_scrape_path_local_not_exist(monkeypatch):
+    fi = SimpleNamespace(path="/nonexistent/m.mkv")
+    ctx = SimpleNamespace(media_info=SimpleNamespace(), meta_info=SimpleNamespace())
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(
+            recognize_by_path=lambda p, obtain_images: ctx,
+            scrape_metadata=lambda **k: None,
+        ),
+    )
+    ok, msg = svc.scrape_path(fi, storage="local")
+    assert ok is False
+    assert "刮削路径不存在" in msg
+
+
+def test_scrape_path_success(monkeypatch, tmp_path):
+    f = tmp_path / "m.mkv"
+    f.write_text("x")
+    fi = SimpleNamespace(path=str(f))
+    ctx = SimpleNamespace(media_info=SimpleNamespace(), meta_info=SimpleNamespace())
+    scraped = {}
+
+    def fake_scrape(**k):
+        scraped.update(k)
+
+    monkeypatch.setattr(
+        svc, "MediaChain",
+        lambda: SimpleNamespace(
+            recognize_by_path=lambda p, obtain_images: ctx,
+            scrape_metadata=fake_scrape,
+        ),
+    )
+    ok, msg = svc.scrape_path(fi, storage="local")
+    assert ok is True
+    assert "刮削完成" in msg
+    assert scraped["overwrite"] is True


### PR DESCRIPTION
## 背景（S7 第四个「Chain→service」深抽）

media 端点中两处有真实编排的 handler 下沉到服务层（其余 recognize/category 等较薄，保留）。

`app/service/media.py`：
- `search_media`（async）—— `MediaChain` 按 `media`/`collection`/`person` 分支检索 + 按 `settings.SEARCH_SOURCE` 配置排序 + 分页；含 `_get_source` 兼容 dict 与模型对象。
- `scrape_path` —— 识别 by path → 本地路径存在性校验 → `scrape_metadata`；返回 `(success, message)`。

## 端点退化为薄 HTTP 适配层

- 以同名 re-export 别名导入；`search`/`scrape` 两 handler 仅保留委派（`scrape` 把 `(success, message)` 映射为 `schemas.Response`，统一了原先多处 Response 构造）。
- 卸下 `from pathlib import Path` 与 `typing.Union`（随 `scrape`/`__get_source` 失效）。`settings`/`MediaChain`/`TmdbChain` 仍被其它 handler（recognize/category/group_seasons 等）使用，保留。验证：端点经别名委派、无 `Path` 属性、保留 `MediaChain`/`settings`。
- 其它 handler 未改动。

## 可测性（mock Chain）

新增 `tests/test_media_service.py` 8 例，`monkeypatch` `MediaChain`/`settings`（`search_media` 为 async，用 `asyncio.run` 驱动）：
- search：SEARCH_SOURCE 排序+分页、第二页、空结果、person 走 `model_dump`。
- scrape：无效路径 / 识别失败 / 本地路径不存在 / 成功（`tmp_path` 校验 `overwrite=True`）。

## 验证

- `py_compile` 通过；fresh-interp 探针确认端点经别名委派、卸下 `Path`、保留 `MediaChain`/`settings`。
- `test_media_service` = **8 passed**。