### PR TITLE
refactor(S6 #5): 组合根服务注册表（ServiceRegistry）

### DIFF
--- a/app/startup/modules_initializer.py
+++ b/app/startup/modules_initializer.py
@@ -28,6 +28,7 @@ from app.command import CommandChain
 from app.schemas import Notification, NotificationType
 from app.schemas.types import SystemConfigKey
 from app.startup.agent_initializer import init_agent, stop_agent
+from app.startup.service_registry import service_registry
 
 
 def start_frontend():
@@ -113,12 +114,15 @@ async def stop_modules():
     """
     # 停止AI智能体
     await stop_agent()
-    # 停止模块
-    ModuleManager().stop()
+    # 停止模块（从组合根注册表取所拥有的实例，不再重新 X() 取单例）
+    if (module_manager := service_registry.get("module_manager")) is not None:
+        module_manager.stop()
     # 停止事件消费
-    EventManager().stop()
+    if (event_manager := service_registry.get("event_manager")) is not None:
+        event_manager.stop()
     # 停止虚拟显示
-    DisplayHelper().stop()
+    if (display := service_registry.get("display")) is not None:
+        display.stop()
     # 停止线程池
     ThreadHelper().shutdown()
     # 停止消息服务
@@ -138,20 +142,22 @@ def init_modules():
     """
     启动模块
     """
-    # 虚拟显示
-    DisplayHelper()
-    # DoH
+    # 重置组合根注册表（单进程内 init_modules 仅调用一次；防御性清空，避免假想的二次 init 残留旧实例）
+    service_registry.clear()
+    # 虚拟显示（生命周期服务：登记到注册表，stop_modules 取回关闭）
+    service_registry.register("display", DisplayHelper())
+    # DoH（仅构造副作用，无 stop()，不纳入注册表）
     DohHelper()
-    # 站点管理
+    # 站点管理（同上）
     SitesHelper()
-    # 资源包检测
+    # 资源包检测（同上）
     ResourceHelper()
     # 用户认证
     user_auth()
     # 加载模块
-    ModuleManager()
-    # 启动事件消费
-    EventManager().start()
+    service_registry.register("module_manager", ModuleManager())
+    # 启动事件消费（登记后启动同一实例）
+    service_registry.register("event_manager", EventManager()).start()
     # 初始化共享服务端状态
     MoviePilotServerHelper.init_plugin_report()
     MoviePilotServerHelper.init_subscribe_report()

--- a/app/startup/service_registry.py
+++ b/app/startup/service_registry.py
@@ -1,0 +1,37 @@
+"""组合根服务注册表（composition-root registry）。
+
+S6 DI：让组合根（app/startup/modules_initializer.py 的 init_modules / stop_modules）
+**显式拥有**其构造的生命周期服务实例，替掉「stop 时重新 `X()` 取全局单例」的隐式反模式
+（依赖 Singleton 元类在 init/stop 两处返回同一实例）。
+
+本注册表**只在组合根内部使用**，不作为随处可取的服务定位器——那正是 S6 要消除的访问
+模式。它是组合根对其所拥有服务的显式清单与生命周期句柄，也是后续逐步去单例（让这些服务
+不再全局可取、改由注册表唯一持有）的落点。
+
+无任何外部依赖（仅 typing），是叶子模块。
+"""
+from typing import Any, Dict, Optional
+
+
+class ServiceRegistry:
+    """组合根持有的服务实例注册表（按名登记 / 取用 / 清空）。"""
+
+    def __init__(self):
+        self._services: Dict[str, Any] = {}
+
+    def register(self, name: str, instance: Any) -> Any:
+        """登记一个服务实例并原样返回（便于 register(name, X()).start() 链式调用）。"""
+        self._services[name] = instance
+        return instance
+
+    def get(self, name: str) -> Optional[Any]:
+        """取登记的服务实例；未登记返回 None。"""
+        return self._services.get(name)
+
+    def clear(self) -> None:
+        """清空注册表（测试隔离用）。"""
+        self._services.clear()
+
+
+# 组合根的全局注册表实例（仅组合根使用）
+service_registry = ServiceRegistry()

--- a/tests/test_s6_di_service_registry.py
+++ b/tests/test_s6_di_service_registry.py
@@ -1,0 +1,88 @@
+"""S6 DI #5：组合根服务注册表（composition-root registry）。
+
+ServiceRegistry 让组合根（modules_initializer.init_modules / stop_modules）显式拥有其构造的
+生命周期服务，替掉「stop 时重新 X() 取全局单例」的隐式反模式。
+
+本测试覆盖：(1) ServiceRegistry 单元行为（register 返回实例便于链式、get、clear、未登记返回
+None）；(2) **源码层**断言 init_modules 经 service_registry.register 登记服务、stop_modules 经
+service_registry.get 取回。
+
+注：不 import modules_initializer——它顶层 import agent_initializer → app.agent → jieba_next，
+本 venv 缺包（预存环境限制）；改为直接读取其源码文件做结构断言，亦不触发真实启动/关闭
+（会起线程 / 连 redis/db）。service_registry 本身是零依赖叶子，可正常 import。
+"""
+import unittest
+from pathlib import Path
+
+from app.startup.service_registry import ServiceRegistry, service_registry
+
+_MODULES_INIT_SRC = (
+    Path(__file__).resolve().parent.parent
+    / "app" / "startup" / "modules_initializer.py"
+).read_text(encoding="utf-8")
+
+
+class ServiceRegistryUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.reg = ServiceRegistry()
+
+    def test_register_returns_instance_for_chaining(self):
+        """register 原样返回实例（支持 register(name, X()).start() 链式）。"""
+        sentinel = object()
+        self.assertIs(sentinel, self.reg.register("svc", sentinel))
+
+    def test_get_returns_registered_instance(self):
+        sentinel = object()
+        self.reg.register("svc", sentinel)
+        self.assertIs(sentinel, self.reg.get("svc"))
+
+    def test_get_unregistered_returns_none(self):
+        self.assertIsNone(self.reg.get("missing"))
+
+    def test_clear_empties_registry(self):
+        self.reg.register("svc", object())
+        self.reg.clear()
+        self.assertIsNone(self.reg.get("svc"))
+
+    def test_module_level_singleton_instance_is_a_registry(self):
+        self.assertIsInstance(service_registry, ServiceRegistry)
+
+
+class CompositionRootWiringTest(unittest.TestCase):
+    """源码层验证组合根经注册表持有/取回生命周期服务（不执行真实 init/stop）。"""
+
+    def test_init_modules_registers_only_lifecycle_services_with_stop(self):
+        # 仅登记有 stop()、且 stop_modules 会取回的 3 个生命周期服务
+        for name in ("display", "module_manager", "event_manager"):
+            self.assertIn(
+                f'service_registry.register("{name}"',
+                _MODULES_INIT_SRC,
+                f"init_modules 未经注册表登记 {name}",
+            )
+        # doh/sites/resource 无 stop()，不应登记进注册表（避免无用引用与语义误导）
+        for name in ("doh", "sites", "resource"):
+            self.assertNotIn(
+                f'service_registry.register("{name}"',
+                _MODULES_INIT_SRC,
+                f"无 stop() 的 {name} 不应登记进注册表",
+            )
+
+    def test_init_modules_clears_registry_first(self):
+        """init_modules 开头清空注册表（文档化单进程单次 init 假设 + 防御二次 init 残留）。"""
+        self.assertIn("service_registry.clear()", _MODULES_INIT_SRC)
+
+    def test_stop_modules_retrieves_from_registry_not_resingleton(self):
+        for name in ("module_manager", "event_manager", "display"):
+            self.assertIn(
+                f'service_registry.get("{name}")',
+                _MODULES_INIT_SRC,
+                f"stop_modules 未从注册表取回 {name}",
+            )
+        # 不再重新 X() 取单例来 stop（反模式已替换）
+        self.assertNotIn("ModuleManager().stop()", _MODULES_INIT_SRC)
+        self.assertNotIn("EventManager().stop()", _MODULES_INIT_SRC)
+        self.assertNotIn("DisplayHelper().stop()", _MODULES_INIT_SRC)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## S6 #5：composition-root registry（结构升级）

让组合根 `modules_initializer` **显式拥有**其构造的生命周期服务，替掉 `stop_modules` 重新 `X()` 取全局单例的隐式反模式。

### 改动
- 新增 `app/startup/service_registry.py`：`ServiceRegistry`（register/get/clear）+ 模块级 `service_registry`，**零依赖叶子**、仅组合根使用（非随处可取的服务定位器）。
- `init_modules`：`display`/`module_manager`/`event_manager`（均有 `stop()`）登记进注册表；开头 `service_registry.clear()` 文档化「单进程单次 init」假设。`doh`/`sites`/`resource` 无 `stop()` 保持普通构造、不入注册表。
- `stop_modules`：从注册表 `get` 取回这 3 个实例 `.stop()`（null-safe），不再重新 `X()` 取单例。

### 行为等价
这些类是 Singleton，`register` 的实例 == `X()`；stop 顺序逐行不变；null-safe（`if (x := get(...)) is not None`）比原 `X().stop()` **更安全**（原代码未 init 时会构造新实例再 stop，触发 `ModuleManager.load_modules` 全量扫描）。

### 验证
- 新增 `test_s6_di_service_registry.py`（8 例：注册表单元行为 + 源码层接线断言；规避 `jieba_next` 缺包用读源码而非 import）。
- **全量差分零回归**：基线 22f/1084p/31e → 改动后 22f/**1092**p/31e（failed+errors 一致、passed +8）。
- **code-reviewer 对抗审查 APPROVE**（0 Crit/High；启动/关闭行为等价+顺序保持，null-safe 为改进；2 Medium 已采纳——只登记有 stop() 的服务、clear() 文档化单次 init）。

> 这是 DI 化的结构基础：后续可逐步去单例（让核心服务不再全局可取、改由注册表唯一持有）。