### PR TITLE
test(S8-step2 #2): __start_transfer worker-loop 特征化测试

### DIFF
--- a/tests/test_transfer_queue_machinery.py
+++ b/tests/test_transfer_queue_machinery.py
@@ -5,10 +5,34 @@ __start_transfer worker loop / 生命周期 / 入队的特征化测试奠基；�
 把队列/守护/计数器机器抽成 TransferService 前的行为锁。
 """
 import queue
+import threading
 import unittest
 
+from app.core.config import global_vars
 from app.chain.transfer import JobManager
-from tests.transfer_fixtures import make_queue_chain
+from app.schemas.transfer import TransferQueue
+from tests.transfer_fixtures import make_queue_chain, make_task
+
+
+def _drain_worker(chain, items, timeout=5):
+    """预填 items，在线程里跑 __start_transfer 至全部 task_done，再停循环并 join。
+
+    确定性要点：(1) 不向队列投 sentinel——worker 对 `if not item: continue` 不调用
+    task_done()，投 None 会让 queue.join() 永久挂起，且会污染序列末尾的 _queue.empty() 检查；
+    (2) queue.join() 等所有项 task_done（task_done 是 finally 首行）后再翻 _queue_active=False，
+    worker 在下一次 0.01s 超时的 get 后从 while 顶退出，最后一项的 finally（含序列末尾
+    progress.end + 计数重置）已在此前同步跑完。
+    """
+    global_vars.resume_system()  # 确保 STOP_EVENT 未设 → is_system_stopped False
+    chain._queue_active = True
+    for it in items:
+        chain._queue.put(it)
+    t = threading.Thread(target=chain._TransferChain__start_transfer, daemon=True)
+    t.start()
+    chain._queue.join()
+    chain._queue_active = False
+    t.join(timeout=timeout)
+    return t
 
 
 class MakeQueueChainContractTest(unittest.TestCase):
@@ -42,6 +66,93 @@ class MakeQueueChainContractTest(unittest.TestCase):
         self.assertFalse(chain._queue.empty())
         self.assertIs(sentinel, chain._queue.get_nowait())
         self.assertTrue(chain._queue.empty())
+
+
+class WorkerLoopCharacterizationTest(unittest.TestCase):
+    """特征化 __start_transfer worker loop 的计数器/进度/异常行为（抽 TransferService 前的行为锁）。
+
+    断言以 _progress（Mock）的调用参数为准——这些在调用时即被捕获，不受序列末尾计数重置影响。
+    """
+
+    def _run(self, results):
+        """results: 每项一个 (state, errmsg) 元组或一个 Exception 实例。
+
+        返回 (chain, handle_calls, fail_calls)。worker 串行处理，故 results 顺序即处理顺序。
+        """
+        chain = make_queue_chain()
+        handle_calls = []
+        counter = {"i": 0}
+
+        def fake_handle(task, callback=None):
+            i = counter["i"]
+            counter["i"] += 1
+            handle_calls.append((task, callback))
+            r = results[i]
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        # 实例属性遮蔽类方法：self.__handle_transfer 解析到 _TransferChain__handle_transfer 实例属性
+        chain._TransferChain__handle_transfer = fake_handle
+        fail_calls = []
+        chain._TransferChain__fail_transfer_task = lambda task: fail_calls.append(task)
+
+        items = [
+            TransferQueue(task=make_task(i + 1), callback=None)
+            for i in range(len(results))
+        ]
+        t = _drain_worker(chain, items)
+        self.assertFalse(t.is_alive(), "worker 线程未在超时内退出")
+        return chain, handle_calls, fail_calls
+
+    def _end_msg(self, chain):
+        """从 _progress.update 调用里取序列末尾消息（唯一含『共整理』）。"""
+        for c in chain._progress.update.call_args_list:
+            text = c.kwargs.get("text", "")
+            if "共整理" in text:
+                return text
+        return None
+
+    def test_all_success_counts_and_progress_lifecycle(self):
+        """3 项全成功：每项调用一次 handle、序列起始/结束各一次、末尾消息失败 0、计数归零。"""
+        chain, handle_calls, _ = self._run([(True, ""), (True, ""), (True, "")])
+        self.assertEqual(3, len(handle_calls))
+        chain._progress.start.assert_called_once()
+        chain._progress.end.assert_called_once()
+        self.assertIn("共整理 3 个文件，失败 0 个", self._end_msg(chain))
+        self.assertEqual(0, chain._active_tasks)
+        self.assertEqual(0, chain._processed_num)
+        self.assertEqual(0, chain._fail_num)
+
+    def test_failures_counted_in_end_message(self):
+        """3 项 2 失败（handle 返回 (False, ...)）：末尾消息失败计数为 2。"""
+        chain, _, _ = self._run([(True, ""), (False, "x"), (False, "y")])
+        self.assertIn("共整理 3 个文件，失败 2 个", self._end_msg(chain))
+        chain._progress.end.assert_called_once()
+
+    def test_exception_path_invokes_fail_transfer_task_and_counts(self):
+        """handle 抛异常：走 __fail_transfer_task，且该项计入 processed 与 fail。"""
+        chain, handle_calls, fail_calls = self._run(
+            [(True, ""), RuntimeError("boom"), (True, "")]
+        )
+        self.assertEqual(3, len(handle_calls))
+        self.assertEqual(1, len(fail_calls))
+        self.assertIn("共整理 3 个文件，失败 1 个", self._end_msg(chain))
+
+    def test_empty_task_item_is_skipped(self):
+        """TransferQueue.task 为空：worker task_done 后跳过，不调用 handle。"""
+        chain = make_queue_chain()
+        handle_calls = []
+        chain._TransferChain__handle_transfer = (
+            lambda task, callback=None: handle_calls.append(task) or (True, "")
+        )
+        items = [
+            TransferQueue(task=None, callback=None),
+            TransferQueue(task=make_task(1), callback=None),
+        ]
+        t = _drain_worker(chain, items)
+        self.assertFalse(t.is_alive())
+        self.assertEqual(1, len(handle_calls))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
S8-step2（抽 TransferService）安全网**核心**，承接 #38。在搬动队列/守护/计数器机器**之前**，用特征化测试锁住 worker loop `__start_transfer` 的行为。**test-only，零生产改动。**

## 设计
- `_drain_worker` 助手确定性驱动 worker：预填 N 项 → 线程跑 `__start_transfer` → `queue.join()`（等所有项 task_done）→ 翻 `_queue_active=False` 停循环 → `t.join()`。
- **关键坑**：worker 对 `if not item: continue` **不**调用 `task_done()`，故不能投 `None` sentinel（`queue.join()` 会永久挂起，且会污染序列末尾的 `_queue.empty()` 检查）；改用真实项耗尽 + 翻标志退出。
- 断言以 `_progress`(Mock) 调用参数为准——调用时即捕获，不受序列末尾计数重置影响。

## 4 例特征化
1. 全成功：每项调用一次 `__handle_transfer`、`progress.start/end` 各一次、末尾消息失败 0、`_active_tasks/_processed_num/_fail_num` 归零。
2. 失败计数：`(False, ...)` 计入末尾消息失败数。
3. 异常路径：`__handle_transfer` 抛异常 → 走 `__fail_transfer_task`，且该项计入 processed 与 fail。
4. 空 task 项（`TransferQueue.task=None`）被跳过。

## 验证
- 零生产改动；p115 触达面未动。
- 3× 重复运行确定性通过；queue machinery **6 passed**，全套 transfer **52 passed**。

后续：Step 3 生命周期（__init/__stop/on_config_changed）+ Step 4 入队 → 绿灯后 Step 5 薄 facade TransferService + 委派。

🤖 Generated with [Claude Code](https://claude.com/claude-code)