### PR TITLE
feat(Q1 S3): 插件 SPI 声明式扩展点 + 只读聚合器

### DIFF
--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -133,6 +133,55 @@ def get_plugin_modules(running_plugins, pid: Optional[str] = None) -> Dict[tuple
                 logger.error(f"获取插件 {plugin_id} 模块出错：{str(e)}")
     return ret_modules
 
+def get_plugin_provided_modules(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_modules() 声明【新增】的系统模块类，按 plugin_id(owner) 归集。
+    供 PluginManager 启停时统一向 ModuleManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [module_cls, ...]
+    }
+    """
+    ret_modules: Dict[str, List[type]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_modules") and ObjectUtils.check_method(plugin.provides_modules):
+            try:
+                if not plugin.get_state():
+                    continue
+                modules = plugin.provides_modules() or []
+                if modules:
+                    ret_modules[plugin_id] = list(modules)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册模块出错：{str(e)}")
+    return ret_modules
+
+def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。
+    供 PluginManager 启停时统一向 FileManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [storage_cls, ...]
+    }
+    """
+    ret_storages: Dict[str, List[type]] = {}
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_storages") and ObjectUtils.check_method(plugin.provides_storages):
+            try:
+                if not plugin.get_state():
+                    continue
+                storages = plugin.provides_storages() or []
+                if storages:
+                    ret_storages[plugin_id] = list(storages)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册存储器出错：{str(e)}")
+    return ret_storages
+
 def get_plugin_actions(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     获取插件动作

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -199,6 +199,30 @@ class _PluginBase(metaclass=ABCMeta):
         """
         pass
 
+    def provides_modules(self) -> List[Type]:
+        """
+        声明本插件向模块层【新增】的系统模块类（区别于 get_module 的方法胁持：
+        get_module 改既有方法，本钩子新增一个完整模块，如新的下载器/媒体服务器/消息渠道）。
+
+        返回模块【类】列表（非实例），每个类需实现 _ModuleBase 契约：
+        init_module / init_setting / stop / test，以及 get_type / get_subtype（或
+        get_subtype_id 返回枚举外字符串如 "aria2"）/ get_priority。
+        由框架（PluginManager 启停）统一注册到 ModuleManager 并参与 chain 分发，
+        无需插件自行 monkey-patch app.modules。默认不新增任何模块。
+
+        [DownloaderModuleClass, MediaServerModuleClass, ...]
+        """
+        return []
+
+    def provides_storages(self) -> List[Type]:
+        """
+        声明本插件向文件整理层【新增】的存储器类（provides_modules 的语法糖，
+        内部经 FileManager 注册）。返回 StorageBase 子类列表（非实例）。默认不新增。
+
+        [StorageClass1, StorageClass2, ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/tests/test_plugin_spi_aggregator.py
+++ b/tests/test_plugin_spi_aggregator.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S3 回归测试：插件 SPI 声明式扩展点（provides_modules/provides_storages）与只读聚合器。
+
+验证：
+  1. _PluginBase 提供默认 provides_modules()/provides_storages()，默认返回 []（老插件零改动）；
+  2. get_plugin_provided_modules/get_plugin_provided_storages 聚合运行态插件的声明，按
+     plugin_id(owner) 归集为 {plugin_id: [module_cls, ...]}；
+  3. 未启用插件(get_state=False)被跳过；
+  4. 单插件钩子抛异常被隔离，不影响其它插件聚合；
+  5. pid 过滤只聚合指定插件。
+"""
+from unittest import TestCase
+
+from app.helper.plugin_metadata import (
+    get_plugin_provided_modules,
+    get_plugin_provided_storages,
+)
+from app.plugins import _PluginBase
+
+
+class _DummyModuleA:
+    pass
+
+
+class _DummyModuleB:
+    pass
+
+
+class _DummyStorage:
+    pass
+
+
+class _FakePlugin:
+    """duck-typed 运行态插件，仿 _PluginBase 暴露 SPI 钩子"""
+
+    def __init__(self, modules=None, storages=None, state=True, raise_modules=False):
+        self._modules = modules or []
+        self._storages = storages or []
+        self._state = state
+        self._raise = raise_modules
+
+    def get_state(self) -> bool:
+        return self._state
+
+    def get_name(self) -> str:
+        return "FakePlugin"
+
+    def provides_modules(self):
+        if self._raise:
+            raise RuntimeError("boom")
+        return self._modules
+
+    def provides_storages(self):
+        return self._storages
+
+
+class PluginSpiAggregatorTest(TestCase):
+
+    def test_base_defaults_empty(self):
+        # 默认实现不依赖 self，直接以未绑定方式校验返回空
+        self.assertEqual(_PluginBase.provides_modules(object()), [])
+        self.assertEqual(_PluginBase.provides_storages(object()), [])
+
+    def test_aggregates_modules_by_owner(self):
+        running = {"plugin.a": _FakePlugin(modules=[_DummyModuleA, _DummyModuleB])}
+        result = get_plugin_provided_modules(running)
+        self.assertIn("plugin.a", result)
+        self.assertEqual(result["plugin.a"], [_DummyModuleA, _DummyModuleB])
+
+    def test_disabled_plugin_excluded(self):
+        running = {"plugin.a": _FakePlugin(modules=[_DummyModuleA], state=False)}
+        result = get_plugin_provided_modules(running)
+        self.assertEqual(result, {})
+
+    def test_error_isolated(self):
+        running = {
+            "plugin.bad": _FakePlugin(raise_modules=True),
+            "plugin.good": _FakePlugin(modules=[_DummyModuleA]),
+        }
+        result = get_plugin_provided_modules(running)
+        self.assertNotIn("plugin.bad", result)
+        self.assertIn("plugin.good", result)
+
+    def test_pid_filter(self):
+        running = {
+            "plugin.a": _FakePlugin(modules=[_DummyModuleA]),
+            "plugin.b": _FakePlugin(modules=[_DummyModuleB]),
+        }
+        result = get_plugin_provided_modules(running, pid="plugin.a")
+        self.assertEqual(set(result.keys()), {"plugin.a"})
+
+    def test_storages_aggregated(self):
+        running = {"plugin.s": _FakePlugin(storages=[_DummyStorage])}
+        result = get_plugin_provided_storages(running)
+        self.assertEqual(result["plugin.s"], [_DummyStorage])
+
+    def test_empty_declarations_omitted(self):
+        # 声明为空的插件不产生空条目
+        running = {"plugin.empty": _FakePlugin(modules=[])}
+        result = get_plugin_provided_modules(running)
+        self.assertEqual(result, {})


### PR DESCRIPTION
## Q1 路线图 · S3（栈式叠在 #51 之上）

把 p115 式的「插件新增下载器/存储器」从 **monkey-patch 反模式**，正规化为**声明式钩子**。本步纯加法——仅定义扩展点与聚合器，生命周期接线在 S4。

## 改动

- `_PluginBase` 新增 `provides_modules()` / `provides_storages()`，默认返回 `[]`
  - 区别于 `get_module` 的方法胁持：本钩子是【新增】一个完整模块/存储器，而非改既有方法
  - 老插件零改动
- `plugin_metadata` 新增 `get_plugin_provided_modules` / `get_plugin_provided_storages` 只读聚合器
  - 仿现有 `get_plugin_modules`：`running_plugins` 快照、`check get_state`、逐插件 `try/except` 隔离
  - 按 `plugin_id(owner)` 归集为 `{pid: [cls, ...]}`，对接 S1 的 `register_module(cls, owner=pid)`

## 插件作者视角（S4 接线后即可用）

```python
class MyAria2Plugin(_PluginBase):
    def provides_modules(self):
        return [Aria2DownloaderModule]   # 一个实现 _ModuleBase 契约的类
# Aria2DownloaderModule.get_subtype_id() -> "aria2"（枚举外字符串，S2 支持）
```

## 测试

- `tests/test_plugin_spi_aggregator.py` 7 例（默认空 / 按 owner 聚合 / 禁用跳过 / 异常隔离 / pid 过滤 / 存储器聚合 / 空声明不产生空条目）全绿
- `plugin_metadata` 6 例回归零破坏