### PR TITLE
refactor(S8 ⑥): 抽 ScrapeBatchCoordinator（批次级刮削事件协调器）

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -897,6 +897,149 @@ class TransferService:
                 logger.error(f"整理队列处理出现错误：{e} - {traceback.format_exc()}")
 
 
+class ScrapeBatchCoordinator:
+    """批次级刮削事件协调器（从 TransferChain 抽出，组合于其单例上 ``chain._scrape_coordinator``）。
+
+    职责：把同一整理批次（``transfer_batch_id``）内多文件的刮削目标聚合，待批次关闭且批内任务
+    全部结束后统一发送一次 ``MetadataScrape`` 事件——避免逐文件重复触发目录刮削。状态 ``_batches``
+    原 ``TransferChain._scrape_batches``，**非 p115 触达点**，可安全移出；仍用模块级 ``job_lock``
+    守护，并经 ``self._chain`` read-through 读取 ``eventmanager`` 与 ``__is_media_file``（留在单例）。
+    """
+
+    def __init__(self, chain: "TransferChain"):
+        self._chain = chain
+        # batch_id -> {"pending": set[path], "targets": {(storage,path): {...}}, "closed": bool}
+        self._batches: Dict[str, Dict[str, Any]] = {}
+
+    def register(self, task: TransferTask):
+        """
+        登记批次任务。刮削事件只在批次关闭且任务全部完成后统一发送。
+        """
+        if not task or not task.transfer_batch_id:
+            return
+        with job_lock:
+            batch = self._batches.setdefault(
+                task.transfer_batch_id,
+                {
+                    "pending": set(),
+                    "targets": {},
+                    "closed": False,
+                },
+            )
+            batch["pending"].add(task.fileitem.path)
+
+    def close(self, batch_id: Optional[str]):
+        """
+        标记批次不再接收新任务，并尝试发送已聚合的刮削事件。
+        """
+        if not batch_id:
+            return
+        with job_lock:
+            batch = self._batches.setdefault(
+                batch_id,
+                {
+                    "pending": set(),
+                    "targets": {},
+                    "closed": False,
+                },
+            )
+            batch["closed"] = True
+        self._flush_if_ready(batch_id)
+
+    def record_target(self, task: TransferTask, transferinfo: TransferInfo):
+        """
+        记录批次内需要刮削的目标文件，按目标媒体根目录聚合。
+        """
+        if (
+                not task
+                or not task.transfer_batch_id
+                or not transferinfo
+                or not transferinfo.need_scrape
+                or not self._chain._TransferChain__is_media_file(task.fileitem)
+        ):
+            return
+
+        target_diritem = transferinfo.target_diritem
+        if not target_diritem:
+            return
+
+        target_files = transferinfo.file_list_new or []
+        target_key = (target_diritem.storage, target_diritem.path)
+        with job_lock:
+            batch = self._batches.setdefault(
+                task.transfer_batch_id,
+                {
+                    "pending": set(),
+                    "targets": {},
+                    "closed": False,
+                },
+            )
+            target = batch["targets"].setdefault(
+                target_key,
+                {
+                    "fileitem": target_diritem,
+                    "meta": task.meta,
+                    "mediainfo": task.mediainfo,
+                    "files": [],
+                    "overwrite": False,
+                },
+            )
+            if not target.get("meta"):
+                target["meta"] = task.meta
+            if not target.get("mediainfo"):
+                target["mediainfo"] = task.mediainfo
+            for target_file in target_files:
+                if target_file and target_file not in target["files"]:
+                    target["files"].append(target_file)
+
+    def finish(self, task: TransferTask):
+        """
+        标记批次内单个任务已结束。
+        """
+        if not task or not task.transfer_batch_id:
+            return
+        with job_lock:
+            batch = self._batches.get(task.transfer_batch_id)
+            if not batch:
+                return
+            batch["pending"].discard(task.fileitem.path)
+        self._flush_if_ready(task.transfer_batch_id)
+
+    def _flush_if_ready(self, batch_id: Optional[str]):
+        """
+        批次任务全部结束后发送聚合后的刮削事件。
+        """
+        if not batch_id:
+            return
+
+        with job_lock:
+            batch = self._batches.get(batch_id)
+            if (
+                    not batch
+                    or not batch.get("closed")
+                    or batch.get("pending")
+            ):
+                return
+            targets = list(batch.get("targets", {}).values())
+            self._batches.pop(batch_id, None)
+
+        for target in targets:
+            fileitem = target.get("fileitem")
+            if not fileitem:
+                continue
+            file_list = list(dict.fromkeys(target.get("files") or []))
+            self._chain.eventmanager.send_event(
+                EventType.MetadataScrape,
+                {
+                    "meta": target.get("meta"),
+                    "mediainfo": target.get("mediainfo"),
+                    "fileitem": fileitem,
+                    "file_list": file_list,
+                    "overwrite": target.get("overwrite", False),
+                },
+            )
+
+
 class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
     """
     文件整理处理链
@@ -922,8 +1065,8 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         self.retry_scheduler = FailedRetryScheduler()
         # 转移成功的文件清单
         self._success_target_files: Dict[str, List[str]] = {}
-        # 批次级刮削缓冲，避免同一批多文件入库重复触发目录刮削
-        self._scrape_batches: Dict[str, Dict[str, Any]] = {}
+        # 批次级刮削协调器（避免同一批多文件入库重复触发目录刮削；状态已移出本单例到协调器）
+        self._scrape_coordinator = ScrapeBatchCoordinator(chain=self)
         # 文件整理队列服务（队列 / 守护线程 / 计数器机器；契约态仍 read-through 本单例）
         self._service = TransferService(chain=self)
         # 启动整理线程
@@ -1366,132 +1509,20 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         )
 
     def __register_scrape_batch_task(self, task: TransferTask):
-        """
-        登记批次任务。刮削事件只在批次关闭且任务全部完成后统一发送。
-        """
-        if not task or not task.transfer_batch_id:
-            return
-        with job_lock:
-            batch = self._scrape_batches.setdefault(
-                task.transfer_batch_id,
-                {
-                    "pending": set(),
-                    "targets": {},
-                    "closed": False,
-                },
-            )
-            batch["pending"].add(task.fileitem.path)
+        """登记批次任务（委派刮削批次协调器）。"""
+        self._scrape_coordinator.register(task)
 
     def __close_scrape_batch(self, batch_id: Optional[str]):
-        """
-        标记批次不再接收新任务，并尝试发送已聚合的刮削事件。
-        """
-        if not batch_id:
-            return
-        with job_lock:
-            batch = self._scrape_batches.setdefault(
-                batch_id,
-                {
-                    "pending": set(),
-                    "targets": {},
-                    "closed": False,
-                },
-            )
-            batch["closed"] = True
-        self.__flush_scrape_batch_if_ready(batch_id)
+        """标记批次不再接收新任务（委派刮削批次协调器）。"""
+        self._scrape_coordinator.close(batch_id)
 
     def __record_scrape_target(self, task: TransferTask, transferinfo: TransferInfo):
-        """
-        记录批次内需要刮削的目标文件，按目标媒体根目录聚合。
-        """
-        if (
-                not task
-                or not task.transfer_batch_id
-                or not transferinfo
-                or not transferinfo.need_scrape
-                or not self.__is_media_file(task.fileitem)
-        ):
-            return
-
-        target_diritem = transferinfo.target_diritem
-        if not target_diritem:
-            return
-
-        target_files = transferinfo.file_list_new or []
-        target_key = (target_diritem.storage, target_diritem.path)
-        with job_lock:
-            batch = self._scrape_batches.setdefault(
-                task.transfer_batch_id,
-                {
-                    "pending": set(),
-                    "targets": {},
-                    "closed": False,
-                },
-            )
-            target = batch["targets"].setdefault(
-                target_key,
-                {
-                    "fileitem": target_diritem,
-                    "meta": task.meta,
-                    "mediainfo": task.mediainfo,
-                    "files": [],
-                    "overwrite": False,
-                },
-            )
-            if not target.get("meta"):
-                target["meta"] = task.meta
-            if not target.get("mediainfo"):
-                target["mediainfo"] = task.mediainfo
-            for target_file in target_files:
-                if target_file and target_file not in target["files"]:
-                    target["files"].append(target_file)
+        """记录批次内需刮削的目标文件（委派刮削批次协调器）。"""
+        self._scrape_coordinator.record_target(task, transferinfo)
 
     def __finish_scrape_batch_task(self, task: TransferTask):
-        """
-        标记批次内单个任务已结束。
-        """
-        if not task or not task.transfer_batch_id:
-            return
-        with job_lock:
-            batch = self._scrape_batches.get(task.transfer_batch_id)
-            if not batch:
-                return
-            batch["pending"].discard(task.fileitem.path)
-        self.__flush_scrape_batch_if_ready(task.transfer_batch_id)
-
-    def __flush_scrape_batch_if_ready(self, batch_id: Optional[str]):
-        """
-        批次任务全部结束后发送聚合后的刮削事件。
-        """
-        if not batch_id:
-            return
-
-        with job_lock:
-            batch = self._scrape_batches.get(batch_id)
-            if (
-                    not batch
-                    or not batch.get("closed")
-                    or batch.get("pending")
-            ):
-                return
-            targets = list(batch.get("targets", {}).values())
-            self._scrape_batches.pop(batch_id, None)
-
-        for target in targets:
-            fileitem = target.get("fileitem")
-            if not fileitem:
-                continue
-            file_list = list(dict.fromkeys(target.get("files") or []))
-            self.eventmanager.send_event(
-                EventType.MetadataScrape,
-                {
-                    "meta": target.get("meta"),
-                    "mediainfo": target.get("mediainfo"),
-                    "fileitem": fileitem,
-                    "file_list": file_list,
-                    "overwrite": target.get("overwrite", False),
-                },
-            )
+        """标记批次内单个任务已结束（委派刮削批次协调器）。"""
+        self._scrape_coordinator.finish(task)
 
     def remove_from_queue(self, fileitem: FileItem):
         """

--- a/tests/test_scrape_batch_coordinator.py
+++ b/tests/test_scrape_batch_coordinator.py
@@ -1,0 +1,119 @@
+"""S8 ⑥ 单元测试：ScrapeBatchCoordinator（批次级刮削事件协调器，从 TransferChain 抽出）。
+
+协调器把同一整理批次（``transfer_batch_id``）内多文件的刮削目标聚合，待批次关闭（``close``）
+且批内任务全部结束（``finish`` 把 pending 清空）后，统一发一次 ``MetadataScrape`` 事件——
+避免逐文件重复触发目录刮削。
+
+这些测试不构造真实 TransferChain（避 Singleton 跨测试泄漏 + jieba_next 环境块），而以
+SimpleNamespace 伪造 ``_chain``：协调器只 read-through 读取它的 ``eventmanager``（捕获事件）
+与 name-mangled ``_TransferChain__is_media_file``（判定是否媒体文件）。``_batches`` 是协调器
+自己的状态（原 ``TransferChain._scrape_batches``，非 p115 触达点）。
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from app.chain.transfer import ScrapeBatchCoordinator
+from app.schemas.types import EventType
+
+
+def _fake_chain(is_media: bool = True) -> SimpleNamespace:
+    """伪造 chain：仅暴露协调器 read-through 的两个面 —— eventmanager 与 __is_media_file。"""
+    return SimpleNamespace(
+        eventmanager=Mock(),
+        # 单前导下划线 → 不被 mangling，恰好命中协调器内 self._chain._TransferChain__is_media_file
+        _TransferChain__is_media_file=lambda fileitem: is_media,
+    )
+
+
+def _task(batch_id="b1", path="/dl/a.mkv") -> SimpleNamespace:
+    return SimpleNamespace(
+        transfer_batch_id=batch_id,
+        fileitem=SimpleNamespace(path=path),
+        meta=SimpleNamespace(title="Show"),
+        mediainfo=SimpleNamespace(title_year="Show (2026)"),
+    )
+
+
+def _transferinfo(target_path="/lib/Show", files=None, need_scrape=True) -> SimpleNamespace:
+    return SimpleNamespace(
+        need_scrape=need_scrape,
+        target_diritem=SimpleNamespace(storage="local", path=target_path),
+        file_list_new=files if files is not None else ["/lib/Show/a.mkv"],
+    )
+
+
+class ScrapeBatchCoordinatorTest(unittest.TestCase):
+    def test_aggregates_and_emits_once_after_batch_complete(self):
+        """register → record → close（pending 未空，不发） → finish（pending 空 → 唯一一次发送）。"""
+        chain = _fake_chain()
+        coord = ScrapeBatchCoordinator(chain=chain)
+        task = _task()
+
+        coord.register(task)
+        coord.record_target(task, _transferinfo(files=["/lib/Show/a.mkv"]))
+        coord.close(task.transfer_batch_id)
+        chain.eventmanager.send_event.assert_not_called()  # 批已关闭但任务未结束 → 不发
+
+        coord.finish(task)
+        chain.eventmanager.send_event.assert_called_once()
+        evt_type, payload = chain.eventmanager.send_event.call_args.args
+        self.assertEqual(EventType.MetadataScrape, evt_type)
+        self.assertEqual(["/lib/Show/a.mkv"], payload["file_list"])
+        self.assertIs(task.meta, payload["meta"])
+        self.assertIs(task.mediainfo, payload["mediainfo"])
+        self.assertEqual("/lib/Show", payload["fileitem"].path)
+        self.assertEqual({}, coord._batches)  # 发后批次被清出
+
+    def test_two_files_same_batch_aggregate_into_single_event(self):
+        """同批两任务、同目标根目录：聚合进一次事件，file_list 去重含两文件。"""
+        chain = _fake_chain()
+        coord = ScrapeBatchCoordinator(chain=chain)
+        t1 = _task(path="/dl/a.mkv")
+        t2 = _task(path="/dl/b.mkv")
+
+        coord.register(t1)
+        coord.register(t2)
+        coord.record_target(t1, _transferinfo(files=["/lib/Show/a.mkv"]))
+        coord.record_target(t2, _transferinfo(files=["/lib/Show/b.mkv", "/lib/Show/a.mkv"]))
+        coord.close("b1")
+        coord.finish(t1)
+        chain.eventmanager.send_event.assert_not_called()  # t2 仍 pending
+        coord.finish(t2)
+
+        chain.eventmanager.send_event.assert_called_once()
+        _, payload = chain.eventmanager.send_event.call_args.args
+        self.assertEqual(["/lib/Show/a.mkv", "/lib/Show/b.mkv"], payload["file_list"])  # 去重保序
+        self.assertEqual({}, coord._batches)
+
+    def test_no_batch_id_is_noop(self):
+        """无 transfer_batch_id：register/record/close/finish 全为空操作，不发事件、不留状态。"""
+        chain = _fake_chain()
+        coord = ScrapeBatchCoordinator(chain=chain)
+        task = _task(batch_id=None)
+
+        coord.register(task)
+        coord.record_target(task, _transferinfo())
+        coord.close(None)
+        coord.finish(task)
+
+        chain.eventmanager.send_event.assert_not_called()
+        self.assertEqual({}, coord._batches)
+
+    def test_non_media_file_records_no_target_so_no_event(self):
+        """非媒体文件：record_target 不登记目标 → 批次关闭并结束后无目标可发，但状态仍被清出。"""
+        chain = _fake_chain(is_media=False)
+        coord = ScrapeBatchCoordinator(chain=chain)
+        task = _task()
+
+        coord.register(task)
+        coord.record_target(task, _transferinfo())  # 非媒体 → 不登记
+        coord.close("b1")
+        coord.finish(task)
+
+        chain.eventmanager.send_event.assert_not_called()
+        self.assertEqual({}, coord._batches)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -932,7 +932,7 @@ class TransferJobManagerTest(unittest.TestCase):
             ],
             event_data["file_list"],
         )
-        self.assertEqual({}, chain._scrape_batches)
+        self.assertEqual({}, chain._scrape_coordinator._batches)
 
     def test_scrape_event_keeps_immediate_behavior_without_transfer_batch(self):
         chain = make_transfer_chain()

--- a/tests/test_transfer_queue_machinery.py
+++ b/tests/test_transfer_queue_machinery.py
@@ -60,10 +60,10 @@ class MakeQueueChainContractTest(unittest.TestCase):
         self.assertEqual(0, svc._total_num)
         # service read-through 回单例
         self.assertIs(chain, svc._chain)
-        # 契约态仍在 TransferChain（jobview/_success_target_files/_scrape_batches）
+        # 契约态仍在 TransferChain（jobview/_success_target_files）；刮削批次已抽到协调器
         self.assertIsInstance(chain.jobview, JobManager)
         self.assertEqual({}, chain._success_target_files)
-        self.assertEqual({}, chain._scrape_batches)
+        self.assertEqual({}, chain._scrape_coordinator._batches)
 
     def test_queue_put_get_roundtrip(self):
         """种入的 service._queue 是可用的 queue.Queue（put/get 往返）。"""

--- a/tests/transfer_fixtures.py
+++ b/tests/transfer_fixtures.py
@@ -12,7 +12,12 @@ from unittest.mock import Mock
 
 from app.core.config import settings
 from app.core.context import MediaInfo
-from app.chain.transfer import JobManager, TransferChain, TransferService
+from app.chain.transfer import (
+    JobManager,
+    ScrapeBatchCoordinator,
+    TransferChain,
+    TransferService,
+)
 from app.schemas import FileItem, TransferTask
 from app.schemas.types import MediaType
 
@@ -120,7 +125,7 @@ def make_transfer_chain() -> TransferChain:
         chain._media_exts + chain._audio_exts + chain._subtitle_exts
     )
     chain._success_target_files = {}
-    chain._scrape_batches = {}
+    chain._scrape_coordinator = ScrapeBatchCoordinator(chain=chain)
     return chain
 
 


### PR DESCRIPTION
## 背景

S8-step2 解耦 TransferChain god-class 的延续。批次级刮削事件聚合（同一整理批次内多文件合并为一次 `MetadataScrape` 事件，避免逐文件重复触发目录刮削）此前内嵌在 TransferChain，与下载/整理/队列职责纠缠。

## 改动

- 新增 `ScrapeBatchCoordinator` 类，组合于单例上 `chain._scrape_coordinator`。
- `_scrape_batches` 状态 + `register`/`close`/`record_target`/`finish`/`_flush_if_ready` 五法整体移入。
- TransferChain 上原四个 `__*_scrape_*` 方法降为薄委派，**所有调用点不变**。
- `__handle_transfer` 体保持字节不变；协调器经 `self._chain` read-through 读 `eventmanager` 与 `__is_media_file`（p115 契约面不动；`_scrape_batches` 非 p115 触达点，可安全移出）。

## 测试

- 新增 `tests/test_scrape_batch_coordinator.py`：4 个隔离单测（单文件聚合一次、同批两文件去重聚合、无 batch_id 空操作、非媒体文件不登记目标）。
- 夹具 `make_transfer_chain` / `make_queue_chain` 改种 `_scrape_coordinator`。
- 既有 `test_transfer_handle_carve`（__handle_transfer 契约锁）继续通过。

## 全量差分（零回归）

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| 基线 | 22 | 1092 | 19 | 31 |
| 含改动 | 22 | **1096** | 19 | 31 |

failed/errors/skipped 与基线完全一致，passed 仅 +4（4 个新协调器测试）。（22 failed / 31 errors 为 pre-existing jieba_next/agent 环境块，与本改动无关。）