### PR TITLE
feat(Q1 S1): ModuleManager 外部模块二级注册核心（运行期线程安全）

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,5 +1,6 @@
+import threading
 import traceback
-from typing import Generator, Optional, Tuple, Any, Union, List
+from typing import Generator, Optional, Tuple, Any, Union, List, Dict
 
 from app.core.config import settings
 from app.core.event import eventmanager
@@ -24,40 +25,48 @@ class ModuleManager(metaclass=Singleton):
         self._modules: dict = {}
         # 运行态模块列表
         self._running_modules: dict = {}
+        # 外部(插件)注册的模块类，按 owner 记账：{owner: [module_cls, ...]}
+        # 作为与静态扫描并列的二级源，存类对象以便 reload 全量重扫后重放，挺过重扫不丢失。
+        self._external_classes: Dict[str, List[type]] = {}
+        # 保护 _modules/_running_modules/_external_classes 运行期并发读写的可重入锁
+        self._lock = threading.RLock()
         self.load_modules()
 
     def load_modules(self):
         """
         加载所有模块
         """
-        # 扫描模块目录
-        modules = ModuleHelper.load(
-            "app.modules",
-            filter_func=lambda _, obj: hasattr(obj, 'init_module') and hasattr(obj, 'init_setting')
-        )
-        self._running_modules = {}
-        self._modules = {}
-        for module in modules:
-            module_id = module.__name__
-            self._modules[module_id] = module
-            try:
-                # 生成实例
-                _module = module()
-                # 初始化模块
-                if self.check_setting(_module.init_setting()):
-                    # 通过模板开关控制加载
-                    _module.init_module()
-                    self._running_modules[module_id] = _module
-                    logger.debug(f"Moudle Loaded：{module_id}")
-            except Exception as err:
-                logger.error(f"Load Moudle Error：{module_id}，{str(err)} - {traceback.format_exc()}", exc_info=True)
+        with self._lock:
+            # 扫描模块目录
+            modules = ModuleHelper.load(
+                "app.modules",
+                filter_func=lambda _, obj: hasattr(obj, 'init_module') and hasattr(obj, 'init_setting')
+            )
+            self._running_modules = {}
+            self._modules = {}
+            for module in modules:
+                module_id = module.__name__
+                self._modules[module_id] = module
+                try:
+                    # 生成实例
+                    _module = module()
+                    # 初始化模块
+                    if self.check_setting(_module.init_setting()):
+                        # 通过模板开关控制加载
+                        _module.init_module()
+                        self._running_modules[module_id] = _module
+                        logger.debug(f"Moudle Loaded：{module_id}")
+                except Exception as err:
+                    logger.error(f"Load Moudle Error：{module_id}，{str(err)} - {traceback.format_exc()}", exc_info=True)
+            # 重放外部(插件)注册的模块，使其挺过 reload 的全量重扫
+            self._replay_external_modules()
 
     def stop(self):
         """
         停止所有模块
         """
         logger.info("正在停止所有模块...")
-        for module_id, module in self._running_modules.items():
+        for module_id, module in list(self._running_modules.items()):
             if hasattr(module, "stop"):
                 try:
                     module.stop()
@@ -122,7 +131,7 @@ class ModuleManager(metaclass=Singleton):
         """
         if not self._running_modules:
             return
-        for _, module in self._running_modules.items():
+        for _, module in list(self._running_modules.items()):
             if hasattr(module, method) \
                     and ObjectUtils.check_method(getattr(module, method)):
                 yield module
@@ -133,7 +142,7 @@ class ModuleManager(metaclass=Singleton):
         """
         if not self._running_modules:
             return
-        for _, module in self._running_modules.items():
+        for _, module in list(self._running_modules.items()):
             if hasattr(module, 'get_type') \
                     and module.get_type() == module_type:
                 yield module
@@ -144,7 +153,7 @@ class ModuleManager(metaclass=Singleton):
         """
         if not self._running_modules:
             return
-        for _, module in self._running_modules.items():
+        for _, module in list(self._running_modules.items()):
             if hasattr(module, 'get_subtype') \
                     and module.get_subtype() == module_subtype:
                 yield module
@@ -170,3 +179,112 @@ class ModuleManager(metaclass=Singleton):
         获取模块id列表
         """
         return list(self._modules.keys())
+
+    # ---------------------------------------------------------------------
+    # 外部(插件)模块二级注册：与静态扫描并列的来源。外部模块经 register 进入
+    # _running_modules 后，被 chain 分发层(仅按 method 名 + get_priority 取模块)
+    # 无差别接管，无需改动分发链。运行期线程安全，支持热插拔。
+    # ---------------------------------------------------------------------
+
+    def register_module(self, module_cls: type, owner: str) -> bool:
+        """
+        注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，
+        成功后进入 _running_modules 即可被分发。owner 用于按来源精确回收(unregister)。
+
+        :param module_cls: 模块类，需实现 _ModuleBase 契约(init_module/init_setting/stop/test 等)
+        :param owner: 注册来源标识(通常为 plugin_id)，用于精确卸载
+        :return: 是否被接受进注册表(命名冲突或非法入参返回 False；
+                 被接受但因开关关闭/初始化异常未上线仍返回 True，运行态另由分发查询体现)
+        """
+        if not owner or not isinstance(module_cls, type):
+            return False
+        module_id = module_cls.__name__
+        with self._lock:
+            # 命名冲突：已存在且不归属本 owner(内建或他插件) → 拒绝，避免遮蔽
+            existing_owner = self._find_owner(module_id)
+            if module_id in self._modules and existing_owner != owner:
+                logger.warning(
+                    f"模块注册冲突：{module_id} 已存在(owner={existing_owner or 'builtin'})，"
+                    f"拒绝来自 {owner} 的注册")
+                return False
+            # 记账(幂等：同 owner 重复注册不产生重复记录)
+            owner_classes = self._external_classes.setdefault(owner, [])
+            if module_cls not in owner_classes:
+                owner_classes.append(module_cls)
+            # 激活(进入 _modules/_running_modules)
+            self._activate_module(module_cls, owner)
+            return True
+
+    def unregister_modules(self, owner: str) -> List[str]:
+        """
+        卸载某来源(owner)注册的全部外部模块，停止其运行实例并从注册表移除，无僵尸残留。
+
+        :param owner: 注册来源标识
+        :return: 被移除的 module_id 列表
+        """
+        if not owner:
+            return []
+        removed: List[str] = []
+        with self._lock:
+            classes = self._external_classes.pop(owner, [])
+            for module_cls in classes:
+                module_id = module_cls.__name__
+                running = self._running_modules.pop(module_id, None)
+                if running is not None and hasattr(running, "stop"):
+                    try:
+                        running.stop()
+                    except Exception as err:
+                        logger.error(f"Stop Module Error：{module_id}，{str(err)} - {traceback.format_exc()}",
+                                     exc_info=True)
+                self._modules.pop(module_id, None)
+                removed.append(module_id)
+        return removed
+
+    def get_external_module_ids(self, owner: Optional[str] = None) -> List[str]:
+        """
+        获取外部(插件)注册的模块id列表。owner 为空时返回全部来源。
+        """
+        with self._lock:
+            if owner is not None:
+                return [cls.__name__ for cls in self._external_classes.get(owner, [])]
+            return [cls.__name__
+                    for classes in self._external_classes.values()
+                    for cls in classes]
+
+    def _activate_module(self, module_cls: type, owner: Optional[str] = None) -> bool:
+        """
+        实例化并初始化一个模块类，写入 _modules，开关通过则写入 _running_modules。
+        异常被捕获并隔离，不影响其它模块。调用方需持有 self._lock。
+
+        :return: 是否成功进入运行态
+        """
+        module_id = module_cls.__name__
+        self._modules[module_id] = module_cls
+        try:
+            _module = module_cls()
+            if self.check_setting(_module.init_setting()):
+                _module.init_module()
+                self._running_modules[module_id] = _module
+                logger.debug(f"Module Loaded：{module_id}" + (f"（owner={owner}）" if owner else ""))
+                return True
+            return False
+        except Exception as err:
+            logger.error(f"Load Module Error：{module_id}，{str(err)} - {traceback.format_exc()}", exc_info=True)
+            return False
+
+    def _replay_external_modules(self):
+        """
+        重放外部注册的模块类(reload 全量重扫后调用)。调用方需持有 self._lock。
+        """
+        for owner, classes in list(self._external_classes.items()):
+            for module_cls in classes:
+                self._activate_module(module_cls, owner)
+
+    def _find_owner(self, module_id: str) -> Optional[str]:
+        """
+        查找某 module_id 归属的外部 owner，未注册或为内建模块返回 None。调用方需持有 self._lock。
+        """
+        for owner, classes in self._external_classes.items():
+            if any(cls.__name__ == module_id for cls in classes):
+                return owner
+        return None

--- a/tests/test_module_external_registration.py
+++ b/tests/test_module_external_registration.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S1 回归测试：ModuleManager 外部(插件)模块二级注册核心。
+
+验证：
+  1. register_module 后，外部模块进入 _modules/_running_modules，且能被
+     get_running_modules(method)/get_running_type_modules/get_running_subtype_module 分发枚举到；
+  2. reload() 后外部模块仍在（类记账 + 重放，挺过全量重扫）；
+  3. unregister_modules(owner) 后外部模块下线，无僵尸；
+  4. 外部类 init_module 抛异常被隔离，不影响内建模块加载；
+  5. 同 owner 重复注册幂等（不产生重复记账）；
+  6. 命名冲突（module_id 已存在且非本 owner）被拒绝，原模块完好；
+  7. 运行期并发 register/unregister 与分发迭代不抛 "dictionary changed size"。
+"""
+import threading
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType, DownloaderType
+
+
+class _DummyDownloaderModule(_ModuleBase):
+    """最小可分发的外部下载器模块（无开关，始终加载）"""
+
+    inited = False
+    stopped = False
+
+    def init_module(self) -> None:
+        type(self).inited = True
+
+    def init_setting(self):
+        return None  # 无开关 → check_setting 返回 True，始终加载
+
+    def stop(self) -> None:
+        type(self).stopped = True
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_name() -> str:
+        return "DummyDownloader"
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        return DownloaderType.Qbittorrent
+
+    @staticmethod
+    def get_priority() -> int:
+        return 99
+
+    def download(self, *args, **kwargs):
+        return "dummy-download"
+
+
+class _BrokenModule(_ModuleBase):
+    """init_module 抛异常的外部模块，用于验证隔离性"""
+
+    def init_module(self) -> None:
+        raise RuntimeError("boom")
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+
+_OWNER = "test.plugin.q1s1"
+_OWNER2 = "test.plugin.q1s1.other"
+
+
+class ModuleExternalRegistrationTest(TestCase):
+
+    def setUp(self):
+        self.mm = ModuleManager()
+        _DummyDownloaderModule.inited = False
+        _DummyDownloaderModule.stopped = False
+
+    def tearDown(self):
+        # 清理本测试注册的外部模块，避免污染共享单例
+        self.mm.unregister_modules(_OWNER)
+        self.mm.unregister_modules(_OWNER2)
+
+    def test_register_enters_modules_and_dispatch(self):
+        ok = self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        self.assertTrue(ok)
+        # 进入 _modules 与运行态
+        self.assertIn("_DummyDownloaderModule", self.mm.get_module_ids())
+        self.assertIn("_DummyDownloaderModule", self.mm.get_external_module_ids(_OWNER))
+        self.assertTrue(_DummyDownloaderModule.inited)
+        # 按方法名分发可枚举到
+        method_modules = list(self.mm.get_running_modules("download"))
+        self.assertIn(_DummyDownloaderModule, [type(m) for m in method_modules])
+        # 按类型分发
+        type_modules = list(self.mm.get_running_type_modules(ModuleType.Downloader))
+        self.assertIn(_DummyDownloaderModule, [type(m) for m in type_modules])
+        # 按子类型分发（与内建 Qbittorrent 共存，断言 dummy 在其中）
+        subtype_modules = list(self.mm.get_running_subtype_module(DownloaderType.Qbittorrent))
+        self.assertIn(_DummyDownloaderModule, [type(m) for m in subtype_modules])
+
+    def test_reload_replays_external_modules(self):
+        self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        self.assertIn("_DummyDownloaderModule", self.mm.get_module_ids())
+        # reload 会全量重扫 app.modules 并重置 _modules/_running_modules
+        self.mm.reload()
+        # 外部模块应被重放回来
+        self.assertIn("_DummyDownloaderModule", self.mm.get_module_ids())
+        running = [type(m) for m in self.mm.get_running_modules("download")]
+        self.assertIn(_DummyDownloaderModule, running)
+
+    def test_unregister_removes_module(self):
+        self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        removed = self.mm.unregister_modules(_OWNER)
+        self.assertIn("_DummyDownloaderModule", removed)
+        self.assertNotIn("_DummyDownloaderModule", self.mm.get_module_ids())
+        self.assertEqual(self.mm.get_external_module_ids(_OWNER), [])
+        self.assertTrue(_DummyDownloaderModule.stopped)
+        running = [type(m) for m in self.mm.get_running_modules("download")]
+        self.assertNotIn(_DummyDownloaderModule, running)
+
+    def test_broken_module_isolated(self):
+        builtin_before = set(self.mm.get_module_ids())
+        ok = self.mm.register_module(_BrokenModule, owner=_OWNER)
+        # 接受进注册表（记账成功），但未进入运行态
+        self.assertTrue(ok)
+        running = [type(m) for m in self.mm.get_running_modules("download")]
+        self.assertNotIn(_BrokenModule, running)
+        # 内建模块不受影响
+        self.assertTrue(builtin_before.issubset(set(self.mm.get_module_ids())))
+
+    def test_idempotent_register(self):
+        self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        self.assertEqual(self.mm.get_external_module_ids(_OWNER).count("_DummyDownloaderModule"), 1)
+
+    def test_collision_rejected(self):
+        self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+        # 另一 owner 试图注册同名 module_id → 拒绝
+        ok = self.mm.register_module(_DummyDownloaderModule, owner=_OWNER2)
+        self.assertFalse(ok)
+        # 原归属不变
+        self.assertIn("_DummyDownloaderModule", self.mm.get_external_module_ids(_OWNER))
+        self.assertEqual(self.mm.get_external_module_ids(_OWNER2), [])
+
+    def test_concurrent_register_unregister_no_race(self):
+        errors = []
+
+        def churn():
+            try:
+                for _ in range(100):
+                    self.mm.register_module(_DummyDownloaderModule, owner=_OWNER)
+                    self.mm.unregister_modules(_OWNER)
+            except Exception as err:  # pragma: no cover - 只在出错时记录
+                errors.append(err)
+
+        def iterate():
+            try:
+                for _ in range(100):
+                    list(self.mm.get_running_modules("download"))
+                    list(self.mm.get_running_type_modules(ModuleType.Downloader))
+            except Exception as err:  # pragma: no cover
+                errors.append(err)
+
+        threads = [threading.Thread(target=churn), threading.Thread(target=iterate)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [], f"并发读写抛异常：{errors}")


### PR DESCRIPTION
## 背景 / Q1 路线图

让 `app/modules` 模块层对插件**开放注册**，消除「硬编码只扫 `app.modules` + 封闭 Enum 子类型 + `get_module` 只能替换」的限制（p115 靠 monkey-patch 的根因）。

本 PR 是 Q1 的 **S1（共 S1→S6）**：打通后端二级注册骨架。范围决策已确认：运行期动态上下线 / 覆盖下载器+存储器+媒体服务器+消息渠道 / 配置 MVP。

## 关键支点（已代码核查）

`app/chain/__init__.py` 的 `__execute_system_modules` 只依赖 `modulemanager.get_running_modules(method)` + `get_priority()` 排序，**完全不碰 Enum**。所以「外部模块只要进了 `_running_modules`，就自动获得分发能力」——分发链一行都不用改。

## 改动

`ModuleManager` 增加与静态扫描并列的「外部模块二级源」：

- 新增 `register_module(cls, owner)` / `unregister_modules(owner)` / `get_external_module_ids(owner)` 三个公共方法，复用现成 `check_setting/init_setting/init_module` 流程
- `_external_classes` 按 `owner` 记账；`load_modules()` 末尾 `_replay_external_modules()`，使外部模块挺过 `reload()` 全量重扫不丢失
- **运行期并发安全**：`RLock` 保护 `register/unregister/load_modules`；三个分发生成器与 `stop()` 改为快照迭代，避免 `dictionary changed size during iteration`
- 命名冲突（`module_id` 已存在且非本 owner）拒绝；同 owner 幂等；外部类初始化异常被隔离，不波及内建
- **内建 32 模块 `load_modules` 主路径零行为变更**

## 测试

- 新增 `tests/test_module_external_registration.py` 7 例：分发(method/type/subtype) / reload 重放 / 卸载无僵尸 / 异常隔离 / 幂等 / 冲突拒绝 / 并发读写无 race —— 全绿
- module / plugin / s6 / system 相关 46 例回归零破坏

## 后续

- S2 子类型字符串化（`get_subtype_id()`，纯加法）
- S3 插件 SPI 钩子 `provides_modules/provides_storages`
- S4 PluginManager 生命周期接线（运行期 register/unregister + 加锁）
- S5 存储器开放（filemanager 二级源）
- S6 消息渠道能力矩阵开放注册（ChannelCapabilityManager）