### PR TITLE
refactor(S8b): 抽 __handle_transfer block-3 jobview 去重为哨兵 helper

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1591,13 +1591,10 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 mediainfo, mediainfo_changed, transferhis
             )
 
-            if mediainfo_changed:
-                # 更新任务信息
-                task.mediainfo = mediainfo
-                # 更新队列任务
-                if not self.jobview.migrate_task(task):
-                    logger.info(f"{task.fileitem.name} 已存在整理任务，跳过重复处理")
-                    return False, f"{task.fileitem.name} 已在整理队列中"
+            # 更新队列任务（mediainfo 变更时回写并去重），命中重复则提前返回
+            result = self._migrate_or_skip(task, mediainfo, mediainfo_changed)
+            if result is not None:
+                return result
 
             # 获取集数据
             self._resolve_episodes_info(task)
@@ -1660,6 +1657,28 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 mediainfo.title = transfer_history.title
                 mediainfo_changed = True
         return mediainfo_changed
+
+    def _migrate_or_skip(
+        self,
+        task: TransferTask,
+        mediainfo: MediaInfo,
+        mediainfo_changed: bool,
+    ) -> Optional[Tuple[bool, str]]:
+        """
+        S8b：自 __handle_transfer 抽出的早返回子块，经哨兵协议保持行为字节级不变。
+
+        mediainfo 变更时把（可能重识别后的）mediainfo 回写到 task 并在 jobview 重新登记；
+        若 migrate_task 报告任务已存在，则记录日志并返回 (False, ...) 哨兵，由调用方提前返回；
+        否则返回 None 表示继续。未变更时不回写、不去重，直接返回 None。
+        """
+        if mediainfo_changed:
+            # 更新任务信息
+            task.mediainfo = mediainfo
+            # 更新队列任务
+            if not self.jobview.migrate_task(task):
+                logger.info(f"{task.fileitem.name} 已存在整理任务，跳过重复处理")
+                return False, f"{task.fileitem.name} 已在整理队列中"
+        return None
 
     def _resolve_episodes_info(self, task: TransferTask) -> None:
         """获取集数据：TV 且缺失 episodes_info 时从 TMDB 拉取。

--- a/tests/test_transfer_handle_carve.py
+++ b/tests/test_transfer_handle_carve.py
@@ -35,7 +35,7 @@ def test_handle_transfer_signature_stable():
 
 def test_extracted_helpers_present():
     """3 个抽出的无早返回 helper 必须就位（单下划线、非 name-mangled）。"""
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb"):
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip"):
         assert hasattr(TransferChain, h), f"抽出的 helper 缺失: {h}"
 
 
@@ -44,9 +44,28 @@ def test_handle_transfer_keeps_finally_cleanup():
     src = inspect.getsource(getattr(TransferChain, MANGLED))
     assert "finally:" in src, "__handle_transfer 丢失 finally"
     assert "try_remove_job" in src and "__finish_scrape_batch_task" in src, "finally 清理动作被改动"
-    # 入口编排仍按序调用 4 个 helper
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb"):
+    # 入口编排仍按序调用 5 个 helper
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip"):
         assert h in src, f"入口未调用 helper: {h}"
+
+
+# 入口编排里 5 个 helper 的调用先后顺序（与 __handle_transfer 源码出现次序一致）
+_HELPER_CALL_ORDER = (
+    "_apply_scrap_follow_tmdb",
+    "_migrate_or_skip",
+    "_resolve_episodes_info",
+    "_resolve_target_directory",
+    "_select_storage_opers",
+)
+
+
+def test_handle_transfer_helper_call_order():
+    """守卫调用顺序：未来重排 helper 调用次序会立即失败（补审查 LOW 项）。"""
+    src = inspect.getsource(getattr(TransferChain, MANGLED))
+    positions = [src.index(h) for h in _HELPER_CALL_ORDER]
+    assert positions == sorted(positions), (
+        f"helper 调用顺序被改动，期望 {_HELPER_CALL_ORDER}，实际源码次序错位"
+    )
 
 
 # ---------- S8b：_apply_scrap_follow_tmdb 行为单测（mock 历史 Oper，无需 DB） ----------
@@ -104,3 +123,57 @@ def test_scrap_follow_disabled_no_history_keeps_input(monkeypatch):
     out = _apply(mi, True, _transferhis(None))
     assert out is True
     assert mi.title == "New Title"
+
+
+# ---------- S8b：_migrate_or_skip 行为单测（哨兵协议，mock jobview，无需 DB） ----------
+
+
+def _fake_self(migrate_result, calls):
+    """伪 self：仅需 jobview.migrate_task；记录被传入的 task 以验证调用。"""
+    return types.SimpleNamespace(
+        jobview=types.SimpleNamespace(
+            migrate_task=lambda t: (calls.append(t) or migrate_result)
+        )
+    )
+
+
+def _task(name="file.mkv"):
+    return types.SimpleNamespace(
+        mediainfo="ORIGINAL", fileitem=types.SimpleNamespace(name=name)
+    )
+
+
+def test_migrate_skip_not_changed_returns_none_no_migrate():
+    """mediainfo_changed=False：返回 None（继续），不调用 migrate，不回写 task.mediainfo。"""
+    calls = []
+    s = _fake_self(True, calls)
+    task = _task()
+    mi = object()
+    out = TransferChain._migrate_or_skip(s, task, mi, False)
+    assert out is None
+    assert calls == []
+    assert task.mediainfo == "ORIGINAL"
+
+
+def test_migrate_changed_success_returns_none_sets_mediainfo():
+    """变更 + migrate 成功：回写 task.mediainfo，migrate 调用一次，返回 None（继续）。"""
+    calls = []
+    s = _fake_self(True, calls)
+    task = _task()
+    mi = object()
+    out = TransferChain._migrate_or_skip(s, task, mi, True)
+    assert out is None
+    assert task.mediainfo is mi
+    assert calls == [task]
+
+
+def test_migrate_changed_duplicate_returns_bail_tuple():
+    """变更 + migrate 报重复：先回写 mediainfo，再返回精确 (False, '...已在整理队列中') 哨兵。"""
+    calls = []
+    s = _fake_self(False, calls)
+    task = _task(name="movie.mkv")
+    mi = object()
+    out = TransferChain._migrate_or_skip(s, task, mi, True)
+    assert out == (False, "movie.mkv 已在整理队列中")
+    assert task.mediainfo is mi
+    assert calls == [task]


### PR DESCRIPTION
## 概要
S8b 第二刀（继 Block-2）：把 `__handle_transfer` 中 **mediainfo 变更回写 + jobview 去重**的早返回块（原 1594-1600）经**哨兵协议**抽成单下划线私有 helper `_migrate_or_skip(self, task, mediainfo, mediainfo_changed) -> Optional[Tuple[bool, str]]`。

- 入口换哨兵调用：`result = self._migrate_or_skip(...); if result is not None: return result`（`None`=继续，`(bool,str)`=提前返回）。
- 行为字节级不变：guard、`task.mediainfo` 回写在 migrate 检查前、bail 元组/日志字符串、`finally` 触发全保。

## 契约保持（P5 关键路径）
- p115strmhelper monkey-patch 目标 `TransferChain._TransferChain__handle_transfer`（name-mangled）名/签名 `(self,task,callback=None)`/类位置/`finally` **均不变**；其 patched hand-copy 不经过本 helper。
- 新 helper 非 mangled、`app/plugins/` 零引用（grep 确认）。
- `(bool,str)` 元组形状（`__start_transfer` 解包 fail-counting）保持，`None` 仅内部消费。

## 验证
- 契约探针：mangled 符号/签名/finally 完好。
- 新增 3 例分支单测（未变更/变更成功/变更重复）+ 调用顺序守卫；carve+job_manager **35 passed**。
- `everything-claude-code:code-reviewer` 子代理对抗审查 **PASS**（5 项契约全过，0 Critical/High/Medium）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)