### PR TITLE
refactor(S6 #1): DownloadChain 构造注入 ThreadHelper（DI 试点）

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -41,6 +41,13 @@ class DownloadChain(ChainBase):
         ".rar": "rar",
     }
 
+    def __init__(self, thread_helper: ThreadHelper = None):
+        super().__init__()
+        # S6 DI 试点：线程池依赖可注入，默认回退全局共享单例 ThreadHelper。
+        # 不传参（现有调用点与插件）= 取全局单例，行为不变；测试可注入同步 fake，
+        # 确定性驱动后台提交（_submit_download_added_task），无需 mock.patch 全局。
+        self._thread_helper = thread_helper or ThreadHelper()
+
     @staticmethod
     def _safe_subtitle_file_name(file_name: str, fallback_name: str) -> str:
         """
@@ -353,7 +360,7 @@ class DownloadChain(ChainBase):
                 logger.error(f"执行下载成功后处理失败：{str(e)}")
 
         try:
-            ThreadHelper().submit(_run_download_added)
+            self._thread_helper.submit(_run_download_added)
         except Exception as err:
             logger.error(f"提交下载成功后处理后台任务失败：{str(err)}")
 

--- a/tests/test_download_chain.py
+++ b/tests/test_download_chain.py
@@ -106,11 +106,12 @@ def test_download_single_submits_download_added_to_background(monkeypatch):
     添加下载成功后，站点字幕等后处理应提交到后台，不能阻塞下载接口返回。
     """
     _FakeThreadHelper.submitted = []
-    monkeypatch.setattr(download_module, "ThreadHelper", _FakeThreadHelper)
     monkeypatch.setattr(download_module, "DownloadHistoryOper", _FakeDownloadHistoryOper)
     monkeypatch.setattr(download_module, "TorrentHelper", _FakeTorrentHelper)
 
     chain = DownloadChain.__new__(DownloadChain)
+    # S6 DI：直接注入 fake 线程池（不再 monkeypatch 全局 ThreadHelper，演示构造注入收益）
+    chain._thread_helper = _FakeThreadHelper()
     chain.download = MagicMock(return_value=("qb", "hash123", "Original", "添加下载成功"))
     chain.download_added = MagicMock()
     chain.eventmanager = MagicMock()

--- a/tests/test_s6_di_downloadchain.py
+++ b/tests/test_s6_di_downloadchain.py
@@ -1,0 +1,66 @@
+"""S6 DI 试点（首切片）：DownloadChain 经构造注入 ThreadHelper，默认回退全局共享单例。
+
+这是 S6（去服务定位器 / 依赖注入）的模板示范——「构造注入 + 默认回退全局单例」：
+  - 不传参（现有 463 处 Chain() 调用点与市场插件）= 取全局单例，行为与内存零变化；
+  - 测试可注入同步 fake executor，**无需 mock.patch 全局 ThreadHelper** 即确定性驱动
+    原本会起真实线程的后台提交（_submit_download_added_task）。
+
+本测试锁定该注入缝（签名）+ 证明后台提交确实路由经 self._thread_helper（可注入），
+作为 S6 推广到其余 Chain/Oper 的行为锁与范式样板。
+"""
+import inspect
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+from app.chain.download import DownloadChain
+
+
+class DownloadChainThreadHelperInjectionTest(unittest.TestCase):
+    def test_init_exposes_injectable_thread_helper_defaulting_none(self):
+        """__init__ 暴露 thread_helper 形参且默认 None（不传 = 回退全局单例）。"""
+        sig = inspect.signature(DownloadChain.__init__)
+        self.assertIn("thread_helper", sig.parameters)
+        self.assertIsNone(sig.parameters["thread_helper"].default)
+
+    def test_background_submit_routes_through_injected_executor(self):
+        """后台下载附加处理经 self._thread_helper.submit 提交，可被同步 fake 确定性驱动。"""
+        # object.__new__ 绕过 ChainBase.__init__（避免构造 8 个全局单例），仅注入受测依赖
+        chain = object.__new__(DownloadChain)
+        fake_executor = Mock()
+        chain._thread_helper = fake_executor
+        added_calls = []
+        chain.download_added = lambda **kw: added_calls.append(kw)
+
+        chain._submit_download_added_task(
+            context="CTX", download_dir=Path("/d"), torrent_content="T"
+        )
+
+        # 提交到注入的执行器（而非全局 ThreadHelper），且仅一次
+        fake_executor.submit.assert_called_once()
+        submitted = fake_executor.submit.call_args.args[0]
+        self.assertTrue(callable(submitted))
+        # 执行被提交的闭包 → 原样透传到 download_added
+        submitted()
+        self.assertEqual(
+            [{"context": "CTX", "download_dir": Path("/d"), "torrent_content": "T"}],
+            added_calls,
+        )
+
+    def test_submit_failure_is_swallowed_and_logged(self):
+        """注入的 executor.submit 抛错时被 try/except 吞掉（不冒泡阻塞添加下载响应）。"""
+        chain = object.__new__(DownloadChain)
+        boom = Mock()
+        boom.submit.side_effect = RuntimeError("pool down")
+        chain._thread_helper = boom
+        chain.download_added = lambda **kw: None
+
+        # 不抛出即通过（原 try/except 行为保持）
+        chain._submit_download_added_task(
+            context="CTX", download_dir=Path("/d"), torrent_content="T"
+        )
+        boom.submit.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## S6 首切片：依赖注入模板试点

S6（去服务定位器 / 干掉全局单例访问）的**首处生产改动**，确立可复用模板：**「构造注入 + 默认回退全局单例」**。

### 改动
- `DownloadChain.__init__(self, thread_helper: ThreadHelper = None)`：默认 = 全局共享单例 `ThreadHelper`。
- 后台提交 `_submit_download_added_task` 改走 `self._thread_helper.submit(...)`（原直调全局 `ThreadHelper().submit`）。

### 为什么是它
`DownloadChain` **非单例**（构造注入无 Singleton kwargs-缓存副作用）；后台提交原本起真实线程、**难以确定性测试**，注入后测试可传同步 fake。

### 零破坏
所有 `DownloadChain()` **无参**调用点（11 文件）与市场插件取全局单例、行为/内存不变。`ThreadHelper` 仍是共享单例。

### 可测性收益（S6 的目标）
既有 `test_download_single_submits_download_added_to_background` 从 **mock.patch 全局 ThreadHelper** 改为**直接注入 fake**——不再打全局补丁即可确定性驱动后台提交。

### 验证
新增 `test_s6_di_downloadchain.py`（注入缝签名 / 提交路由经注入执行器 / 失败吞掉）；download 套件回归 **45 passed**。

> 这是 S6（~1335 处、XL）的模板奠基切片，后续按此范式推广到其余 Chain/Oper 及 settings 注入。