### PR TITLE
test(S8-step2 #1): transfer 共享工厂 + make_queue_chain（安全网奠基）

### DIFF
--- a/tests/test_transfer_handle_integration.py
+++ b/tests/test_transfer_handle_integration.py
@@ -19,105 +19,14 @@ mock 边界（3 patch + 1 实例方法替换）：
 真实运行：JobManager（内存）、_apply_scrap_follow_tmdb/_migrate_or_skip/_resolve_target_directory/
 _select_storage_opers 编排、try/finally 清理（try_remove_job + __finish_scrape_batch_task 空态返回）。
 
-工厂函数（make_transfer_chain/make_task/make_media_info/FakeMeta）就地内联自
-test_transfer_job_manager 的同名实现——本仓库 pytest 导入模式不把 tests/ 暴露为顶层包，
-同级测试模块不可直接 import，故复制必要工厂（测试夹具，受控重复）。
+工厂函数（make_transfer_chain/make_task/make_media_info）来自共享模块
+tests/transfer_fixtures.py（tests 为包，`from tests.transfer_fixtures import ...`）。
 """
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from app.core.config import settings
-from app.core.context import MediaInfo
-from app.chain.transfer import JobManager, TransferChain
-from app.schemas import FileItem, TransferTask
-from app.schemas.types import MediaType
-
-
-class FakeMeta:
-    """TV 元数据（复制自 test_transfer_job_manager.FakeMeta，含 add_task 所需的 to_dict）。"""
-
-    def __init__(self, episode: int, season: int = 1):
-        self.name = "Test Show"
-        self.title = f"Test Show S{season:02d}E{episode:02d}"
-        self.year = "2026"
-        self.type = MediaType.TV
-        self.begin_season = season
-        self.end_season = None
-        self.total_season = 1
-        self.begin_episode = episode
-        self.end_episode = None
-        self.total_episode = 1
-        self.episode_list = [episode]
-        self.season_episode = f"S01E{episode:02d}"
-        self.part = None
-
-    @property
-    def season(self):
-        return f"S{self.begin_season:02d}"
-
-    @property
-    def episode(self):
-        return f"E{self.begin_episode:02d}"
-
-    def to_dict(self):
-        return {
-            "title": self.title,
-            "name": self.name,
-            "year": self.year,
-            "type": self.type.value,
-            "begin_season": self.begin_season,
-            "end_season": self.end_season,
-            "total_season": self.total_season,
-            "begin_episode": self.begin_episode,
-            "end_episode": self.end_episode,
-            "total_episode": self.total_episode,
-            "season_episode": self.season_episode,
-            "episode_list": self.episode_list,
-            "part": self.part,
-        }
-
-
-def make_media_info() -> MediaInfo:
-    media = MediaInfo()
-    media.type = MediaType.TV
-    media.title = "Test Show"
-    media.title_year = "Test Show (2026)"
-    media.year = "2026"
-    media.tmdb_id = 12345
-    media.category = ""
-    media.actors = []
-    media.season_years = {}
-    media.vote_average = 0
-    return media
-
-
-def make_task(episode: int, season: int = 1) -> TransferTask:
-    name = f"Test.Show.S{season:02d}E{episode:02d}.mkv"
-    return TransferTask(
-        fileitem=FileItem(
-            storage="local",
-            path=f"/downloads/Test Show/{name}",
-            type="file",
-            name=name,
-            basename=name.removesuffix(".mkv"),
-            extension="mkv",
-            size=1024,
-        ),
-        meta=FakeMeta(episode, season),
-    )
-
-
-def make_transfer_chain() -> TransferChain:
-    chain = object.__new__(TransferChain)
-    chain.jobview = JobManager()
-    chain._media_exts = settings.RMT_MEDIAEXT
-    chain._subtitle_exts = settings.RMT_SUBEXT
-    chain._audio_exts = settings.RMT_AUDIOEXT
-    chain._allowed_exts = chain._media_exts + chain._audio_exts + chain._subtitle_exts
-    chain._success_target_files = {}
-    chain._scrape_batches = {}
-    return chain
+from tests.transfer_fixtures import make_media_info, make_task, make_transfer_chain
 
 
 def _prepare_recognized_task():

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -10,137 +10,15 @@ from app.chain.transfer import JobManager, TransferChain
 from app.modules.filemanager.transhandler import TransHandler
 from app.schemas import EpisodeFormat, FileItem, TransferInfo, TransferTask
 from app.schemas.types import EventType, MediaType
-
-
-class FakeMeta:
-    def __init__(self, episode: int, season: int = 1):
-        self.name = "Test Show"
-        self.title = f"Test Show S{season:02d}E{episode:02d}"
-        self.year = "2026"
-        self.type = MediaType.TV
-        self.begin_season = season
-        self.end_season = None
-        self.total_season = 1
-        self.begin_episode = episode
-        self.end_episode = None
-        self.total_episode = 1
-        self.episode_list = [episode]
-        self.season_episode = f"S01E{episode:02d}"
-        self.part = None
-
-    @property
-    def season(self):
-        return f"S{self.begin_season:02d}"
-
-    @property
-    def episode(self):
-        return f"E{self.begin_episode:02d}"
-
-    def to_dict(self):
-        return {
-            "title": self.title,
-            "name": self.name,
-            "year": self.year,
-            "type": self.type.value,
-            "begin_season": self.begin_season,
-            "end_season": self.end_season,
-            "total_season": self.total_season,
-            "begin_episode": self.begin_episode,
-            "end_episode": self.end_episode,
-            "total_episode": self.total_episode,
-            "season_episode": self.season_episode,
-            "episode_list": self.episode_list,
-            "part": self.part,
-        }
-
-
-class FakeMedia:
-    def __init__(self, tmdb_id: int = 12345):
-        self.tmdb_id = tmdb_id
-        self.douban_id = None
-        self.type = MediaType.TV
-        self.title_year = "Test Show (2026)"
-
-    def clear(self):
-        pass
-
-    def to_dict(self):
-        return {
-            "type": MediaType.TV.value,
-            "title": "Test Show",
-            "year": "2026",
-            "title_year": "Test Show (2026)",
-            "tmdb_id": self.tmdb_id,
-            "douban_id": self.douban_id,
-        }
-
-
-def make_media_info() -> MediaInfo:
-    media = MediaInfo()
-    media.type = MediaType.TV
-    media.title = "Test Show"
-    media.title_year = "Test Show (2026)"
-    media.year = "2026"
-    media.tmdb_id = 12345
-    media.category = ""
-    media.actors = []
-    media.season_years = {}
-    media.vote_average = 0
-    return media
-
-
-def make_task(episode: int, season: int = 1) -> TransferTask:
-    name = f"Test.Show.S{season:02d}E{episode:02d}.mkv"
-    return TransferTask(
-        fileitem=FileItem(
-            storage="local",
-            path=f"/downloads/Test Show/{name}",
-            type="file",
-            name=name,
-            basename=name.removesuffix(".mkv"),
-            extension="mkv",
-            size=1024,
-        ),
-        meta=FakeMeta(episode),
-    )
-
-
-def make_transfer_chain() -> TransferChain:
-    chain = object.__new__(TransferChain)
-    chain.jobview = JobManager()
-    chain._media_exts = settings.RMT_MEDIAEXT
-    chain._subtitle_exts = settings.RMT_SUBEXT
-    chain._audio_exts = settings.RMT_AUDIOEXT
-    chain._allowed_exts = (
-        chain._media_exts + chain._audio_exts + chain._subtitle_exts
-    )
-    chain._success_target_files = {}
-    chain._scrape_batches = {}
-    return chain
-
-
-def make_fileitem(path: str, size: int = 1024) -> FileItem:
-    file_path = path
-    name = file_path.rsplit("/", 1)[-1]
-    suffix = name.rsplit(".", 1)[-1] if "." in name else ""
-    basename = name[: -(len(suffix) + 1)] if suffix else name
-    return FileItem(
-        storage="local",
-        path=file_path,
-        type="file",
-        name=name,
-        basename=basename,
-        extension=suffix,
-        size=size,
-    )
-
-
-def migrate_to_media_job(jobview: JobManager, task: TransferTask):
-    task.mediainfo = FakeMedia()
-    jobview.migrate_task(task)
-    jobview.running_task(task)
-    jobview.finish_task(task)
-    jobview.try_remove_job(task)
+from tests.transfer_fixtures import (
+    FakeMedia,
+    FakeMeta,
+    make_fileitem,
+    make_media_info,
+    make_task,
+    make_transfer_chain,
+    migrate_to_media_job,
+)
 
 
 class TransferJobManagerTest(unittest.TestCase):

--- a/tests/test_transfer_queue_machinery.py
+++ b/tests/test_transfer_queue_machinery.py
@@ -1,0 +1,48 @@
+"""S8-step2 安全网（建设中）：transfer 队列/守护/worker 机器的特征化测试。
+
+本批先验证 make_queue_chain() 夹具契约（不起线程即可种入机器属性），为后续
+__start_transfer worker loop / 生命周期 / 入队的特征化测试奠基；这些特征化测试是
+把队列/守护/计数器机器抽成 TransferService 前的行为锁。
+"""
+import queue
+import unittest
+
+from app.chain.transfer import JobManager
+from tests.transfer_fixtures import make_queue_chain
+
+
+class MakeQueueChainContractTest(unittest.TestCase):
+    def test_seeds_machinery_attrs_without_threads(self):
+        """make_queue_chain 种入队列/计数器/守护属性，且不 spawn 任何线程。"""
+        chain = make_queue_chain()
+        # 队列就绪且为空
+        self.assertIsInstance(chain._queue, queue.Queue)
+        self.assertTrue(chain._queue.empty())
+        # 无线程被启动（worker loop 可被受控单步驱动，不阻塞在 15s 的 _queue.get）
+        self.assertEqual([], chain._threads)
+        self.assertEqual([], chain._transfer_threads)
+        # 守护 run 标志 + 极小轮询间隔
+        self.assertTrue(chain._queue_active)
+        self.assertLess(chain._transfer_interval, 1)
+        # 计数器清零
+        self.assertEqual(0, chain._active_tasks)
+        self.assertEqual(0, chain._processed_num)
+        self.assertEqual(0, chain._fail_num)
+        self.assertEqual(0, chain._total_num)
+        # 复用 make_transfer_chain 的 jobview/_success_target_files/_scrape_batches
+        self.assertIsInstance(chain.jobview, JobManager)
+        self.assertEqual({}, chain._success_target_files)
+        self.assertEqual({}, chain._scrape_batches)
+
+    def test_queue_put_get_roundtrip(self):
+        """种入的 _queue 是可用的 queue.Queue（put/get 往返）。"""
+        chain = make_queue_chain()
+        sentinel = object()
+        chain._queue.put(sentinel)
+        self.assertFalse(chain._queue.empty())
+        self.assertIs(sentinel, chain._queue.get_nowait())
+        self.assertTrue(chain._queue.empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transfer_fixtures.py
+++ b/tests/transfer_fixtures.py
@@ -1,0 +1,171 @@
+"""transfer 测试共享工厂（单一来源）。
+
+此前 make_transfer_chain/make_task/make_media_info/FakeMeta/FakeMedia/make_fileitem/
+migrate_to_media_job 在 test_transfer_job_manager.py 与 test_transfer_handle_integration.py
+两处重复，现集中于此（``from tests.transfer_fixtures import ...``，tests 为包）。
+
+S8-step2：新增 make_queue_chain()——在 make_transfer_chain 基础上额外种入队列/守护/计数器
+机器属性（不起线程），使 worker loop (__start_transfer) 可在 venv 内被受控驱动，作为后续
+抽取 TransferService 前的特征化测试安全网的基础。
+"""
+import queue
+from unittest.mock import Mock
+
+from app.core.config import settings
+from app.core.context import MediaInfo
+from app.chain.transfer import JobManager, TransferChain
+from app.schemas import FileItem, TransferTask
+from app.schemas.types import MediaType
+
+
+class FakeMeta:
+    def __init__(self, episode: int, season: int = 1):
+        self.name = "Test Show"
+        self.title = f"Test Show S{season:02d}E{episode:02d}"
+        self.year = "2026"
+        self.type = MediaType.TV
+        self.begin_season = season
+        self.end_season = None
+        self.total_season = 1
+        self.begin_episode = episode
+        self.end_episode = None
+        self.total_episode = 1
+        self.episode_list = [episode]
+        self.season_episode = f"S01E{episode:02d}"
+        self.part = None
+
+    @property
+    def season(self):
+        return f"S{self.begin_season:02d}"
+
+    @property
+    def episode(self):
+        return f"E{self.begin_episode:02d}"
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "name": self.name,
+            "year": self.year,
+            "type": self.type.value,
+            "begin_season": self.begin_season,
+            "end_season": self.end_season,
+            "total_season": self.total_season,
+            "begin_episode": self.begin_episode,
+            "end_episode": self.end_episode,
+            "total_episode": self.total_episode,
+            "season_episode": self.season_episode,
+            "episode_list": self.episode_list,
+            "part": self.part,
+        }
+
+
+class FakeMedia:
+    def __init__(self, tmdb_id: int = 12345):
+        self.tmdb_id = tmdb_id
+        self.douban_id = None
+        self.type = MediaType.TV
+        self.title_year = "Test Show (2026)"
+
+    def clear(self):
+        pass
+
+    def to_dict(self):
+        return {
+            "type": MediaType.TV.value,
+            "title": "Test Show",
+            "year": "2026",
+            "title_year": "Test Show (2026)",
+            "tmdb_id": self.tmdb_id,
+            "douban_id": self.douban_id,
+        }
+
+
+def make_media_info() -> MediaInfo:
+    media = MediaInfo()
+    media.type = MediaType.TV
+    media.title = "Test Show"
+    media.title_year = "Test Show (2026)"
+    media.year = "2026"
+    media.tmdb_id = 12345
+    media.category = ""
+    media.actors = []
+    media.season_years = {}
+    media.vote_average = 0
+    return media
+
+
+def make_task(episode: int, season: int = 1) -> TransferTask:
+    name = f"Test.Show.S{season:02d}E{episode:02d}.mkv"
+    return TransferTask(
+        fileitem=FileItem(
+            storage="local",
+            path=f"/downloads/Test Show/{name}",
+            type="file",
+            name=name,
+            basename=name.removesuffix(".mkv"),
+            extension="mkv",
+            size=1024,
+        ),
+        meta=FakeMeta(episode),
+    )
+
+
+def make_transfer_chain() -> TransferChain:
+    chain = object.__new__(TransferChain)
+    chain.jobview = JobManager()
+    chain._media_exts = settings.RMT_MEDIAEXT
+    chain._subtitle_exts = settings.RMT_SUBEXT
+    chain._audio_exts = settings.RMT_AUDIOEXT
+    chain._allowed_exts = (
+        chain._media_exts + chain._audio_exts + chain._subtitle_exts
+    )
+    chain._success_target_files = {}
+    chain._scrape_batches = {}
+    return chain
+
+
+def make_fileitem(path: str, size: int = 1024) -> FileItem:
+    file_path = path
+    name = file_path.rsplit("/", 1)[-1]
+    suffix = name.rsplit(".", 1)[-1] if "." in name else ""
+    basename = name[: -(len(suffix) + 1)] if suffix else name
+    return FileItem(
+        storage="local",
+        path=file_path,
+        type="file",
+        name=name,
+        basename=basename,
+        extension=suffix,
+        size=size,
+    )
+
+
+def migrate_to_media_job(jobview: JobManager, task: TransferTask):
+    task.mediainfo = FakeMedia()
+    jobview.migrate_task(task)
+    jobview.running_task(task)
+    jobview.finish_task(task)
+    jobview.try_remove_job(task)
+
+
+def make_queue_chain() -> TransferChain:
+    """make_transfer_chain + 队列/守护/计数器机器属性（不起线程）。
+
+    S8-step2：让 worker loop (__start_transfer) 在 venv 内可被受控驱动而无需真实
+    daemon 线程（真实 TransferChain() 会起线程并阻塞在 _queue.get(timeout=15s)）。
+    种入的属性对齐 TransferChain.__init__ 中机器部分，但 _transfer_interval 取极小、
+    _progress 用 Mock、不 spawn 任何线程。
+    """
+    chain = make_transfer_chain()
+    chain._queue = queue.Queue()
+    chain._transfer_threads = []
+    chain._threads = []
+    chain._transfer_interval = 0.01
+    chain._queue_active = True
+    chain._active_tasks = 0
+    chain._processed_num = 0
+    chain._fail_num = 0
+    chain._total_num = 0
+    chain._progress = Mock()
+    return chain


### PR DESCRIPTION
## 概要
S8-step2（抽 TransferService）第一刀，**test-only、零生产改动**。设计勘察结论：队列/守护/计数器机器**今天零测试覆盖**（所有 fixture 用 `object.__new__` 跳过 `__init__`，机器属性不存在、`__start_transfer` 从未被驱动），在 p115 跨线程+跨模块脆弱契约下盲搬危险 → **先建特征化安全网**。

## 本 PR（安全网奠基）
- **tests/transfer_fixtures.py**（新）：`make_transfer_chain/make_task/make_media_info/FakeMeta/FakeMedia/make_fileitem/migrate_to_media_job` 单一来源。此前在 `test_transfer_job_manager.py` 与 `test_transfer_handle_integration.py` **重复**，现两文件改为 `from tests.transfer_fixtures import`（`tests` 为包，已验证可导入）。
- **make_queue_chain()**（新）：在 `make_transfer_chain` 基础上种入队列/守护/计数器机器属性（`_queue/_threads/_queue_active/_active_tasks/_processed_num/_fail_num/_total_num/_transfer_interval/_progress`），**不 spawn 线程** → 让 worker loop `__start_transfer` 在 venv 内可被受控驱动（真实 `TransferChain()` 会起 daemon 线程阻塞在 `_queue.get(timeout=15s)`）。
- **tests/test_transfer_queue_machinery.py**（新）：`make_queue_chain` 夹具契约测试（Step 2 worker-loop 特征化测试的归宿）。

## 后续（本 PR 不含）
Step 2 worker-loop 特征化（计数器不变量/进度/异常路径）→ Step 3 生命周期 → Step 4 入队 → 绿灯后 Step 5 薄 facade `TransferService` + 委派（`task_lock` 留模块级、`jobview`/`_success_target_files` 留单例、`__start_transfer` 回调 `self._chain._TransferChain__handle_transfer`，保 p115 契约）。

## 验证
- 零生产改动；p115 触达面（TransferChain/task_lock/jobview/_success_target_files/__handle_transfer）原样未动。
- 全套 transfer 8 文件 **67 passed**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)