### PR TITLE
refactor(S6 #3): settings 经构造注入（CookieCloudHelper pilot）

### DIFF
--- a/app/helper/cookiecloud.py
+++ b/app/helper/cookiecloud.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, Tuple, Optional
 
-from app.core.config import settings
+from app.core.config import settings as _global_settings
 from app.log import logger
 from app.utils.crypto import CryptoJsUtils, HashUtils
 from app.utils.http import RequestUtils
@@ -12,18 +12,21 @@ from app.utils.url import UrlUtils
 class CookieCloudHelper:
     _ignore_cookies: list = ["CookieAutoDeleteBrowsingDataCleanup", "CookieAutoDeleteCleaningDiscarded"]
 
-    def __init__(self):
+    def __init__(self, settings=None):
+        # S6 DI：settings 可注入，默认回退全局单例（测试可注入 fake 配置，不改全局 settings）。
+        # 注：形参 settings 遮蔽模块级 settings，故全局以别名 _global_settings 导入。
+        self._settings = settings or _global_settings
         self.__sync_setting()
 
     def __sync_setting(self):
         """
         同步CookieCloud配置项
         """
-        self._server = UrlUtils.standardize_base_url(settings.COOKIECLOUD_HOST)
-        self._key = StringUtils.safe_strip(settings.COOKIECLOUD_KEY)
-        self._password = StringUtils.safe_strip(settings.COOKIECLOUD_PASSWORD)
-        self._enable_local = settings.COOKIECLOUD_ENABLE_LOCAL
-        self._local_path = settings.COOKIE_PATH
+        self._server = UrlUtils.standardize_base_url(self._settings.COOKIECLOUD_HOST)
+        self._key = StringUtils.safe_strip(self._settings.COOKIECLOUD_KEY)
+        self._password = StringUtils.safe_strip(self._settings.COOKIECLOUD_PASSWORD)
+        self._enable_local = self._settings.COOKIECLOUD_ENABLE_LOCAL
+        self._local_path = self._settings.COOKIE_PATH
 
     def download(self) -> Tuple[Optional[dict], str]:
         """

--- a/tests/test_s6_di_settings_cookiecloud.py
+++ b/tests/test_s6_di_settings_cookiecloud.py
@@ -1,0 +1,54 @@
+"""S6 DI #3：settings 经构造注入（CookieCloudHelper pilot），默认回退全局单例。
+
+这是 S6 把「构造注入 + 默认回退全局」模板（#1 ThreadHelper、#2 ChainBase 8 依赖）
+扩到**最广引用的全局 `settings`**（193 文件）的首个 pilot：CookieCloudHelper 不再直读
+模块级 `settings`，而是经 __init__ 注入、默认回退全局单例，配置读取走 self._settings。
+
+价值：测试可注入 fake 配置对象、不触碰全局 settings；现有 CookieCloudHelper() 无参调用
+（chain/site.py:344）= 取全局单例、行为不变。
+"""
+import inspect
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.core.config import settings as _global_settings
+from app.helper.cookiecloud import CookieCloudHelper
+
+
+def _fake_settings(**overrides):
+    base = dict(
+        COOKIECLOUD_HOST="http://cc.example",
+        COOKIECLOUD_KEY="  mykey  ",
+        COOKIECLOUD_PASSWORD="  mypass  ",
+        COOKIECLOUD_ENABLE_LOCAL=True,
+        COOKIE_PATH=Path("/cookies"),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class CookieCloudSettingsInjectionTest(unittest.TestCase):
+    def test_init_exposes_injectable_settings_defaulting_none(self):
+        """__init__ 暴露 settings 形参且默认 None（不传 = 回退全局单例）。"""
+        sig = inspect.signature(CookieCloudHelper.__init__)
+        self.assertIn("settings", sig.parameters)
+        self.assertIsNone(sig.parameters["settings"].default)
+
+    def test_sync_reads_from_injected_settings(self):
+        """注入 fake settings → 配置从 fake 读取（key/password 经 safe_strip 去空白）。"""
+        helper = CookieCloudHelper(settings=_fake_settings())
+        self.assertEqual("mykey", helper._key)
+        self.assertEqual("mypass", helper._password)
+        self.assertTrue(helper._enable_local)
+        self.assertEqual(Path("/cookies"), helper._local_path)
+        self.assertIn("cc.example", helper._server)
+
+    def test_default_falls_back_to_global_settings(self):
+        """不传 settings → 持有的就是全局单例（零破坏：现有无参调用行为不变）。"""
+        helper = CookieCloudHelper()
+        self.assertIs(_global_settings, helper._settings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## S6 #3：settings 注入 pilot

S6 DI 模板（#1 ThreadHelper、#2 ChainBase 8 依赖）扩到**最广引用的全局 `settings`**（193 文件）的首个 pilot。

### 改动
`CookieCloudHelper` 不再直读模块级 `settings`，改 `__init__(self, settings=None)` 注入、默认回退全局单例（全局以别名 `_global_settings` 导入避形参遮蔽），`__sync_setting` 走 `self._settings`。

### 零破坏
唯一调用点 `chain/site.py:344 CookieCloudHelper()` 无参 → 取全局单例、行为不变。

### 可测性收益
测试可注入 fake 配置对象、**不触碰全局 settings**。

### 验证
- 新增 `test_s6_di_settings_cookiecloud.py`（注入读取 / 签名契约 / 默认回退全局）。
- **全量套件差分零新增失败**：基线 22 failed/1078 passed/31 errors → 改动后 22/**1081**/31（failed+errors 一致、passed +3）。

### 说明
settings 注入价值低于 Chain/Oper 注入（`monkeypatch.setattr(settings, ...)` 本就能测 settings），193 文件全量迁移**不建议**；本 pilot 确立模式供按需采用，不做大规模铺开。