### PR TITLE
refactor(S6 #2): ChainBase 8 个公共依赖可注入（keyword-only，默认回退全局单例）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -56,18 +56,34 @@ class ChainBase(metaclass=ABCMeta):
     处理链基类
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        modulemanager=None,
+        eventmanager=None,
+        messageoper=None,
+        messagehelper=None,
+        messagequeue=None,
+        pluginmanager=None,
+        filecache=None,
+        async_filecache=None,
+    ):
         """
         公共初始化
+
+        S6 DI：8 个公共依赖均可经关键字参数注入，默认回退各自全局单例。不传参（现有所有
+        SomeChain() 调用点、子类 super().__init__()、市场插件如 p115 的 PluginChian(ChainBase)）
+        = 取全局单例，行为不变；测试可注入 fake 而无需 mock.patch 全局。参数为 keyword-only，
+        杜绝位置传参歧义（原 __init__(self) 不接受位置参，无调用方受影响）。
         """
-        self.modulemanager = ModuleManager()
-        self.eventmanager = EventManager()
-        self.messageoper = MessageOper()
-        self.messagehelper = MessageHelper()
-        self.messagequeue = MessageQueueManager(send_callback=self.run_module)
-        self.pluginmanager = PluginManager()
-        self.filecache = FileCache()
-        self.async_filecache = AsyncFileCache()
+        self.modulemanager = modulemanager or ModuleManager()
+        self.eventmanager = eventmanager or EventManager()
+        self.messageoper = messageoper or MessageOper()
+        self.messagehelper = messagehelper or MessageHelper()
+        self.messagequeue = messagequeue or MessageQueueManager(send_callback=self.run_module)
+        self.pluginmanager = pluginmanager or PluginManager()
+        self.filecache = filecache or FileCache()
+        self.async_filecache = async_filecache or AsyncFileCache()
 
     def load_cache(self, filename: str) -> Any:
         """

--- a/tests/test_s6_di_chainbase.py
+++ b/tests/test_s6_di_chainbase.py
@@ -1,0 +1,68 @@
+"""S6 DI #2：ChainBase 的 8 个公共依赖经 keyword-only 参数可注入，默认回退全局单例。
+
+这是 S6（去服务定位器 / 依赖注入）从「单 consumer 试点」(#1 DownloadChain) 升级到
+**所有 chain 的基类**——ChainBase.__init__ 构造的 modulemanager/eventmanager/messageoper/
+messagehelper/messagequeue/pluginmanager/filecache/async_filecache 八个全局单例，现可整体注入。
+
+价值：测试可注入 fake 依赖、且不构造任何真实全局单例（ModuleManager/EventManager/
+PluginManager 等），无需 mock.patch 一长串导入点；现有 SomeChain() 无参调用点、子类
+super().__init__()、市场插件（p115 的 PluginChian(ChainBase)）取全局单例、行为不变。
+"""
+import inspect
+import unittest
+from unittest.mock import Mock
+
+from app.chain import ChainBase
+
+
+# ChainBase 无 @abstractmethod，可裸子类化用于测试
+class _StubChain(ChainBase):
+    pass
+
+
+_DEPS = (
+    "modulemanager",
+    "eventmanager",
+    "messageoper",
+    "messagehelper",
+    "messagequeue",
+    "pluginmanager",
+    "filecache",
+    "async_filecache",
+)
+
+
+class ChainBaseDependencyInjectionTest(unittest.TestCase):
+    def test_all_deps_injectable_via_keyword(self):
+        """注入全部 8 个 fake → 原样落到实例属性，且不构造任何真实全局单例。"""
+        fakes = {name: Mock(name=name) for name in _DEPS}
+        chain = _StubChain(**fakes)
+        for name in _DEPS:
+            self.assertIs(fakes[name], getattr(chain, name))
+
+    def test_init_params_keyword_only_with_none_default(self):
+        """8 个依赖参数均为 keyword-only 且默认 None（不传 = 回退全局单例）。"""
+        sig = inspect.signature(ChainBase.__init__)
+        for name in _DEPS:
+            self.assertIn(name, sig.parameters)
+            param = sig.parameters[name]
+            self.assertIsNone(param.default, f"{name} 默认值应为 None")
+            self.assertEqual(
+                inspect.Parameter.KEYWORD_ONLY,
+                param.kind,
+                f"{name} 应为 keyword-only",
+            )
+
+    def test_partial_injection_keeps_other_deps_defaulting(self):
+        """只注入部分依赖：被注入的用 fake，其余仍回退全局单例（不报错、属性就位）。"""
+        em = Mock(name="eventmanager")
+        # 仅注入 eventmanager；其余走默认（构造真实全局单例，验证编排不破）
+        chain = _StubChain(eventmanager=em)
+        self.assertIs(em, chain.eventmanager)
+        # 其余依赖仍被赋值（非 None）
+        for name in _DEPS:
+            self.assertIsNotNone(getattr(chain, name))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## S6 #2：依赖注入升级到所有 chain 的基类

S6 DI 从单 consumer 试点（#1 DownloadChain）升级到 **ChainBase**——所有 28+ chain 子类的基类。

### 改动
`ChainBase.__init__` 构造的 8 个全局单例改为 **keyword-only 可选参数 + 默认回退全局单例**：
`modulemanager / eventmanager / messageoper / messagehelper / messagequeue / pluginmanager / filecache / async_filecache`。

### 零破坏（可证明）
- 参数 **keyword-only + 默认 None**；原 `__init__(self)` 不接受位置参 → **无任何调用方能受影响**。
- 现有所有 `SomeChain()` 无参调用、28+ 子类 `super().__init__()`、市场插件（**p115 的 `PluginChian(ChainBase)`**）= 取全局单例、行为不变。

### 可测性收益（S6 目标）
测试可注入 fake 依赖、且**不构造任何真实全局单例**（ModuleManager/EventManager/PluginManager…），无需 mock.patch 一长串导入点。

### 验证
- 新增 `test_s6_di_chainbase.py`（全注入 / keyword-only+默认契约 / 部分注入）。
- **全量套件差分 = 零新增失败**：基线 22 failed/1075 passed/31 errors → 改动后 22 failed/**1078** passed/31 errors（22 failed 与 31 errors 全为预存 jieba_next/agent 环境缺包，passed +3 即新测试）。

> S6 模板（构造注入+默认回退全局）现已覆盖基类，后续可在任意 chain 测试中注入依赖。