### PR TITLE
refactor(S8b): 抽 __handle_transfer block-1（识别块，多值回流）— 七块收官

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1489,102 +1489,13 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         处理整理任务
         """
         try:
-            # 识别
+            # 识别（block-1：双早返回 + 多值回流，抽出后以三元组带出 early/mediainfo/changed）
             transferhis = TransferHistoryOper()
-            mediainfo = task.mediainfo
-            mediainfo_changed = False
-            need_obtain_images = False
-            if not mediainfo:
-                download_history = task.download_history
-                # 下载用户
-                if download_history:
-                    task.username = download_history.username
-                    # 识别媒体信息
-                    if download_history.tmdbid or download_history.doubanid:
-                        # 下载记录中已存在识别信息
-                        mediainfo: Optional[MediaInfo] = self.recognize_media(
-                            mtype=MediaType(download_history.type),
-                            tmdbid=download_history.tmdbid,
-                            doubanid=download_history.doubanid,
-                            episode_group=download_history.episode_group,
-                        )
-                        need_obtain_images = True
-                        if mediainfo:
-                            # 更新自定义媒体类别
-                            if download_history.media_category:
-                                mediainfo.category = download_history.media_category
-                else:
-                    # 识别媒体信息
-                    mediainfo = MediaChain().recognize_by_meta(
-                        task.meta,
-                        obtain_images=True,
-                    )
-
-                # 按名称识别时已在识别链路补图，这里只补齐显式ID识别的场景。
-                if mediainfo and need_obtain_images:
-                    self.obtain_images(mediainfo=mediainfo)
-
-                if not mediainfo:
-                    if task.preview:
-                        return False, "未识别到媒体信息"
-                    # 新增整理失败历史记录
-                    his = transferhis.add_fail(
-                        fileitem=task.fileitem,
-                        mode=task.transfer_type,
-                        meta=task.meta,
-                        downloader=task.downloader,
-                        download_hash=task.download_hash,
-                    )
-                    self.post_message(
-                        Notification(
-                            mtype=NotificationType.Manual,
-                            title=f"{task.fileitem.name} 未识别到媒体信息，无法入库！",
-                            text=(
-                                "原因：未识别到媒体信息\n"
-                                "如果按钮不可用，可回复：\n"
-                                f"```\n/redo {his.id}\n/redo {his.id} [tmdbid]|[类型]\n```\n"
-                                "自动重试或手动识别整理。"
-                            ),
-                            username=task.username,
-                            link=settings.MP_DOMAIN("#/history"),
-                            buttons=self.build_failed_transfer_buttons(
-                                his.id if his else None
-                            ),
-                        )
-                    )
-                    # 任务失败，直接移除task
-                    self.jobview.remove_task(task.fileitem)
-                    self.__mark_torrent_completed_if_done(
-                        task.download_hash, task.downloader
-                    )
-
-                    # AI智能体自动重试整理
-                    if (
-                            his
-                            and settings.AI_AGENT_ENABLE
-                            and settings.AI_AGENT_RETRY_TRANSFER
-                    ):
-                        try:
-                            # 使用 download_hash 或源文件父目录作为分组键
-                            group_key = (
-                                task.download_hash
-                                or str(task.fileitem.path).rsplit("/", 1)[0]
-                                if task.fileitem
-                                else ""
-                            )
-                            asyncio.run_coroutine_threadsafe(
-                                self.retry_scheduler.schedule_retry(
-                                    his.id, group_key=group_key
-                                ),
-                                global_vars.loop,
-                            )
-                            logger.info(f"已触发AI智能体重试整理历史记录 #{his.id}")
-                        except Exception as e:
-                            logger.error(f"触发AI智能体重试整理失败: {e}")
-
-                    return False, "未识别到媒体信息"
-
-                mediainfo_changed = True
+            early, mediainfo, mediainfo_changed = self._recognize_for_transfer(
+                task, transferhis
+            )
+            if early is not None:
+                return early
 
             # 如果未开启新增已入库媒体是否跟随TMDB信息变化则根据tmdbid查询之前的title
             mediainfo_changed = self._apply_scrap_follow_tmdb(
@@ -1614,6 +1525,114 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             # 移除已完成的任务
             self.jobview.try_remove_job(task)
             self.__finish_scrape_batch_task(task)
+
+    def _recognize_for_transfer(
+        self, task: TransferTask, transferhis: TransferHistoryOper
+    ) -> Tuple[Optional[Tuple[bool, str]], Optional[MediaInfo], bool]:
+        """识别媒体信息（block-1：__handle_transfer 的识别块，含双早返回与多值回流）。
+
+        S8b：自 __handle_transfer 抽出，返回三元组 (early, mediainfo, mediainfo_changed)：
+        early 非 None 时调用方须 `return early`（preview 短路 / 识别失败两条原早返回，值均为
+        (False, "未识别到媒体信息")）；early 为 None 时带出识别得到的 mediainfo 与
+        mediainfo_changed 供后续块使用。识别失败分支的副作用（add_fail / 通知 / 移除任务 /
+        标记下载完成 / AI 重试）逐字保留，行为字节级不变。
+        """
+        mediainfo = task.mediainfo
+        mediainfo_changed = False
+        need_obtain_images = False
+        if not mediainfo:
+            download_history = task.download_history
+            # 下载用户
+            if download_history:
+                task.username = download_history.username
+                # 识别媒体信息
+                if download_history.tmdbid or download_history.doubanid:
+                    # 下载记录中已存在识别信息
+                    mediainfo: Optional[MediaInfo] = self.recognize_media(
+                        mtype=MediaType(download_history.type),
+                        tmdbid=download_history.tmdbid,
+                        doubanid=download_history.doubanid,
+                        episode_group=download_history.episode_group,
+                    )
+                    need_obtain_images = True
+                    if mediainfo:
+                        # 更新自定义媒体类别
+                        if download_history.media_category:
+                            mediainfo.category = download_history.media_category
+            else:
+                # 识别媒体信息
+                mediainfo = MediaChain().recognize_by_meta(
+                    task.meta,
+                    obtain_images=True,
+                )
+
+            # 按名称识别时已在识别链路补图，这里只补齐显式ID识别的场景。
+            if mediainfo and need_obtain_images:
+                self.obtain_images(mediainfo=mediainfo)
+
+            if not mediainfo:
+                if task.preview:
+                    return (False, "未识别到媒体信息"), None, False
+                # 新增整理失败历史记录
+                his = transferhis.add_fail(
+                    fileitem=task.fileitem,
+                    mode=task.transfer_type,
+                    meta=task.meta,
+                    downloader=task.downloader,
+                    download_hash=task.download_hash,
+                )
+                self.post_message(
+                    Notification(
+                        mtype=NotificationType.Manual,
+                        title=f"{task.fileitem.name} 未识别到媒体信息，无法入库！",
+                        text=(
+                            "原因：未识别到媒体信息\n"
+                            "如果按钮不可用，可回复：\n"
+                            f"```\n/redo {his.id}\n/redo {his.id} [tmdbid]|[类型]\n```\n"
+                            "自动重试或手动识别整理。"
+                        ),
+                        username=task.username,
+                        link=settings.MP_DOMAIN("#/history"),
+                        buttons=self.build_failed_transfer_buttons(
+                            his.id if his else None
+                        ),
+                    )
+                )
+                # 任务失败，直接移除task
+                self.jobview.remove_task(task.fileitem)
+                self.__mark_torrent_completed_if_done(
+                    task.download_hash, task.downloader
+                )
+
+                # AI智能体自动重试整理
+                if (
+                        his
+                        and settings.AI_AGENT_ENABLE
+                        and settings.AI_AGENT_RETRY_TRANSFER
+                ):
+                    try:
+                        # 使用 download_hash 或源文件父目录作为分组键
+                        group_key = (
+                            task.download_hash
+                            or str(task.fileitem.path).rsplit("/", 1)[0]
+                            if task.fileitem
+                            else ""
+                        )
+                        asyncio.run_coroutine_threadsafe(
+                            self.retry_scheduler.schedule_retry(
+                                his.id, group_key=group_key
+                            ),
+                            global_vars.loop,
+                        )
+                        logger.info(f"已触发AI智能体重试整理历史记录 #{his.id}")
+                    except Exception as e:
+                        logger.error(f"触发AI智能体重试整理失败: {e}")
+
+                return (False, "未识别到媒体信息"), None, False
+
+            mediainfo_changed = True
+
+        return None, mediainfo, mediainfo_changed
 
     def _apply_scrap_follow_tmdb(
         self,

--- a/tests/test_transfer_handle_carve.py
+++ b/tests/test_transfer_handle_carve.py
@@ -1,8 +1,9 @@
 """
-S8a/S8b 契约守护：__handle_transfer 的 7 块中已抽出 6 个为私有 helper
-（无早返回块 _resolve_episodes_info/_resolve_target_directory/_select_storage_opers/
-_apply_scrap_follow_tmdb；哨兵块 _migrate_or_skip；终末 tail 块 _run_transfer_and_dispatch），
-入口方法保持薄编排 + 同序调用 + 原 try/finally；仅识别块 block-1 未抽。
+S8a/S8b 契约守护：__handle_transfer 的 7 块已全部抽成私有 helper
+（识别块 _recognize_for_transfer（多值回流）；无早返回块 _resolve_episodes_info/
+_resolve_target_directory/_select_storage_opers/_apply_scrap_follow_tmdb；哨兵块
+_migrate_or_skip；终末 tail 块 _run_transfer_and_dispatch），入口方法退化为薄编排
++ 同序调用 + 原 try/finally。
 
 本测试守护 P5 CRITICAL 的 monkey-patch 契约：p115strmhelper 通过 name-mangled
 类属性 `TransferChain._TransferChain__handle_transfer` 存/换/复原补丁（patch/transfer_chain.py
@@ -35,8 +36,8 @@ def test_handle_transfer_signature_stable():
 
 
 def test_extracted_helpers_present():
-    """6 个抽出的 helper 必须就位（单下划线、非 name-mangled）。"""
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
+    """7 个抽出的 helper 必须就位（单下划线、非 name-mangled）。"""
+    for h in ("_recognize_for_transfer", "_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
         assert hasattr(TransferChain, h), f"抽出的 helper 缺失: {h}"
 
 
@@ -45,13 +46,14 @@ def test_handle_transfer_keeps_finally_cleanup():
     src = inspect.getsource(getattr(TransferChain, MANGLED))
     assert "finally:" in src, "__handle_transfer 丢失 finally"
     assert "try_remove_job" in src and "__finish_scrape_batch_task" in src, "finally 清理动作被改动"
-    # 入口编排仍按序调用 6 个 helper
-    for h in ("_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
+    # 入口编排仍按序调用 7 个 helper
+    for h in ("_recognize_for_transfer", "_resolve_episodes_info", "_resolve_target_directory", "_select_storage_opers", "_apply_scrap_follow_tmdb", "_migrate_or_skip", "_run_transfer_and_dispatch"):
         assert h in src, f"入口未调用 helper: {h}"
 
 
-# 入口编排里 6 个 helper 的调用先后顺序（与 __handle_transfer 源码出现次序一致）
+# 入口编排里 7 个 helper 的调用先后顺序（与 __handle_transfer 源码出现次序一致）
 _HELPER_CALL_ORDER = (
+    "_recognize_for_transfer",
     "_apply_scrap_follow_tmdb",
     "_migrate_or_skip",
     "_resolve_episodes_info",


### PR DESCRIPTION
## 概要
把 `__handle_transfer` 的**首块**（block-1 识别媒体信息，~95 行，**双早返回 + 重副作用**）抽成私有 helper `_recognize_for_transfer(self, task, transferhis) -> Tuple[Optional[Tuple[bool, str]], Optional[MediaInfo], bool]`，返回三元组 `(early, mediainfo, mediainfo_changed)`。

入口：
```python
transferhis = TransferHistoryOper()
early, mediainfo, mediainfo_changed = self._recognize_for_transfer(task, transferhis)
if early is not None:
    return early
```
两条原早返回（preview 短路 / 识别失败）均 → `(False, '未识别到媒体信息'), None, False`；识别成功带出 mediainfo/changed 供后续块。行为**字节级不变**。

## 契约保持（P5 关键路径，最精细一刀）
- mangled `_TransferChain__handle_transfer` 名/签名 `(self,task,callback=None)`/类位置/`finally` **不变**。
- helper 内 `self.__mark_torrent_completed_if_done` 在同类 TransferChain 内 mangle 解析正确（bytecode 已验证）。
- p115 deep-reach 的 `self.jobview.remove_task` 仍同一 `JobManager()` 实例；`patch/transfer_chain.py` **未动**；新 helper 非 mangled、`app/plugins/` 零引用。
- 多值回流：mediainfo 已置时跳过识别（返回 `(None, task.mediainfo, False)`）；识别成功返回 `(None, recognized, True)`；`task.username`/`task.mediainfo` 引用回写正确。

## 验证
- 覆盖：集成夹具 2 例（识别成功多值回流 + preview 短路无副作用，PR #36）+ `test_transfer_job_manager.py:583/612`（识别失败完整 add_fail/notify/downloader-hash-completed）。
- 契约守卫扩到 **7 helper**（存在性 + 调用顺序，`_recognize_for_transfer` 首位）；transfer 套件 **65 passed**。
- 契约探针：入口已无 `recognize_media(`/`add_fail(`/`recognize_by_meta(`。
- `everything-claude-code:code-reviewer` 子代理 **6 契约对抗审查 PASS（0 Crit/High/Med/Low）**。

## 里程碑
**至此 `__handle_transfer` 7 块（block-1..7）全部抽出**，入口退化为薄编排 + try/finally。剩 S8-step2（抽 TransferService）与 S6（DI）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)