### PR TITLE
refactor(S8-step2 #5): 抽 TransferService 队列机器组合于 TransferChain 单例

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -730,6 +730,173 @@ class FailedRetryScheduler:
             )
 
 
+class TransferService:
+    """
+    文件整理队列服务（队列 / 守护线程 / 计数器机器）。
+
+    从 TransferChain 抽出，组合于其单例上（``chain._service``）。仅持有与队列调度相关的
+    机器态；契约固定的状态（``jobview`` / ``_success_target_files`` / 刮削批次 /
+    ``__handle_transfer`` / ``__default_callback`` / 模块级 ``task_lock``）仍在 TransferChain，
+    本服务通过 ``self._chain`` read-through 回调单例——p115strmhelper 的 monkey-patch 与
+    私有态深入访问因此不受影响（worker 仍调用单例的 ``_TransferChain__handle_transfer``）。
+    """
+
+    def __init__(self, chain: "TransferChain"):
+        # 所属整理链单例（契约态 read-through 回调点）
+        self._chain = chain
+        # 待整理任务队列
+        self._queue = queue.Queue()
+        # 文件整理线程
+        self._transfer_threads = []
+        # 队列间隔时间（秒）
+        self._transfer_interval = 15
+        # 整理进度
+        self._progress = ProgressHelper(ProgressKey.FileTransfer)
+        # 队列相关状态
+        self._threads = []
+        self._queue_active = False
+        self._active_tasks = 0
+        self._processed_num = 0
+        self._fail_num = 0
+        self._total_num = 0
+
+    def start(self):
+        """
+        启动文件整理线程
+        """
+        self._queue_active = True
+        for i in range(settings.TRANSFER_THREADS):
+            logger.info(f"启动文件整理线程 {i + 1} ...")
+            thread = threading.Thread(
+                target=self.run_worker, name=f"transfer-{i}", daemon=True
+            )
+            self._threads.append(thread)
+            thread.start()
+
+    def stop(self):
+        """
+        停止文件整理进程
+        """
+        self._queue_active = False
+        for thread in self._threads:
+            thread.join()
+        self._threads = []
+        logger.info("文件整理线程已停止")
+
+    def on_config_changed(self):
+        self.stop()
+        self.start()
+
+    def enqueue(self, task: TransferTask, callback):
+        """
+        把任务放入待整理队列（生产者；去重 / 刮削批次登记由 TransferChain.put_to_queue 负责）
+        """
+        self._queue.put(TransferQueue(task=task, callback=callback))
+
+    def run_worker(self):
+        """
+        处理队列（守护线程主循环）
+        """
+        while not global_vars.is_system_stopped and self._queue_active:
+            try:
+                item: TransferQueue = self._queue.get(
+                    block=True, timeout=self._transfer_interval
+                )
+                if not item:
+                    continue
+
+                task = item.task
+                if not task:
+                    self._queue.task_done()
+                    continue
+
+                # 文件信息
+                fileitem = task.fileitem
+
+                with task_lock:
+                    # 获取当前最新总数
+                    current_total = self._chain.jobview.total()
+                    # 更新总数，取当前总数和当前已处理+运行中+队列中的最大值
+                    self._total_num = max(self._total_num, current_total)
+
+                    # 如果当前没有在运行的任务且处理数为0，说明是一个新序列的开始
+                    if self._active_tasks == 0 and self._processed_num == 0:
+                        logger.info("开始整理队列处理...")
+                        # 启动进度
+                        self._progress.start()
+                        # 重置计数
+                        self._processed_num = 0
+                        self._fail_num = 0
+                        __process_msg = (
+                            f"开始整理队列处理，当前共 {self._total_num} 个文件 ..."
+                        )
+                        logger.info(__process_msg)
+                        self._progress.update(value=0, text=__process_msg)
+                    # 增加运行中的任务数
+                    self._active_tasks += 1
+
+                try:
+                    # 更新进度
+                    __process_msg = f"正在整理 {fileitem.name} ..."
+                    logger.info(__process_msg)
+                    with task_lock:
+                        self._progress.update(
+                            value=(self._processed_num / self._total_num * 100)
+                            if self._total_num
+                            else 0,
+                            text=__process_msg,
+                        )
+                    # 整理
+                    state, err_msg = self._chain._TransferChain__handle_transfer(
+                        task=task, callback=item.callback
+                    )
+
+                    with task_lock:
+                        if not state:
+                            # 任务失败
+                            self._fail_num += 1
+                        # 更新进度
+                        self._processed_num += 1
+                        __process_msg = f"{fileitem.name} 整理完成"
+                        logger.info(__process_msg)
+                        self._progress.update(
+                            value=(self._processed_num / self._total_num * 100)
+                            if self._total_num
+                            else 100,
+                            text=__process_msg,
+                        )
+                except Exception as e:
+                    logger.error(
+                        f"{fileitem.name} 整理任务处理出现错误：{e} - {traceback.format_exc()}"
+                    )
+                    self._chain._TransferChain__fail_transfer_task(task)
+                    with task_lock:
+                        self._processed_num += 1
+                        self._fail_num += 1
+                finally:
+                    self._queue.task_done()
+                    with task_lock:
+                        # 减少运行中的任务数
+                        self._active_tasks -= 1
+                        # 检查是否所有任务都已完成且队列为空
+                        if self._active_tasks == 0 and self._queue.empty():
+                            # 结束进度
+                            __end_msg = f"整理队列处理完成，共整理 {self._processed_num} 个文件，失败 {self._fail_num} 个"
+                            logger.info(__end_msg)
+                            self._progress.update(value=100, text=__end_msg)
+                            self._progress.end()
+                            # 重置计数
+                            self._processed_num = 0
+                            self._fail_num = 0
+
+            except queue.Empty:
+                # 即使队列空了，如果还有任务在运行，也不应该结束进度
+                # 这部分逻辑已经在 finally 的 active_tasks == 0 中处理了
+                continue
+            except Exception as e:
+                logger.error(f"整理队列处理出现错误：{e} - {traceback.format_exc()}")
+
+
 class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
     """
     文件整理处理链
@@ -749,12 +916,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         self._audio_exts = settings.RMT_AUDIOEXT
         # 可处理的文件后缀（视频文件、字幕、音频文件）
         self._allowed_exts = self._media_exts + self._audio_exts + self._subtitle_exts
-        # 待整理任务队列
-        self._queue = queue.Queue()
-        # 文件整理线程
-        self._transfer_threads = []
-        # 队列间隔时间（秒）
-        self._transfer_interval = 15
         # 事件管理器
         self.jobview = JobManager()
         # Agent重试管理器
@@ -763,44 +924,13 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         self._success_target_files: Dict[str, List[str]] = {}
         # 批次级刮削缓冲，避免同一批多文件入库重复触发目录刮削
         self._scrape_batches: Dict[str, Dict[str, Any]] = {}
-        # 整理进度进度
-        self._progress = ProgressHelper(ProgressKey.FileTransfer)
-        # 队列相关状态
-        self._threads = []
-        self._queue_active = False
-        self._active_tasks = 0
-        self._processed_num = 0
-        self._fail_num = 0
-        self._total_num = 0
-        # 启动整理任务
-        self.__init()
-
-    def __init(self):
-        """
-        启动文件整理线程
-        """
-        self._queue_active = True
-        for i in range(settings.TRANSFER_THREADS):
-            logger.info(f"启动文件整理线程 {i + 1} ...")
-            thread = threading.Thread(
-                target=self.__start_transfer, name=f"transfer-{i}", daemon=True
-            )
-            self._threads.append(thread)
-            thread.start()
-
-    def __stop(self):
-        """
-        停止文件整理进程
-        """
-        self._queue_active = False
-        for thread in self._threads:
-            thread.join()
-        self._threads = []
-        logger.info("文件整理线程已停止")
+        # 文件整理队列服务（队列 / 守护线程 / 计数器机器；契约态仍 read-through 本单例）
+        self._service = TransferService(chain=self)
+        # 启动整理线程
+        self._service.start()
 
     def on_config_changed(self):
-        self.__stop()
-        self.__init()
+        self._service.on_config_changed()
 
     def __is_subtitle_file(self, fileitem: FileItem) -> bool:
         """
@@ -1179,8 +1309,8 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         if not self.__put_to_jobview(task):
             return False
         self.__register_scrape_batch_task(task)
-        # 添加到队列
-        self._queue.put(TransferQueue(task=task, callback=self.__default_callback))
+        # 添加到队列（队列机器已抽到 TransferService，回调仍为本单例的 __default_callback）
+        self._service.enqueue(task=task, callback=self.__default_callback)
         return True
 
     def __put_to_jobview(self, task: TransferTask) -> bool:
@@ -1378,109 +1508,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         self.jobview.fail_unfinished_task(task)
         self.jobview.try_remove_job(task)
         self.__finish_scrape_batch_task(task)
-
-    def __start_transfer(self):
-        """
-        处理队列
-        """
-        while not global_vars.is_system_stopped and self._queue_active:
-            try:
-                item: TransferQueue = self._queue.get(
-                    block=True, timeout=self._transfer_interval
-                )
-                if not item:
-                    continue
-
-                task = item.task
-                if not task:
-                    self._queue.task_done()
-                    continue
-
-                # 文件信息
-                fileitem = task.fileitem
-
-                with task_lock:
-                    # 获取当前最新总数
-                    current_total = self.jobview.total()
-                    # 更新总数，取当前总数和当前已处理+运行中+队列中的最大值
-                    self._total_num = max(self._total_num, current_total)
-
-                    # 如果当前没有在运行的任务且处理数为0，说明是一个新序列的开始
-                    if self._active_tasks == 0 and self._processed_num == 0:
-                        logger.info("开始整理队列处理...")
-                        # 启动进度
-                        self._progress.start()
-                        # 重置计数
-                        self._processed_num = 0
-                        self._fail_num = 0
-                        __process_msg = (
-                            f"开始整理队列处理，当前共 {self._total_num} 个文件 ..."
-                        )
-                        logger.info(__process_msg)
-                        self._progress.update(value=0, text=__process_msg)
-                    # 增加运行中的任务数
-                    self._active_tasks += 1
-
-                try:
-                    # 更新进度
-                    __process_msg = f"正在整理 {fileitem.name} ..."
-                    logger.info(__process_msg)
-                    with task_lock:
-                        self._progress.update(
-                            value=(self._processed_num / self._total_num * 100)
-                            if self._total_num
-                            else 0,
-                            text=__process_msg,
-                        )
-                    # 整理
-                    state, err_msg = self.__handle_transfer(
-                        task=task, callback=item.callback
-                    )
-
-                    with task_lock:
-                        if not state:
-                            # 任务失败
-                            self._fail_num += 1
-                        # 更新进度
-                        self._processed_num += 1
-                        __process_msg = f"{fileitem.name} 整理完成"
-                        logger.info(__process_msg)
-                        self._progress.update(
-                            value=(self._processed_num / self._total_num * 100)
-                            if self._total_num
-                            else 100,
-                            text=__process_msg,
-                        )
-                except Exception as e:
-                    logger.error(
-                        f"{fileitem.name} 整理任务处理出现错误：{e} - {traceback.format_exc()}"
-                    )
-                    self.__fail_transfer_task(task)
-                    with task_lock:
-                        self._processed_num += 1
-                        self._fail_num += 1
-                finally:
-                    self._queue.task_done()
-                    with task_lock:
-                        # 减少运行中的任务数
-                        self._active_tasks -= 1
-                        # 检查是否所有任务都已完成且队列为空
-                        if self._active_tasks == 0 and self._queue.empty():
-                            # 结束进度
-                            __end_msg = f"整理队列处理完成，共整理 {self._processed_num} 个文件，失败 {self._fail_num} 个"
-                            logger.info(__end_msg)
-                            self._progress.update(value=100, text=__end_msg)
-                            self._progress.end()
-                            # 重置计数
-                            self._processed_num = 0
-                            self._fail_num = 0
-
-            except queue.Empty:
-                # 即使队列空了，如果还有任务在运行，也不应该结束进度
-                # 这部分逻辑已经在 finally 的 active_tasks == 0 中处理了
-                continue
-            except Exception as e:
-                logger.error(f"整理队列处理出现错误：{e} - {traceback.format_exc()}")
 
     def __handle_transfer(
             self, task: TransferTask, callback: Optional[Callable] = None

--- a/tests/test_transfer_queue_machinery.py
+++ b/tests/test_transfer_queue_machinery.py
@@ -1,8 +1,10 @@
-"""S8-step2 安全网（建设中）：transfer 队列/守护/worker 机器的特征化测试。
+"""S8-step2 安全网：transfer 队列/守护/worker 机器的特征化测试。
 
-本批先验证 make_queue_chain() 夹具契约（不起线程即可种入机器属性），为后续
-__start_transfer worker loop / 生命周期 / 入队的特征化测试奠基；这些特征化测试是
-把队列/守护/计数器机器抽成 TransferService 前的行为锁。
+S8-step2 ⑤ 已落地——队列机器从 TransferChain 抽到 TransferService（组合于 ``chain._service``）。
+本套测试驱动/断言 ``chain._service`` 上的 worker loop (run_worker) / 生命周期 (start/stop) /
+入队 (put_to_queue→service.enqueue)，作为抽取的行为锁；worker 仍经
+``self._chain._TransferChain__handle_transfer`` / ``__fail_transfer_task`` 回调单例
+（p115 契约 read-through），故注入点仍在 chain 上。
 """
 import queue
 import threading
@@ -16,7 +18,7 @@ from tests.transfer_fixtures import make_queue_chain, make_task
 
 
 def _drain_worker(chain, items, timeout=5):
-    """预填 items，在线程里跑 __start_transfer 至全部 task_done，再停循环并 join。
+    """预填 items，在线程里跑 service.run_worker 至全部 task_done，再停循环并 join。
 
     确定性要点：(1) 不向队列投 sentinel——worker 对 `if not item: continue` 不调用
     task_done()，投 None 会让 queue.join() 永久挂起，且会污染序列末尾的 _queue.empty() 检查；
@@ -25,54 +27,60 @@ def _drain_worker(chain, items, timeout=5):
     progress.end + 计数重置）已在此前同步跑完。
     """
     global_vars.resume_system()  # 确保 STOP_EVENT 未设 → is_system_stopped False
-    chain._queue_active = True
+    svc = chain._service
+    svc._queue_active = True
     for it in items:
-        chain._queue.put(it)
-    t = threading.Thread(target=chain._TransferChain__start_transfer, daemon=True)
+        svc._queue.put(it)
+    t = threading.Thread(target=svc.run_worker, daemon=True)
     t.start()
-    chain._queue.join()
-    chain._queue_active = False
+    svc._queue.join()
+    svc._queue_active = False
     t.join(timeout=timeout)
     return t
 
 
 class MakeQueueChainContractTest(unittest.TestCase):
-    def test_seeds_machinery_attrs_without_threads(self):
-        """make_queue_chain 种入队列/计数器/守护属性，且不 spawn 任何线程。"""
+    def test_seeds_service_machinery_without_threads(self):
+        """make_queue_chain 组合一个未起线程的 TransferService，机器态就绪，契约态仍在 chain。"""
         chain = make_queue_chain()
+        svc = chain._service
         # 队列就绪且为空
-        self.assertIsInstance(chain._queue, queue.Queue)
-        self.assertTrue(chain._queue.empty())
-        # 无线程被启动（worker loop 可被受控单步驱动，不阻塞在 15s 的 _queue.get）
-        self.assertEqual([], chain._threads)
-        self.assertEqual([], chain._transfer_threads)
-        # 守护 run 标志 + 极小轮询间隔
-        self.assertTrue(chain._queue_active)
-        self.assertLess(chain._transfer_interval, 1)
+        self.assertIsInstance(svc._queue, queue.Queue)
+        self.assertTrue(svc._queue.empty())
+        # 无线程被启动（构造态，start() 未调用 → worker loop 可被受控单步驱动）
+        self.assertEqual([], svc._threads)
+        self.assertEqual([], svc._transfer_threads)
+        self.assertFalse(svc._queue_active)
+        # 极小轮询间隔（夹具覆盖为 0.01）
+        self.assertLess(svc._transfer_interval, 1)
         # 计数器清零
-        self.assertEqual(0, chain._active_tasks)
-        self.assertEqual(0, chain._processed_num)
-        self.assertEqual(0, chain._fail_num)
-        self.assertEqual(0, chain._total_num)
-        # 复用 make_transfer_chain 的 jobview/_success_target_files/_scrape_batches
+        self.assertEqual(0, svc._active_tasks)
+        self.assertEqual(0, svc._processed_num)
+        self.assertEqual(0, svc._fail_num)
+        self.assertEqual(0, svc._total_num)
+        # service read-through 回单例
+        self.assertIs(chain, svc._chain)
+        # 契约态仍在 TransferChain（jobview/_success_target_files/_scrape_batches）
         self.assertIsInstance(chain.jobview, JobManager)
         self.assertEqual({}, chain._success_target_files)
         self.assertEqual({}, chain._scrape_batches)
 
     def test_queue_put_get_roundtrip(self):
-        """种入的 _queue 是可用的 queue.Queue（put/get 往返）。"""
+        """种入的 service._queue 是可用的 queue.Queue（put/get 往返）。"""
         chain = make_queue_chain()
         sentinel = object()
-        chain._queue.put(sentinel)
-        self.assertFalse(chain._queue.empty())
-        self.assertIs(sentinel, chain._queue.get_nowait())
-        self.assertTrue(chain._queue.empty())
+        chain._service._queue.put(sentinel)
+        self.assertFalse(chain._service._queue.empty())
+        self.assertIs(sentinel, chain._service._queue.get_nowait())
+        self.assertTrue(chain._service._queue.empty())
 
 
 class WorkerLoopCharacterizationTest(unittest.TestCase):
-    """特征化 __start_transfer worker loop 的计数器/进度/异常行为（抽 TransferService 前的行为锁）。
+    """特征化 service.run_worker 的计数器/进度/异常行为（抽 TransferService 后的行为锁）。
 
-    断言以 _progress（Mock）的调用参数为准——这些在调用时即被捕获，不受序列末尾计数重置影响。
+    断言以 service._progress（Mock）的调用参数为准——这些在调用时即被捕获，不受序列末尾计数重置影响。
+    worker 经 self._chain._TransferChain__handle_transfer / __fail_transfer_task 回调单例，
+    故下面替换这两者于 chain 实例上即可注入。
     """
 
     def _run(self, results):
@@ -93,7 +101,7 @@ class WorkerLoopCharacterizationTest(unittest.TestCase):
                 raise r
             return r
 
-        # 实例属性遮蔽类方法：self.__handle_transfer 解析到 _TransferChain__handle_transfer 实例属性
+        # 替换单例上的 __handle_transfer / __fail_transfer_task（worker 经 self._chain 回调）
         chain._TransferChain__handle_transfer = fake_handle
         fail_calls = []
         chain._TransferChain__fail_transfer_task = lambda task: fail_calls.append(task)
@@ -107,8 +115,8 @@ class WorkerLoopCharacterizationTest(unittest.TestCase):
         return chain, handle_calls, fail_calls
 
     def _end_msg(self, chain):
-        """从 _progress.update 调用里取序列末尾消息（唯一含『共整理』）。"""
-        for c in chain._progress.update.call_args_list:
+        """从 service._progress.update 调用里取序列末尾消息（唯一含『共整理』）。"""
+        for c in chain._service._progress.update.call_args_list:
             text = c.kwargs.get("text", "")
             if "共整理" in text:
                 return text
@@ -118,18 +126,18 @@ class WorkerLoopCharacterizationTest(unittest.TestCase):
         """3 项全成功：每项调用一次 handle、序列起始/结束各一次、末尾消息失败 0、计数归零。"""
         chain, handle_calls, _ = self._run([(True, ""), (True, ""), (True, "")])
         self.assertEqual(3, len(handle_calls))
-        chain._progress.start.assert_called_once()
-        chain._progress.end.assert_called_once()
+        chain._service._progress.start.assert_called_once()
+        chain._service._progress.end.assert_called_once()
         self.assertIn("共整理 3 个文件，失败 0 个", self._end_msg(chain))
-        self.assertEqual(0, chain._active_tasks)
-        self.assertEqual(0, chain._processed_num)
-        self.assertEqual(0, chain._fail_num)
+        self.assertEqual(0, chain._service._active_tasks)
+        self.assertEqual(0, chain._service._processed_num)
+        self.assertEqual(0, chain._service._fail_num)
 
     def test_failures_counted_in_end_message(self):
         """3 项 2 失败（handle 返回 (False, ...)）：末尾消息失败计数为 2。"""
         chain, _, _ = self._run([(True, ""), (False, "x"), (False, "y")])
         self.assertIn("共整理 3 个文件，失败 2 个", self._end_msg(chain))
-        chain._progress.end.assert_called_once()
+        chain._service._progress.end.assert_called_once()
 
     def test_exception_path_invokes_fail_transfer_task_and_counts(self):
         """handle 抛异常：走 __fail_transfer_task，且该项计入 processed 与 fail。"""
@@ -157,64 +165,67 @@ class WorkerLoopCharacterizationTest(unittest.TestCase):
 
 
 class LifecycleCharacterizationTest(unittest.TestCase):
-    """特征化守护线程生命周期 __init/__stop/on_config_changed（在 make_queue_chain 实例上手动驱动，
-    不构造真实 TransferChain()——避 Singleton 跨测试泄漏；空队列下线程仅 0.01s 自旋，__stop 快速 join）。
+    """特征化守护线程生命周期 service.start/stop 与 chain.on_config_changed（在 make_queue_chain
+    的 service 上手动驱动，不构造真实 TransferChain()——避 Singleton 跨测试泄漏；空队列下线程仅
+    0.01s 自旋，stop 快速 join）。
     """
 
     def setUp(self):
         global_vars.resume_system()  # 确保线程进入 loop（is_system_stopped False）
 
-    def test_init_spawns_daemon_threads_then_stop_joins(self):
-        """__init 起 TRANSFER_THREADS 个具名守护线程并置 _queue_active；__stop 翻标志、join、清空。"""
+    def test_start_spawns_daemon_threads_then_stop_joins(self):
+        """start 起 TRANSFER_THREADS 个具名守护线程并置 _queue_active；stop 翻标志、join、清空。"""
         chain = make_queue_chain()
+        svc = chain._service
         with patch("app.chain.transfer.settings.TRANSFER_THREADS", 2):
-            chain._TransferChain__init()
+            svc.start()
         try:
-            self.assertTrue(chain._queue_active)
-            self.assertEqual(2, len(chain._threads))
-            for i, th in enumerate(chain._threads):
+            self.assertTrue(svc._queue_active)
+            self.assertEqual(2, len(svc._threads))
+            for i, th in enumerate(svc._threads):
                 self.assertTrue(th.is_alive())
                 self.assertTrue(th.daemon)
                 self.assertEqual(f"transfer-{i}", th.name)
         finally:
-            chain._TransferChain__stop()
-        self.assertFalse(chain._queue_active)
-        self.assertEqual([], chain._threads)
+            svc.stop()
+        self.assertFalse(svc._queue_active)
+        self.assertEqual([], svc._threads)
 
     def test_on_config_changed_restarts_threads(self):
-        """on_config_changed = __stop + __init：旧线程被 join 退出，换上等量新线程。"""
+        """chain.on_config_changed 委派 service.stop+start：旧线程被 join 退出，换上等量新线程。"""
         chain = make_queue_chain()
+        svc = chain._service
         with patch("app.chain.transfer.settings.TRANSFER_THREADS", 1):
-            chain._TransferChain__init()
-            first = list(chain._threads)
+            svc.start()
+            first = list(svc._threads)
             chain.on_config_changed()
-            second = list(chain._threads)
+            second = list(svc._threads)
             try:
                 self.assertEqual(1, len(second))
                 self.assertIsNot(first[0], second[0])
                 self.assertFalse(first[0].is_alive())
                 self.assertTrue(second[0].is_alive())
             finally:
-                chain._TransferChain__stop()
-        self.assertEqual([], chain._threads)
+                svc.stop()
+        self.assertEqual([], svc._threads)
 
 
 class EnqueueCharacterizationTest(unittest.TestCase):
-    """特征化入队 put_to_queue（落队 + 默认回调 + 经 jobview.add_task 去重）。"""
+    """特征化入队 chain.put_to_queue（去重/刮削登记仍在 chain，落队委派 service.enqueue）。"""
 
     def test_put_to_queue_none_returns_false(self):
         """空任务：返回 False，不入队。"""
         chain = make_queue_chain()
         self.assertFalse(chain.put_to_queue(None))
-        self.assertTrue(chain._queue.empty())
+        self.assertTrue(chain._service._queue.empty())
 
     def test_put_to_queue_lands_task_with_default_callback(self):
         """有效任务：入队一个 TransferQueue(task, callback=__default_callback)，并登记进 jobview。"""
         chain = make_queue_chain()
         task = make_task(1)
         self.assertTrue(chain.put_to_queue(task))
-        self.assertEqual(1, chain._queue.qsize())
-        item = chain._queue.get_nowait()
+        self.assertEqual(1, chain._service._queue.qsize())
+        item = chain._service._queue.get_nowait()
         self.assertIs(task, item.task)
         self.assertEqual(chain._TransferChain__default_callback, item.callback)
         self.assertEqual(1, len(chain.jobview.list_jobs()))
@@ -225,7 +236,7 @@ class EnqueueCharacterizationTest(unittest.TestCase):
         task = make_task(1)
         self.assertTrue(chain.put_to_queue(task))
         self.assertFalse(chain.put_to_queue(task))
-        self.assertEqual(1, chain._queue.qsize())
+        self.assertEqual(1, chain._service._queue.qsize())
 
 
 if __name__ == "__main__":

--- a/tests/transfer_fixtures.py
+++ b/tests/transfer_fixtures.py
@@ -8,12 +8,11 @@ S8-step2：新增 make_queue_chain()——在 make_transfer_chain 基础上额�
 机器属性（不起线程），使 worker loop (__start_transfer) 可在 venv 内被受控驱动，作为后续
 抽取 TransferService 前的特征化测试安全网的基础。
 """
-import queue
 from unittest.mock import Mock
 
 from app.core.config import settings
 from app.core.context import MediaInfo
-from app.chain.transfer import JobManager, TransferChain
+from app.chain.transfer import JobManager, TransferChain, TransferService
 from app.schemas import FileItem, TransferTask
 from app.schemas.types import MediaType
 
@@ -150,22 +149,20 @@ def migrate_to_media_job(jobview: JobManager, task: TransferTask):
 
 
 def make_queue_chain() -> TransferChain:
-    """make_transfer_chain + 队列/守护/计数器机器属性（不起线程）。
+    """make_transfer_chain + 组合一个未起线程的 TransferService（队列/守护/计数器机器）。
 
-    S8-step2：让 worker loop (__start_transfer) 在 venv 内可被受控驱动而无需真实
-    daemon 线程（真实 TransferChain() 会起线程并阻塞在 _queue.get(timeout=15s)）。
-    种入的属性对齐 TransferChain.__init__ 中机器部分，但 _transfer_interval 取极小、
-    _progress 用 Mock、不 spawn 任何线程。
+    S8-step2 ⑤：队列机器已从 TransferChain 抽到 TransferService（组合于 ``chain._service``）。
+    本工厂构造一个不 spawn 线程的 service（_transfer_interval 取极小、_progress 用 Mock），
+    使 worker loop (run_worker) / 生命周期 (start/stop) 在 venv 内可被受控驱动，而无需真实
+    daemon 线程（真实 TransferChain() 会经 service.start() 起线程并阻塞在 _queue.get(15s)）。
+
+    注意：返回的 service 处于「已构造未 start」态（``_queue_active=False``、``_threads=[]``）。
+    直接驱动 worker 前须先翻 ``svc._queue_active = True``（``_drain_worker`` 已代为处理），
+    否则 ``run_worker`` 的 ``while ... and self._queue_active`` 会在首轮即退出。
     """
     chain = make_transfer_chain()
-    chain._queue = queue.Queue()
-    chain._transfer_threads = []
-    chain._threads = []
-    chain._transfer_interval = 0.01
-    chain._queue_active = True
-    chain._active_tasks = 0
-    chain._processed_num = 0
-    chain._fail_num = 0
-    chain._total_num = 0
-    chain._progress = Mock()
+    service = TransferService(chain=chain)
+    service._transfer_interval = 0.01
+    service._progress = Mock()
+    chain._service = service
     return chain


### PR DESCRIPTION
## S8-step2 Step ⑤（首处生产改动）

把 `TransferChain` 的队列调度机器抽成新类 `TransferService`，组合于单例（`chain._service`），chain 留薄委派。这是 step2 安全网（①–④，绿灯门）就绪后的首处生产改动。

### 改动
- **新增 `TransferService`**：持有 `_queue`/守护线程/4 计数器/`_progress`/`_transfer_interval` + 方法 `start`/`stop`/`on_config_changed`/`enqueue`/`run_worker`（原 `__init`/`__stop`/`__start_transfer`）。
- **worker `run_worker`** 经 `self._chain._TransferChain__handle_transfer`/`__fail_transfer_task` read-through 回调单例。
- **chain** `__init__` 组合 + `_service.start()`；`put_to_queue` 末行委派 `service.enqueue`；`on_config_changed` 委派 service。

### 契约保持（P5 / p115strmhelper）
`__handle_transfer`+7 helper、模块级 `task_lock`/`job_lock`、`jobview`/`_success_target_files`/`_scrape_batches`、`get_queue_tasks`/`remove_from_queue` **原地不动**；worker 循环**逐行字节级等价**（仅 `self`→`self._chain` 改写）。

### 验证
- 安全网测试重定向到 `chain._service`：queue-machinery **11 passed 3× 确定性**，全套 transfer **56 passed**（唯一失败为预存 `jieba_next` 环境缺包，与本改动无关）。
- 契约探针全过（mangled 符号/签名/finally/Singleton/模块锁/契约公共面/机器搬迁）。
- **code-reviewer 对抗审查 APPROVE**（0 Critical / 0 High；worker 循环字节级等价，5 项 P5 契约全满足）。