### PR TITLE
refactor(S8 ⑦a): 就地分解 __default_callback（薄编排 + 5 个私有 helper）

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1142,236 +1142,25 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             self, task: TransferTask, transferinfo: TransferInfo, /
     ) -> Tuple[bool, str]:
         """
-        整理完成后处理
+        整理完成后处理（薄编排：分派成功/失败分支 → 批次完成通知 → 种子标记 → 移动模式清理）。
+
+        S8 ⑦a：原 god-method 就地分解为单下划线私有 helper（失败/成功分支、结果事件派发、
+        完成通知、移动清理），行为字节等价；``_success_target_files``/``jobview`` 等 p115 触点
+        与 mangled ``__is_*_file`` 等仍直接留在本类（零 read-through）。
         """
-        # 状态
-        ret_status = True
-        # 错误信息
-        ret_message = ""
-
-        def __notify():
-            """
-            完成时发送消息、移除任务等
-            """
-            # 更新文件数量
-            transferinfo.file_count = (
-                    self.jobview.count(task.mediainfo, task.meta.begin_season) or 1
-            )
-            # 更新文件大小
-            transferinfo.total_size = (
-                    self.jobview.size(task.mediainfo, task.meta.begin_season)
-                    or task.fileitem.size
-            )
-            # 发送通知，实时手动整理时不发
-            if transferinfo.need_notify and (task.background or not task.manual):
-                se_str = None
-                if task.mediainfo.type == MediaType.TV:
-                    season_episodes = self.jobview.season_episodes(
-                        task.mediainfo, task.meta.begin_season
-                    )
-                    if season_episodes:
-                        se_str = f"{task.meta.season} {StringUtils.format_ep(season_episodes)}"
-                    else:
-                        se_str = f"{task.meta.season}"
-                # 发送入库成功消息
-                self.send_transfer_message(
-                    meta=task.meta,
-                    mediainfo=task.mediainfo,
-                    transferinfo=transferinfo,
-                    season_episode=se_str,
-                    username=task.username,
-                )
-
         transferhis = TransferHistoryOper()
         target_dir_path = self.__get_transfer_target_dir_path(transferinfo)
 
-        # 转移失败
+        # 分派成功/失败分支
         if not transferinfo.success:
-            logger.warn(f"{task.fileitem.name} 入库失败：{transferinfo.message}")
-
-            # 新增转移失败历史记录
-            history = transferhis.add_fail(
-                fileitem=task.fileitem,
-                mode=transferinfo.transfer_type if transferinfo else "",
-                downloader=task.downloader,
-                download_hash=task.download_hash,
-                meta=task.meta,
-                mediainfo=task.mediainfo,
-                transferinfo=transferinfo,
+            ret_status, ret_message = self._handle_transfer_failure(
+                task, transferinfo, transferhis
             )
-
-            # 整理失败事件
-            if self.__is_media_file(task.fileitem):
-                # 主要媒体文件整理失败事件
-                self.eventmanager.send_event(
-                    EventType.TransferFailed,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-            elif self.__is_subtitle_file(task.fileitem):
-                # 字幕整理失败事件
-                self.eventmanager.send_event(
-                    EventType.SubtitleTransferFailed,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-            elif self.__is_audio_file(task.fileitem):
-                # 音频文件整理失败事件
-                self.eventmanager.send_event(
-                    EventType.AudioTransferFailed,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-
-            # 发送失败消息
-            self.post_message(
-                Notification(
-                    mtype=NotificationType.Manual,
-                    title=f"{task.mediainfo.title_year} {task.meta.season_episode} 入库失败！",
-                    text="\n".join(
-                        [
-                            f"原因：{transferinfo.message or '未知'}",
-                            (
-                                f"如果按钮不可用，可回复：\n```\n/redo {history.id}\n```"
-                                if history
-                                else ""
-                            ),
-                        ]
-                    ).strip(),
-                    image=task.mediainfo.get_message_image(),
-                    username=task.username,
-                    link=settings.MP_DOMAIN("#/history"),
-                    buttons=self.build_failed_transfer_buttons(
-                        history.id if history else None
-                    ),
-                )
-            )
-
-            # 设置任务失败
-            self.jobview.fail_task(task)
-
-            # AI智能体自动重试整理
-            if (
-                    history
-                    and settings.AI_AGENT_ENABLE
-                    and settings.AI_AGENT_RETRY_TRANSFER
-            ):
-                try:
-                    # 使用 download_hash 或源文件父目录作为分组键，
-                    # 同一批次（如同一个种子）的失败记录会被合并为一次agent调用
-                    group_key = (
-                        task.download_hash or str(task.fileitem.path).rsplit("/", 1)[0]
-                        if task.fileitem
-                        else ""
-                    )
-                    asyncio.run_coroutine_threadsafe(
-                        self.retry_scheduler.schedule_retry(
-                            history.id, group_key=group_key
-                        ),
-                        global_vars.loop,
-                    )
-                    logger.info(f"已触发AI智能体重试整理历史记录 #{history.id}")
-                except Exception as e:
-                    logger.error(f"触发AI智能体重试整理失败: {e}")
-
-            # 返回失败
-            ret_status = False
-            ret_message = transferinfo.message
-
         else:
-            # 转移成功
-            logger.info(f"{task.fileitem.name} 入库成功：{target_dir_path or ''}")
-
-            # 新增task转移成功历史记录
-            history = transferhis.add_success(
-                fileitem=task.fileitem,
-                mode=transferinfo.transfer_type if transferinfo else "",
-                downloader=task.downloader,
-                download_hash=task.download_hash,
-                meta=task.meta,
-                mediainfo=task.mediainfo,
-                transferinfo=transferinfo,
+            self._handle_transfer_success(
+                task, transferinfo, transferhis, target_dir_path
             )
-
-            # task整理完成事件
-            if self.__is_media_file(task.fileitem):
-                # 主要媒体文件整理完成事件
-                self.eventmanager.send_event(
-                    EventType.TransferComplete,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-            elif self.__is_subtitle_file(task.fileitem):
-                # 字幕整理完成事件
-                self.eventmanager.send_event(
-                    EventType.SubtitleTransferComplete,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-            elif self.__is_audio_file(task.fileitem):
-                # 音频文件整理完成事件
-                self.eventmanager.send_event(
-                    EventType.AudioTransferComplete,
-                    {
-                        "fileitem": task.fileitem,
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "transferinfo": transferinfo,
-                        "downloader": task.downloader,
-                        "download_hash": task.download_hash,
-                        "transfer_history_id": history.id if history else None,
-                    },
-                )
-
-            # task登记转移成功文件清单
-            target_files = transferinfo.file_list_new
-            if target_dir_path:
-                with job_lock:
-                    if self._success_target_files.get(target_dir_path):
-                        self._success_target_files[target_dir_path].extend(target_files)
-                    else:
-                        self._success_target_files[target_dir_path] = target_files
-
-            # 设置任务成功
-            self.jobview.finish_task(task)
-
-            # 登记批次级刮削目标
-            self.__record_scrape_target(task, transferinfo)
+            ret_status, ret_message = True, ""
 
         # 全部整理完成且有成功的任务时，发送消息和事件
         if self.jobview.is_finished(task):
@@ -1383,7 +1172,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     )
                 else:
                     transferinfo.file_list_new = transferinfo.file_list_new or []
-            __notify()
+            self._notify_transfer_complete(task, transferinfo)
             if not task.transfer_batch_id:
                 self.__send_metadata_scrape_event(task, transferinfo)
 
@@ -1392,37 +1181,238 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
 
         # 移动模式，全部成功时删除空目录和种子文件
         if transferinfo.transfer_type in ["move"]:
-            # 全部整理成功时
-            if self.jobview.is_success(task):
-                # 所有成功的业务
-                tasks = self.jobview.success_tasks(
-                    task.mediainfo, task.meta.begin_season
-                )
-                # 获取整理屏蔽词
-                transfer_exclude_words = SystemConfigOper().get(
-                    SystemConfigKey.TransferExcludeWords
-                )
-                processed_hashes = set()
-                for t in tasks:
-                    if t.download_hash and t.download_hash not in processed_hashes:
-                        # 检查该种子的所有任务（跨作业）是否都已成功
-                        if self.jobview.is_torrent_success(t.download_hash):
-                            processed_hashes.add(t.download_hash)
-                            if self._can_delete_torrent(
-                                    t.download_hash, t.downloader, transfer_exclude_words
-                            ):
-                                # 移除种子及文件
-                                if self.remove_torrents(
-                                        t.download_hash, downloader=t.downloader
-                                ):
-                                    logger.info(
-                                        f"移动模式删除种子成功：{t.download_hash}"
-                                    )
-                    if not t.download_hash and t.fileitem:
-                        # 删除剩余空目录
-                        StorageChain().delete_media_file(t.fileitem, delete_self=False)
+            self._cleanup_torrents_move_mode(task)
 
         return ret_status, ret_message
+
+    def _dispatch_transfer_result_event(
+            self,
+            task: TransferTask,
+            transferinfo: TransferInfo,
+            history,
+            *,
+            success: bool,
+    ):
+        """按文件类型（媒体/字幕/音频）派发整理完成或失败事件，载荷对外保持兼容。"""
+        if success:
+            media_evt, subtitle_evt, audio_evt = (
+                EventType.TransferComplete,
+                EventType.SubtitleTransferComplete,
+                EventType.AudioTransferComplete,
+            )
+        else:
+            media_evt, subtitle_evt, audio_evt = (
+                EventType.TransferFailed,
+                EventType.SubtitleTransferFailed,
+                EventType.AudioTransferFailed,
+            )
+
+        if self.__is_media_file(task.fileitem):
+            event_type = media_evt
+        elif self.__is_subtitle_file(task.fileitem):
+            event_type = subtitle_evt
+        elif self.__is_audio_file(task.fileitem):
+            event_type = audio_evt
+        else:
+            return
+
+        self.eventmanager.send_event(
+            event_type,
+            {
+                "fileitem": task.fileitem,
+                "meta": task.meta,
+                "mediainfo": task.mediainfo,
+                "transferinfo": transferinfo,
+                "downloader": task.downloader,
+                "download_hash": task.download_hash,
+                "transfer_history_id": history.id if history else None,
+            },
+        )
+
+    def _handle_transfer_failure(
+            self,
+            task: TransferTask,
+            transferinfo: TransferInfo,
+            transferhis: TransferHistoryOper,
+    ) -> Tuple[bool, str]:
+        """整理失败分支：记失败历史、派发失败事件、发失败消息、置任务失败、按需触发 AI 重试。"""
+        logger.warn(f"{task.fileitem.name} 入库失败：{transferinfo.message}")
+
+        # 新增转移失败历史记录
+        history = transferhis.add_fail(
+            fileitem=task.fileitem,
+            mode=transferinfo.transfer_type if transferinfo else "",
+            downloader=task.downloader,
+            download_hash=task.download_hash,
+            meta=task.meta,
+            mediainfo=task.mediainfo,
+            transferinfo=transferinfo,
+        )
+
+        # 整理失败事件
+        self._dispatch_transfer_result_event(
+            task, transferinfo, history, success=False
+        )
+
+        # 发送失败消息
+        self.post_message(
+            Notification(
+                mtype=NotificationType.Manual,
+                title=f"{task.mediainfo.title_year} {task.meta.season_episode} 入库失败！",
+                text="\n".join(
+                    [
+                        f"原因：{transferinfo.message or '未知'}",
+                        (
+                            f"如果按钮不可用，可回复：\n```\n/redo {history.id}\n```"
+                            if history
+                            else ""
+                        ),
+                    ]
+                ).strip(),
+                image=task.mediainfo.get_message_image(),
+                username=task.username,
+                link=settings.MP_DOMAIN("#/history"),
+                buttons=self.build_failed_transfer_buttons(
+                    history.id if history else None
+                ),
+            )
+        )
+
+        # 设置任务失败
+        self.jobview.fail_task(task)
+
+        # AI智能体自动重试整理
+        if (
+                history
+                and settings.AI_AGENT_ENABLE
+                and settings.AI_AGENT_RETRY_TRANSFER
+        ):
+            try:
+                # 使用 download_hash 或源文件父目录作为分组键，
+                # 同一批次（如同一个种子）的失败记录会被合并为一次agent调用
+                group_key = (
+                    task.download_hash or str(task.fileitem.path).rsplit("/", 1)[0]
+                    if task.fileitem
+                    else ""
+                )
+                asyncio.run_coroutine_threadsafe(
+                    self.retry_scheduler.schedule_retry(
+                        history.id, group_key=group_key
+                    ),
+                    global_vars.loop,
+                )
+                logger.info(f"已触发AI智能体重试整理历史记录 #{history.id}")
+            except Exception as e:
+                logger.error(f"触发AI智能体重试整理失败: {e}")
+
+        # 返回失败
+        return False, transferinfo.message
+
+    def _handle_transfer_success(
+            self,
+            task: TransferTask,
+            transferinfo: TransferInfo,
+            transferhis: TransferHistoryOper,
+            target_dir_path: Optional[str],
+    ):
+        """整理成功分支：记成功历史、派发完成事件、登记成功文件清单、置任务成功、登记刮削目标。"""
+        logger.info(f"{task.fileitem.name} 入库成功：{target_dir_path or ''}")
+
+        # 新增task转移成功历史记录
+        history = transferhis.add_success(
+            fileitem=task.fileitem,
+            mode=transferinfo.transfer_type if transferinfo else "",
+            downloader=task.downloader,
+            download_hash=task.download_hash,
+            meta=task.meta,
+            mediainfo=task.mediainfo,
+            transferinfo=transferinfo,
+        )
+
+        # task整理完成事件
+        self._dispatch_transfer_result_event(
+            task, transferinfo, history, success=True
+        )
+
+        # task登记转移成功文件清单
+        target_files = transferinfo.file_list_new
+        if target_dir_path:
+            with job_lock:
+                if self._success_target_files.get(target_dir_path):
+                    self._success_target_files[target_dir_path].extend(target_files)
+                else:
+                    self._success_target_files[target_dir_path] = target_files
+
+        # 设置任务成功
+        self.jobview.finish_task(task)
+
+        # 登记批次级刮削目标
+        self.__record_scrape_target(task, transferinfo)
+
+    def _notify_transfer_complete(
+            self, task: TransferTask, transferinfo: TransferInfo
+    ):
+        """批次全部整理完成时：更新文件数量/大小，并按需发送入库成功通知。"""
+        # 更新文件数量
+        transferinfo.file_count = (
+                self.jobview.count(task.mediainfo, task.meta.begin_season) or 1
+        )
+        # 更新文件大小
+        transferinfo.total_size = (
+                self.jobview.size(task.mediainfo, task.meta.begin_season)
+                or task.fileitem.size
+        )
+        # 发送通知，实时手动整理时不发
+        if transferinfo.need_notify and (task.background or not task.manual):
+            se_str = None
+            if task.mediainfo.type == MediaType.TV:
+                season_episodes = self.jobview.season_episodes(
+                    task.mediainfo, task.meta.begin_season
+                )
+                if season_episodes:
+                    se_str = f"{task.meta.season} {StringUtils.format_ep(season_episodes)}"
+                else:
+                    se_str = f"{task.meta.season}"
+            # 发送入库成功消息
+            self.send_transfer_message(
+                meta=task.meta,
+                mediainfo=task.mediainfo,
+                transferinfo=transferinfo,
+                season_episode=se_str,
+                username=task.username,
+            )
+
+    def _cleanup_torrents_move_mode(self, task: TransferTask):
+        """移动模式且全部整理成功时，删除已整理种子文件与剩余空目录。"""
+        if not self.jobview.is_success(task):
+            return
+        # 所有成功的业务
+        tasks = self.jobview.success_tasks(
+            task.mediainfo, task.meta.begin_season
+        )
+        # 获取整理屏蔽词
+        transfer_exclude_words = SystemConfigOper().get(
+            SystemConfigKey.TransferExcludeWords
+        )
+        processed_hashes = set()
+        for t in tasks:
+            if t.download_hash and t.download_hash not in processed_hashes:
+                # 检查该种子的所有任务（跨作业）是否都已成功
+                if self.jobview.is_torrent_success(t.download_hash):
+                    processed_hashes.add(t.download_hash)
+                    if self._can_delete_torrent(
+                            t.download_hash, t.downloader, transfer_exclude_words
+                    ):
+                        # 移除种子及文件
+                        if self.remove_torrents(
+                                t.download_hash, downloader=t.downloader
+                        ):
+                            logger.info(
+                                f"移动模式删除种子成功：{t.download_hash}"
+                            )
+            if not t.download_hash and t.fileitem:
+                # 删除剩余空目录
+                StorageChain().delete_media_file(t.fileitem, delete_self=False)
 
     def __get_transfer_target_dir_path(
             self, transferinfo: Optional[TransferInfo]

--- a/tests/test_transfer_default_callback_decompose.py
+++ b/tests/test_transfer_default_callback_decompose.py
@@ -1,0 +1,117 @@
+"""S8 ⑦a 单元测试：__default_callback 就地分解。
+
+把 god-method ``__default_callback`` 拆成薄编排 + 5 个单下划线私有 helper（失败/成功分支、
+结果事件派发、完成通知、移动清理），行为字节等价。本套覆盖唯一含**新逻辑**的点——
+``_dispatch_transfer_result_event``（把原成功/失败两处逐字重复的「媒体/字幕/音频」三路事件
+派发合并为一个按 success 参数选 EventType 三元组的 helper），并守卫分解后的结构契约：
+``__default_callback`` 仍是 name-mangled 私有方法（调用点 ``self.__default_callback`` 仍解析），
+5 个 helper 存在。
+
+app/chain/transfer.py 本身 agent/jieba-free，可直接 import。
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from app.chain.transfer import TransferChain
+from app.schemas.types import EventType
+from tests.transfer_fixtures import make_fileitem, make_transfer_chain
+
+
+def _task(fileitem) -> SimpleNamespace:
+    return SimpleNamespace(
+        fileitem=fileitem,
+        meta=SimpleNamespace(title="Show"),
+        mediainfo=SimpleNamespace(title_year="Show (2026)"),
+        downloader="qb",
+        download_hash="hash123",
+    )
+
+
+class DispatchTransferResultEventTest(unittest.TestCase):
+    """_dispatch_transfer_result_event：success × 文件类型 → 正确 EventType + 兼容载荷。"""
+
+    def setUp(self):
+        self.chain = make_transfer_chain()
+        self.chain.eventmanager = Mock()
+        self.transferinfo = SimpleNamespace(name="ti")
+        self.history = SimpleNamespace(id=99)
+
+    def _dispatch(self, fileitem, *, success):
+        self.chain._dispatch_transfer_result_event(
+            _task(fileitem), self.transferinfo, self.history, success=success
+        )
+        return self.chain.eventmanager.send_event
+
+    def test_success_media_emits_transfer_complete_with_payload(self):
+        send = self._dispatch(make_fileitem("/dl/a.mkv"), success=True)
+        send.assert_called_once()
+        evt, payload = send.call_args.args
+        self.assertEqual(EventType.TransferComplete, evt)
+        self.assertEqual("/dl/a.mkv", payload["fileitem"].path)
+        self.assertIs(self.transferinfo, payload["transferinfo"])
+        self.assertEqual("qb", payload["downloader"])
+        self.assertEqual("hash123", payload["download_hash"])
+        self.assertEqual(99, payload["transfer_history_id"])
+
+    def test_failure_media_emits_transfer_failed(self):
+        send = self._dispatch(make_fileitem("/dl/a.mkv"), success=False)
+        self.assertEqual(EventType.TransferFailed, send.call_args.args[0])
+
+    def test_subtitle_maps_to_subtitle_events(self):
+        self.assertEqual(
+            EventType.SubtitleTransferComplete,
+            self._dispatch(make_fileitem("/dl/a.srt"), success=True).call_args.args[0],
+        )
+        self.chain.eventmanager.send_event.reset_mock()
+        self.assertEqual(
+            EventType.SubtitleTransferFailed,
+            self._dispatch(make_fileitem("/dl/a.srt"), success=False).call_args.args[0],
+        )
+
+    def test_audio_maps_to_audio_events(self):
+        self.assertEqual(
+            EventType.AudioTransferComplete,
+            self._dispatch(make_fileitem("/dl/a.aac"), success=True).call_args.args[0],
+        )
+        self.chain.eventmanager.send_event.reset_mock()
+        self.assertEqual(
+            EventType.AudioTransferFailed,
+            self._dispatch(make_fileitem("/dl/a.aac"), success=False).call_args.args[0],
+        )
+
+    def test_unclassified_file_emits_no_event(self):
+        """非媒体/字幕/音频（.txt）：原三路 if/elif/elif 无 else → 不发事件，行为保持。"""
+        self._dispatch(make_fileitem("/dl/note.txt"), success=True)
+        self._dispatch(make_fileitem("/dl/note.txt"), success=False)
+        self.chain.eventmanager.send_event.assert_not_called()
+
+    def test_history_none_yields_null_history_id(self):
+        self.chain._dispatch_transfer_result_event(
+            _task(make_fileitem("/dl/a.mkv")), self.transferinfo, None, success=True
+        )
+        self.assertIsNone(
+            self.chain.eventmanager.send_event.call_args.args[1]["transfer_history_id"]
+        )
+
+
+class DefaultCallbackDecomposeContractTest(unittest.TestCase):
+    """分解后的结构契约：编排入口仍 mangled（调用点解析不变）+ 5 个 helper 存在。"""
+
+    def test_orchestrator_still_name_mangled(self):
+        # put_to_queue / do_transfer 以 self.__default_callback 取引用 → 须保留 mangled 名
+        self.assertTrue(hasattr(TransferChain, "_TransferChain__default_callback"))
+
+    def test_five_helpers_exist(self):
+        for name in (
+                "_dispatch_transfer_result_event",
+                "_handle_transfer_failure",
+                "_handle_transfer_success",
+                "_notify_transfer_complete",
+                "_cleanup_torrents_move_mode",
+        ):
+            self.assertTrue(callable(getattr(TransferChain, name, None)), name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

S8-step2 解耦 TransferChain god-class 的延续（⑦a）。`__default_callback`（整理完成后处理，~285 行）此前是单个 god-method：失败/成功分支、三路事件派发（两处逐字重复）、完成通知、移动模式清理全揉在一起。

经评估，`__default_callback` 触达 chain 的面非常多（`__is_*_file`×3、`__mark_torrent_completed_if_done` 等 4 个 mangled 方法广用须留 chain；`jobview`、`_success_target_files` 是 **p115 直接深入的触点**铁定留 chain）——若一步抽成独立类，read-through 面过大。故先做**就地分解**（⑦a），是否进一步迁出独立类（⑦b）下一步再定。

## 改动

把 `__default_callback` 拆为薄编排入口 + 5 个单下划线私有 helper，**行为字节等价、零 read-through**：

- `_handle_transfer_failure` / `_handle_transfer_success`：失败/成功分支
- `_dispatch_transfer_result_event(*, success)`：**合并** 原成功/失败两处逐字重复的「媒体/字幕/音频」三路事件派发（按 `success` 选 `EventType` 三元组，payload 7 键不变，非三类文件不发事件）
- `_notify_transfer_complete`：原 `__notify` 闭包外提
- `_cleanup_torrents_move_mode`：移动模式清理（early-return 替嵌套 `if`）

`__default_callback` 仍 name-mangled（`put_to_queue`/`do_transfer` 以 `self.__default_callback` 取引用不变）；`_success_target_files`/`jobview`/`__is_*_file` 等仍直接 `self.` 访问、全留 `TransferChain`。p115 复刻的成功分支顺序保持不变。

## 测试

- 新增 `tests/test_transfer_default_callback_decompose.py`（8 例）：`_dispatch_transfer_result_event` 的 success×文件类型 6 组映射 + 非三类不发 + `history=None` + 分解结构契约（mangled 名 + 5 helper 存在）。
- 既有 `test_transfer_handle_integration.py`（端到端驱动 callback）、carve 契约、scrape coordinator 等继续通过。

## 全量差分（零回归）

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| 基线 | 22 | 1096 | 19 | 31 |
| 含改动 | 22 | **1104** | 19 | 31 |

failed/errors/skipped 与基线完全一致，passed 仅 +8（8 个新测）。（22 failed / 31 errors 为 pre-existing jieba_next/agent 环境块。）

## 审查

`code-reviewer` 子代理对 diff 做 6 约束行为等价对抗审查 → **APPROVE，0 issue**（顺序逐字保持 / ret 流一致 / 事件映射+载荷无漂移 / p115 触点全留 chain / mangling 正确 / move 清理 early-return 等价）。