### PR TITLE
refactor(transfer): __handle_transfer 抽出 SCRAP_FOLLOW_TMDB 块(S8b Block 2)

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1587,13 +1587,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 mediainfo_changed = True
 
             # 如果未开启新增已入库媒体是否跟随TMDB信息变化则根据tmdbid查询之前的title
-            if not settings.SCRAP_FOLLOW_TMDB:
-                transfer_history = transferhis.get_by_type_tmdbid(
-                    tmdbid=mediainfo.tmdb_id, mtype=mediainfo.type.value
-                )
-                if transfer_history and mediainfo.title != transfer_history.title:
-                    mediainfo.title = transfer_history.title
-                    mediainfo_changed = True
+            mediainfo_changed = self._apply_scrap_follow_tmdb(
+                mediainfo, mediainfo_changed, transferhis
+            )
 
             if mediainfo_changed:
                 # 更新任务信息
@@ -1643,6 +1639,27 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             # 移除已完成的任务
             self.jobview.try_remove_job(task)
             self.__finish_scrape_batch_task(task)
+
+    def _apply_scrap_follow_tmdb(
+        self,
+        mediainfo: MediaInfo,
+        mediainfo_changed: bool,
+        transferhis: TransferHistoryOper,
+    ) -> bool:
+        """
+        S8b：自 __handle_transfer 抽出的无早返回子块，行为字节级不变。
+        未开启「新增已入库媒体跟随 TMDB 信息变化」时，按 tmdbid 查历史 title，
+        若与当前不同则就地覆盖 mediainfo.title 并置 mediainfo_changed=True；
+        返回（可能更新的）mediainfo_changed。
+        """
+        if not settings.SCRAP_FOLLOW_TMDB:
+            transfer_history = transferhis.get_by_type_tmdbid(
+                tmdbid=mediainfo.tmdb_id, mtype=mediainfo.type.value
+            )
+            if transfer_history and mediainfo.title != transfer_history.title:
+                mediainfo.title = transfer_history.title
+                mediainfo_changed = True
+        return mediainfo_changed
 
     def _resolve_episodes_info(self, task: TransferTask) -> None:
         """获取集数据：TV 且缺失 episodes_info 时从 TMDB 拉取。

--- a/tests/test_transfer_handle_carve.py
+++ b/tests/test_transfer_handle_carve.py
@@ -35,7 +35,7 @@ def test_handle_transfer_signature_stable():
 
 def test_extracted_helpers_present():
     """3 个抽出的无早返回 helper 必须就位（单下划线、非 name-mangled）。"""
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers"):
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb"):
         assert hasattr(TransferChain, h), f"抽出的 helper 缺失: {h}"
 
 
@@ -44,6 +44,63 @@ def test_handle_transfer_keeps_finally_cleanup():
     src = inspect.getsource(getattr(TransferChain, MANGLED))
     assert "finally:" in src, "__handle_transfer 丢失 finally"
     assert "try_remove_job" in src and "__finish_scrape_batch_task" in src, "finally 清理动作被改动"
-    # 入口编排仍按序调用 3 个 helper
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers"):
+    # 入口编排仍按序调用 4 个 helper
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb"):
         assert h in src, f"入口未调用 helper: {h}"
+
+
+# ---------- S8b：_apply_scrap_follow_tmdb 行为单测（mock 历史 Oper，无需 DB） ----------
+import types  # noqa: E402
+
+from app.core.config import settings  # noqa: E402
+
+
+def _mediainfo(title="New Title", tmdb_id=1, type_value="电影"):
+    return types.SimpleNamespace(
+        title=title, tmdb_id=tmdb_id, type=types.SimpleNamespace(value=type_value)
+    )
+
+
+def _transferhis(history):
+    return types.SimpleNamespace(get_by_type_tmdbid=lambda tmdbid, mtype: history)
+
+
+def _apply(mediainfo, changed, transferhis):
+    # 该 helper 不使用 self，unbound 调用传 None
+    return TransferChain._apply_scrap_follow_tmdb(None, mediainfo, changed, transferhis)
+
+
+def test_scrap_follow_enabled_skips(monkeypatch):
+    """开启跟随 TMDB 时整块跳过：title 不动，mediainfo_changed 原样返回。"""
+    monkeypatch.setattr(settings, "SCRAP_FOLLOW_TMDB", True, raising=False)
+    mi = _mediainfo(title="New Title")
+    out = _apply(mi, False, _transferhis(types.SimpleNamespace(title="Old Title")))
+    assert out is False
+    assert mi.title == "New Title"
+
+
+def test_scrap_follow_disabled_overwrites_title(monkeypatch):
+    """未开启 + 历史 title 不同：就地覆盖 mediainfo.title，返回 True。"""
+    monkeypatch.setattr(settings, "SCRAP_FOLLOW_TMDB", False, raising=False)
+    mi = _mediainfo(title="New Title")
+    out = _apply(mi, False, _transferhis(types.SimpleNamespace(title="Old Title")))
+    assert out is True
+    assert mi.title == "Old Title"
+
+
+def test_scrap_follow_disabled_same_title_no_change(monkeypatch):
+    """未开启 + 历史 title 相同：不覆盖，mediainfo_changed 原样。"""
+    monkeypatch.setattr(settings, "SCRAP_FOLLOW_TMDB", False, raising=False)
+    mi = _mediainfo(title="Same")
+    out = _apply(mi, False, _transferhis(types.SimpleNamespace(title="Same")))
+    assert out is False
+    assert mi.title == "Same"
+
+
+def test_scrap_follow_disabled_no_history_keeps_input(monkeypatch):
+    """未开启 + 无历史：不覆盖，输入的 mediainfo_changed 透传。"""
+    monkeypatch.setattr(settings, "SCRAP_FOLLOW_TMDB", False, raising=False)
+    mi = _mediainfo(title="New Title")
+    out = _apply(mi, True, _transferhis(None))
+    assert out is True
+    assert mi.title == "New Title"


### PR DESCRIPTION
## 背景（S8b 最安全切片，续 S8a）

`__handle_transfer` 中唯一**控制流中性（无早返回）**的剩余块——`SCRAP_FOLLOW_TMDB`（未开启「新增已入库媒体跟随 TMDB 信息变化」时，按 tmdbid 查历史 title，若不同则覆盖 `mediainfo.title`）——verbatim 抽成单下划线私有方法：

```
_apply_scrap_follow_tmdb(self, mediainfo, mediainfo_changed, transferhis) -> bool
```

就地改 `mediainfo.title`、返回更新后的 `mediainfo_changed`；入口改为 `mediainfo_changed = self._apply_scrap_follow_tmdb(...)`。镜像 S8a 三个无早返回 helper 的做法。

## P5 monkey-patch 契约保持

- name-mangled 入口 `_TransferChain__handle_transfer`（p115strmhelper 唯一补丁目标）的**符号名 / 签名 `(self,task,callback=None)->Optional[Tuple[bool,str]]` / 类位置 / try-finally** 全部不变（fresh-interp 探针验证）。
- 新 helper 为**单下划线、非 mangled**，插件不引用。
- p115 的 `patched_handle_transfer` 是**独立 hand-copy**（`patch/transfer_chain.py:174` 自带同款 inline `SCRAP_FOLLOW_TMDB` 块），不经过本 helper，未受影响；本次**仅改 `app/chain/transfer.py`，未动任何插件文件**。

## 验证

- 契约守卫测试扩到 4 helper（`test_extracted_helpers_present` / `keeps_finally_cleanup`）。
- 新增 4 例行为单测（mock 历史 Oper，unbound 调用，无需 DB）：开启跟随→整块跳过 title 不动 / 未开启+历史不同→就地覆盖返回 True / 同 title→不改 / 无历史→输入透传。
- `test_transfer_handle_carve` **8 passed**；transfer 回归套件（job_manager 23 + download_history_lookup + bluray + episode_format）**60 passed = 字节级等价**。
- 注：`test_transfer_failed_retry_buttons`（block 1 的 AI-retry 路径，import agent）在本 venv 因 jieba_next 缺口收集失败（pre-existing，与本 Block 2 改动无关）。