### PR TITLE
feat(Q1 S2): 子类型字符串化（get_subtype_id，纯加法兼容）

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,5 +1,6 @@
 import threading
 import traceback
+from enum import Enum
 from typing import Generator, Optional, Tuple, Any, Union, List, Dict
 
 from app.core.config import settings
@@ -17,8 +18,8 @@ class ModuleManager(metaclass=Singleton):
     模块管理器
     """
 
-    # 子模块类型集合
-    SubType = Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType]
+    # 子模块类型集合（兼容传入纯字符串子类型标识）
+    SubType = Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType, str]
 
     def __init__(self):
         # 模块列表
@@ -147,15 +148,37 @@ class ModuleManager(metaclass=Singleton):
                     and module.get_type() == module_type:
                 yield module
 
+    @staticmethod
+    def _coerce_subtype(value) -> Optional[str]:
+        """
+        将子类型（Enum 或字符串）归一化为字符串标识，None 原样返回 None。
+        使内建 Enum 子类型与插件纯字符串子类型可统一比较。
+        """
+        if value is None:
+            return None
+        if isinstance(value, Enum):
+            return str(value.value)
+        return str(value)
+
     def get_running_subtype_module(self, module_subtype: SubType) -> Generator:
         """
-        获取指定子类型的模块
+        获取指定子类型的模块。按字符串标识相等匹配，同时兼容 Enum 与纯字符串子类型：
+        查询参数与模块的 get_subtype_id() 均归一化为字符串后比较，使插件无需扩展封闭枚举
+        即可新增子类型。
         """
         if not self._running_modules:
             return
+        target = self._coerce_subtype(module_subtype)
+        if target is None:
+            return
         for _, module in list(self._running_modules.items()):
-            if hasattr(module, 'get_subtype') \
-                    and module.get_subtype() == module_subtype:
+            getter = getattr(module, 'get_subtype_id', None)
+            if getter is not None:
+                value = self._coerce_subtype(getter())
+            else:
+                legacy = getattr(module, 'get_subtype', None)
+                value = self._coerce_subtype(legacy()) if legacy else None
+            if value is not None and value == target:
                 yield module
 
     def get_module(self, module_id: str) -> Any:

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, ABCMeta
+from enum import Enum
 from typing import Generic, Tuple, Union, TypeVar, Type, Dict, Optional, Callable
 from pathlib import Path
 
@@ -51,11 +52,22 @@ class _ModuleBase(ConfigReloadMixin, metaclass=ABCMeta):
         pass
 
     @staticmethod
-    def get_subtype() -> Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType]:
+    def get_subtype() -> Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType, str]:
         """
         获取模块子类型（下载器、媒体服务器、消息通道、存储类型、其他杂项模块类型）
         """
         pass
+
+    def get_subtype_id(self) -> str:
+        """
+        获取模块子类型的字符串标识。默认取 get_subtype().value，使内建模块零改动即具备字符串标识；
+        插件可重写此方法返回封闭枚举之外的任意字符串（如 "aria2"）以新增子类型，
+        无需改动 schemas/types.py 中的封闭枚举。get_subtype() 返回 None 时回退为空串。
+        """
+        subtype = self.get_subtype()
+        if subtype is None:
+            return ""
+        return str(subtype.value) if isinstance(subtype, Enum) else str(subtype)
 
     @staticmethod
     def get_priority() -> int:

--- a/tests/test_module_subtype_id.py
+++ b/tests/test_module_subtype_id.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S2 回归测试：子类型字符串化（get_subtype_id + get_running_subtype_module 字符串相等）。
+
+验证：
+  1. _ModuleBase.get_subtype_id() 默认实现 == get_subtype().value（内建模块零改动获得字符串标识）；
+  2. get_subtype() 返回 None 时 get_subtype_id() 返回 ""（兜底不崩）；
+  3. get_running_subtype_module 既能用 Enum 查询、也能用等价字符串查询命中（向后兼容）；
+  4. 插件可仅重写 get_subtype_id() 返回封闭枚举外的纯字符串（如 "aria2"），被字符串查询命中。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType, DownloaderType
+
+
+class _EnumSubModule(_ModuleBase):
+    """子类型用内建 Enum，不重写 get_subtype_id（走默认 .value）"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        return DownloaderType.Transmission
+
+    @staticmethod
+    def get_priority() -> int:
+        return 99
+
+    def download(self, *args, **kwargs):
+        return "enum-sub"
+
+
+class _StrSubModule(_ModuleBase):
+    """插件式：重写 get_subtype_id 返回封闭枚举外的纯字符串 'aria2'"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+    def get_subtype_id(self) -> str:
+        return "aria2"
+
+    @staticmethod
+    def get_priority() -> int:
+        return 99
+
+    def download(self, *args, **kwargs):
+        return "str-sub"
+
+
+class _NoneSubModule(_ModuleBase):
+    """get_subtype 返回 None（默认），验证 get_subtype_id 兜底返回 ''"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Other
+
+
+_OWNER = "test.plugin.q1s2"
+
+
+class ModuleSubtypeIdTest(TestCase):
+
+    def setUp(self):
+        self.mm = ModuleManager()
+
+    def tearDown(self):
+        self.mm.unregister_modules(_OWNER)
+
+    def test_default_subtype_id_equals_enum_value(self):
+        self.assertEqual(_EnumSubModule().get_subtype_id(), DownloaderType.Transmission.value)
+        self.assertEqual(_EnumSubModule().get_subtype_id(), "Transmission")
+
+    def test_none_subtype_id_is_empty(self):
+        self.assertEqual(_NoneSubModule().get_subtype_id(), "")
+
+    def test_enum_and_string_query_equivalent(self):
+        self.mm.register_module(_EnumSubModule, owner=_OWNER)
+        by_enum = [type(m) for m in self.mm.get_running_subtype_module(DownloaderType.Transmission)]
+        by_str = [type(m) for m in self.mm.get_running_subtype_module("Transmission")]
+        self.assertIn(_EnumSubModule, by_enum)
+        self.assertIn(_EnumSubModule, by_str)
+
+    def test_plugin_string_subtype_dispatch(self):
+        self.mm.register_module(_StrSubModule, owner=_OWNER)
+        by_str = [type(m) for m in self.mm.get_running_subtype_module("aria2")]
+        self.assertIn(_StrSubModule, by_str)
+        # 不会被无关子类型查询误命中
+        by_other = [type(m) for m in self.mm.get_running_subtype_module(DownloaderType.Transmission)]
+        self.assertNotIn(_StrSubModule, by_other)


### PR DESCRIPTION
## Q1 路线图 · S2（栈式叠在 #50 之上）

> base 为 S1 分支（`feat/q1-s1-module-registry-core`），#50 合并后 GitHub 会自动改基到 `v3-python`。

让插件**无需扩展封闭枚举**即可新增子类型。

## 关键发现（代码核查）

`get_running_subtype_module`（`app/core/module.py`）是**全仓唯一**消费子类型 Enum identity 的点，且在 `app/` 内**零调用方**（仅测试引用）。所以「封闭 Enum 子类型」问题被严重高估——用最小加法即可化解，**无需改 `schemas/types.py`**。

## 改动

- `_ModuleBase` 新增非抽象 `get_subtype_id() -> str`，默认 `return get_subtype().value`
  - 31 个内建模块零改动自动获得字符串标识；`get_subtype()=None` 兜底返回 `""`
- `ModuleManager._coerce_subtype`（Enum 取 `.value` 否则 `str`）；`get_running_subtype_module` 改为字符串相等匹配：查询参数与模块 `get_subtype_id()` 均归一化为字符串后比较
- 兼容 Enum 查询与纯字符串子类型；插件可仅重写 `get_subtype_id()` 返回 `"aria2"` 等枚举外字符串

## 测试

- `tests/test_module_subtype_id.py` 4 例（默认值等价 / None 兜底 / Enum 与字符串查询等价 / 插件纯字符串子类型分发）全绿
- S1 7 例 + relocation 4 例回归零破坏

## 备注

`DownloaderType` 等改继承已存在的 `NameValueEnum`（容错反序列化）属 S6 可选二期，本 PR 不含。