### PR TITLE
refactor(api): tmdb 类似/推荐/演员阵容分发下沉至 app.service.tmdb(S7k 收尾)

### DIFF
--- a/app/api/endpoints/tmdb.py
+++ b/app/api/endpoints/tmdb.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter, Depends
 from app import schemas
 from app.chain.tmdb import TmdbChain
 from app.core.security import verify_token
-from app.schemas.types import MediaType
+from app.service.tmdb import (
+    credits_persons as _credits_persons,
+    recommend_medias as _recommend_medias,
+    similar_medias as _similar_medias,
+)
 
 router = APIRouter()
 
@@ -36,16 +40,7 @@ async def tmdb_similar(
     """
     根据TMDBID查询类似电影/电视剧，type_name: 电影/电视剧
     """
-    mediatype = MediaType(type_name)
-    if mediatype == MediaType.MOVIE:
-        medias = await TmdbChain().async_movie_similar(tmdbid=tmdbid)
-    elif mediatype == MediaType.TV:
-        medias = await TmdbChain().async_tv_similar(tmdbid=tmdbid)
-    else:
-        return []
-    if medias:
-        return [media.to_dict() for media in medias]
-    return []
+    return await _similar_medias(tmdbid, type_name)
 
 
 @router.get(
@@ -59,16 +54,7 @@ async def tmdb_recommend(
     """
     根据TMDBID查询推荐电影/电视剧，type_name: 电影/电视剧
     """
-    mediatype = MediaType(type_name)
-    if mediatype == MediaType.MOVIE:
-        medias = await TmdbChain().async_movie_recommend(tmdbid=tmdbid)
-    elif mediatype == MediaType.TV:
-        medias = await TmdbChain().async_tv_recommend(tmdbid=tmdbid)
-    else:
-        return []
-    if medias:
-        return [media.to_dict() for media in medias]
-    return []
+    return await _recommend_medias(tmdbid, type_name)
 
 
 @router.get(
@@ -105,14 +91,7 @@ async def tmdb_credits(
     """
     根据TMDBID查询演员阵容，type_name: 电影/电视剧
     """
-    mediatype = MediaType(type_name)
-    if mediatype == MediaType.MOVIE:
-        persons = await TmdbChain().async_movie_credits(tmdbid=tmdbid, page=page)
-    elif mediatype == MediaType.TV:
-        persons = await TmdbChain().async_tv_credits(tmdbid=tmdbid, page=page)
-    else:
-        return []
-    return persons or []
+    return await _credits_persons(tmdbid, type_name, page)
 
 
 @router.get(

--- a/app/service/tmdb.py
+++ b/app/service/tmdb.py
@@ -1,0 +1,56 @@
+"""
+TMDB 端点的 Chain 编排（service layer）。
+
+类似/推荐/演员阵容均按 type_name（电影/电视剧）分发到 TmdbChain 的不同方法，
+再做 to_dict 映射。从端点下沉到服务层，去重分发逻辑并便于 mock TmdbChain 单测。
+"""
+from typing import Any, List
+
+from app.chain.tmdb import TmdbChain
+from app.schemas.types import MediaType
+
+
+async def similar_medias(tmdbid: int, type_name: str) -> List[dict]:
+    """
+    类似电影/电视剧（type_name: 电影/电视剧）。
+    """
+    mediatype = MediaType(type_name)
+    if mediatype == MediaType.MOVIE:
+        medias = await TmdbChain().async_movie_similar(tmdbid=tmdbid)
+    elif mediatype == MediaType.TV:
+        medias = await TmdbChain().async_tv_similar(tmdbid=tmdbid)
+    else:
+        return []
+    if medias:
+        return [media.to_dict() for media in medias]
+    return []
+
+
+async def recommend_medias(tmdbid: int, type_name: str) -> List[dict]:
+    """
+    推荐电影/电视剧（type_name: 电影/电视剧）。
+    """
+    mediatype = MediaType(type_name)
+    if mediatype == MediaType.MOVIE:
+        medias = await TmdbChain().async_movie_recommend(tmdbid=tmdbid)
+    elif mediatype == MediaType.TV:
+        medias = await TmdbChain().async_tv_recommend(tmdbid=tmdbid)
+    else:
+        return []
+    if medias:
+        return [media.to_dict() for media in medias]
+    return []
+
+
+async def credits_persons(tmdbid: int, type_name: str, page: int = 1) -> List[Any]:
+    """
+    演员阵容（type_name: 电影/电视剧）。
+    """
+    mediatype = MediaType(type_name)
+    if mediatype == MediaType.MOVIE:
+        persons = await TmdbChain().async_movie_credits(tmdbid=tmdbid, page=page)
+    elif mediatype == MediaType.TV:
+        persons = await TmdbChain().async_tv_credits(tmdbid=tmdbid, page=page)
+    else:
+        return []
+    return persons or []

--- a/tests/test_tmdb_service.py
+++ b/tests/test_tmdb_service.py
@@ -1,0 +1,84 @@
+"""
+S7k 抽取验证：app.service.tmdb 的 Chain 分发编排单测（mock Chain）。
+
+类似/推荐/演员阵容按 type_name（电影/电视剧）分发到 TmdbChain 不同方法 + to_dict
+映射。下沉 service 后通过 monkeypatch TmdbChain 在 venv 内单测（async，用 asyncio.run）。
+"""
+import asyncio
+from types import SimpleNamespace
+
+from app.service import tmdb as svc
+
+
+class _M:
+    def __init__(self, k):
+        self._k = k
+
+    def to_dict(self):
+        return {"k": self._k}
+
+
+def test_similar_movie_branch(monkeypatch):
+    async def mv(tmdbid):
+        return [_M(1), _M(2)]
+
+    async def tv(tmdbid):
+        return [_M(9)]
+
+    monkeypatch.setattr(
+        svc, "TmdbChain",
+        lambda: SimpleNamespace(async_movie_similar=mv, async_tv_similar=tv),
+    )
+    assert asyncio.run(svc.similar_medias(1, "电影")) == [{"k": 1}, {"k": 2}]
+
+
+def test_similar_tv_branch(monkeypatch):
+    async def mv(tmdbid):
+        return [_M(1)]
+
+    async def tv(tmdbid):
+        return [_M(9)]
+
+    monkeypatch.setattr(
+        svc, "TmdbChain",
+        lambda: SimpleNamespace(async_movie_similar=mv, async_tv_similar=tv),
+    )
+    assert asyncio.run(svc.similar_medias(1, "电视剧")) == [{"k": 9}]
+
+
+def test_similar_other_type_returns_empty():
+    # 未知（合法 MediaType 但非 电影/电视剧）-> else 分支 -> []
+    assert asyncio.run(svc.similar_medias(1, "未知")) == []
+
+
+def test_similar_empty_result(monkeypatch):
+    async def mv(tmdbid):
+        return None
+
+    monkeypatch.setattr(svc, "TmdbChain", lambda: SimpleNamespace(async_movie_similar=mv))
+    assert asyncio.run(svc.similar_medias(1, "电影")) == []
+
+
+def test_recommend_movie_branch(monkeypatch):
+    async def mv(tmdbid):
+        return [_M(5)]
+
+    monkeypatch.setattr(svc, "TmdbChain", lambda: SimpleNamespace(async_movie_recommend=mv))
+    assert asyncio.run(svc.recommend_medias(2, "电影")) == [{"k": 5}]
+
+
+def test_credits_movie_passes_page(monkeypatch):
+    calls = {}
+
+    async def mc(tmdbid, page):
+        calls["page"] = page
+        return [SimpleNamespace(name="P")]
+
+    monkeypatch.setattr(svc, "TmdbChain", lambda: SimpleNamespace(async_movie_credits=mc))
+    out = asyncio.run(svc.credits_persons(3, "电影", page=4))
+    assert calls["page"] == 4
+    assert len(out) == 1
+
+
+def test_credits_other_type_returns_empty():
+    assert asyncio.run(svc.credits_persons(3, "未知")) == []


### PR DESCRIPTION
## 背景（S7「Chain→service」收尾轮）

tmdb 端点中 `tmdb_similar`/`tmdb_recommend`/`tmdb_credits` 三个 handler 共享同一套「`MediaType(type_name)` 电影/电视剧分发 → TmdbChain 不同方法 → `to_dict` 映射」逻辑，下沉到 `app/service/tmdb.py`（`similar_medias`/`recommend_medias`/`credits_persons`），去重分发逻辑。

## 端点退化为薄 HTTP 适配层

- 以同名 re-export 别名导入，三 handler 仅保留一行委派。
- 卸下 `from app.schemas.types import MediaType`（随三 handler 失效）。`TmdbChain` 仍被其它 handler（seasons/collection/person/person_credits/season_episodes）使用，保留。验证：端点经别名委派、无 `MediaType` 属性、保留 `TmdbChain`。
- 其它 handler 未改动。

## discover.py 评估：无需抽取

discover.py 各 handler 为薄 Chain 透传（单 `async_*` 调用 + `to_dict`-或-空映射），无编排逻辑可抽，本轮未动（避免为一行调用增加无谓 indirection）。

## 可测性（mock Chain）

新增 `tests/test_tmdb_service.py` 7 例，`monkeypatch` `TmdbChain`（async，`asyncio.run` 驱动）：movie/tv 分支、非电影/电视剧（合法 `MediaType` 如「未知」）走 else 返回空、空结果、credits 透传 `page`。

## 验证

- `py_compile` 通过；fresh-interp 探针确认端点经别名委派、卸下 `MediaType`、保留 `TmdbChain`。
- `test_tmdb_service` = **7 passed**。