### PR TITLE
refactor(S8b): tail-抽 __handle_transfer block-7（transfer+callback）

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1605,32 +1605,10 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             # 标记运行中，并广播事件请示额外的源/目标存储操作器
             source_oper, target_oper = self._select_storage_opers(task)
 
-            # 执行整理
-            transferinfo: TransferInfo = self.transfer(
-                fileitem=task.fileitem,
-                meta=task.meta,
-                mediainfo=task.mediainfo,
-                target_directory=task.target_directory,
-                target_storage=task.target_storage,
-                target_path=task.target_path,
-                transfer_type=task.transfer_type,
-                episodes_info=task.episodes_info,
-                scrape=task.scrape,
-                library_type_folder=task.library_type_folder,
-                library_category_folder=task.library_category_folder,
-                source_oper=source_oper,
-                target_oper=target_oper,
-                preview=task.preview,
+            # 执行整理并按回调/默认方式分发结果（block-7：tail 抽取，每条分支均 return）
+            return self._run_transfer_and_dispatch(
+                task, source_oper, target_oper, callback
             )
-            if not transferinfo:
-                logger.error("文件整理模块运行失败")
-                return False, "文件整理模块运行失败"
-
-            # 回调，位置传参：任务、整理结果
-            if callback:
-                return callback(task, transferinfo)
-
-            return transferinfo.success, transferinfo.message
 
         finally:
             # 移除已完成的任务
@@ -1766,6 +1744,47 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 target_oper = target_event_data.storage_oper
 
         return source_oper, target_oper
+
+    def _run_transfer_and_dispatch(
+        self,
+        task: TransferTask,
+        source_oper: Any,
+        target_oper: Any,
+        callback: Optional[Callable],
+    ) -> Optional[Tuple[bool, str]]:
+        """执行整理并分发结果。
+
+        S8b：自 __handle_transfer 抽出的**终末块**（原 try 末尾、finally 之前，每条分支均
+        return），调用方以 `return self._run_transfer_and_dispatch(...)` 等价替换，行为字节级
+        不变。transfer 失败返回模块错误；有 callback 则委派 (task, transferinfo) 并返回其结果；
+        否则返回 (transferinfo.success, transferinfo.message)。
+        """
+        # 执行整理
+        transferinfo: TransferInfo = self.transfer(
+            fileitem=task.fileitem,
+            meta=task.meta,
+            mediainfo=task.mediainfo,
+            target_directory=task.target_directory,
+            target_storage=task.target_storage,
+            target_path=task.target_path,
+            transfer_type=task.transfer_type,
+            episodes_info=task.episodes_info,
+            scrape=task.scrape,
+            library_type_folder=task.library_type_folder,
+            library_category_folder=task.library_category_folder,
+            source_oper=source_oper,
+            target_oper=target_oper,
+            preview=task.preview,
+        )
+        if not transferinfo:
+            logger.error("文件整理模块运行失败")
+            return False, "文件整理模块运行失败"
+
+        # 回调，位置传参：任务、整理结果
+        if callback:
+            return callback(task, transferinfo)
+
+        return transferinfo.success, transferinfo.message
 
     def get_queue_tasks(self) -> List[TransferJob]:
         """

--- a/tests/test_transfer_handle_carve.py
+++ b/tests/test_transfer_handle_carve.py
@@ -1,7 +1,8 @@
 """
-S8a 契约守护：__handle_transfer 的 7 块中 3 个无早返回子块被抽成私有 helper
-（_resolve_episodes_info / _resolve_target_directory / _select_storage_opers），
-入口方法保持薄编排 + 同序调用 + 原 try/finally。
+S8a/S8b 契约守护：__handle_transfer 的 7 块中已抽出 6 个为私有 helper
+（无早返回块 _resolve_episodes_info/_resolve_target_directory/_select_storage_opers/
+_apply_scrap_follow_tmdb；哨兵块 _migrate_or_skip；终末 tail 块 _run_transfer_and_dispatch），
+入口方法保持薄编排 + 同序调用 + 原 try/finally；仅识别块 block-1 未抽。
 
 本测试守护 P5 CRITICAL 的 monkey-patch 契约：p115strmhelper 通过 name-mangled
 类属性 `TransferChain._TransferChain__handle_transfer` 存/换/复原补丁（patch/transfer_chain.py
@@ -34,8 +35,8 @@ def test_handle_transfer_signature_stable():
 
 
 def test_extracted_helpers_present():
-    """3 个抽出的无早返回 helper 必须就位（单下划线、非 name-mangled）。"""
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip"):
+    """6 个抽出的 helper 必须就位（单下划线、非 name-mangled）。"""
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
         assert hasattr(TransferChain, h), f"抽出的 helper 缺失: {h}"
 
 
@@ -44,18 +45,19 @@ def test_handle_transfer_keeps_finally_cleanup():
     src = inspect.getsource(getattr(TransferChain, MANGLED))
     assert "finally:" in src, "__handle_transfer 丢失 finally"
     assert "try_remove_job" in src and "__finish_scrape_batch_task" in src, "finally 清理动作被改动"
-    # 入口编排仍按序调用 5 个 helper
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip"):
+    # 入口编排仍按序调用 6 个 helper
+    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
         assert h in src, f"入口未调用 helper: {h}"
 
 
-# 入口编排里 5 个 helper 的调用先后顺序（与 __handle_transfer 源码出现次序一致）
+# 入口编排里 6 个 helper 的调用先后顺序（与 __handle_transfer 源码出现次序一致）
 _HELPER_CALL_ORDER = (
     "_apply_scrap_follow_tmdb",
     "_migrate_or_skip",
     "_resolve_episodes_info",
     "_resolve_target_directory",
     "_select_storage_opers",
+    "_run_transfer_and_dispatch",
 )
 
 


### PR DESCRIPTION
## 概要
把 `__handle_transfer` 的**终末块**（block-7：`self.transfer(...)` + 失败/回调/默认三条 return）**tail-抽**成私有 helper `_run_transfer_and_dispatch(self, task, source_oper, target_oper, callback) -> Optional[Tuple[bool, str]]`。入口以 `return self._run_transfer_and_dispatch(...)` 等价替换。

因该块是 try 的最后一句、其后仅 `finally`，且每条分支均 return → tail 抽取无哨兵歧义，行为**字节级不变**。

## 契约保持（P5 关键路径）
- mangled `_TransferChain__handle_transfer` 名/签名 `(self,task,callback=None)`/类位置/`finally`(try_remove_job + __finish_scrape_batch_task) **不变**。
- 新 helper 非 mangled、`app/plugins/` 零引用；p115 patched hand-copy 不经过本 helper，patch 文件未动。
- 14 个 kwargs 传给 `self.transfer` 顺序逐一保持。

## 验证
- 由 PR #34 集成夹具的 3 例覆盖 helper 全部 3 条 return：终返回 `(success,message)` / 回调委派 `callback(task, transferinfo)` / `not transferinfo` 模块失败。
- 契约守卫扩到 6 helper（存在性 + 调用顺序）；transfer 套件 **38 passed**（含夹具 byte-equivalent 回归）。
- 契约探针：入口已无 `self.transfer(`，block-7 整体入 helper。
- `everything-claude-code:code-reviewer` 子代理 5 契约对抗审查 **PASS**（0 Crit/High/Med）。

至此 `__handle_transfer` 7 块抽出 block-2/3/4/5/6/7，仅识别块 block-1 待办。

🤖 Generated with [Claude Code](https://claude.com/claude-code)