### PR TITLE
feat(Q1 S4): PluginManager ↔ ModuleManager 注册接线（运行期动态上下线）

### DIFF
--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -24,6 +24,7 @@ from app.core.auth_level import get_auth_level
 from app.core.cache import fresh, async_fresh
 from app.core.config import settings
 from app.core.event import eventmanager
+from app.core.module import ModuleManager
 from app.core.plugin_reporter import report_plugin_install
 from app.core.plugin_source import get_plugin_source
 from app.helper import plugin_market, plugin_metadata
@@ -114,6 +115,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     eventmanager.disable_event_handler(plugin)
             except Exception as err:
                 logger.error(f"加载插件 {plugin_id} 出错：{str(err)} - {traceback.format_exc()}")
+        # 注册插件经 provides_modules 声明新增的系统模块到模块层（运行期动态上线）
+        self._register_plugin_modules(pid)
 
     def init_plugin(self, plugin_id: str, conf: dict):
         """
@@ -133,6 +136,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         else:
             # 禁用插件类的事件处理器
             eventmanager.disable_event_handler(type(plugin))
+        # 运行期重同步该插件注册到模块层的系统模块（启用/禁用/配置变更后幂等上下线）
+        self._unregister_plugin_modules([plugin_id])
+        self._register_plugin_modules(plugin_id)
 
     def stop(self, pid: Optional[str] = None):
         """
@@ -156,6 +162,12 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         for plugin_id, plugin in plugins.items():
             eventmanager.disable_event_handler(type(plugin))
             self.__stop_plugin(plugin)
+        # 卸载这些插件注册到模块层的系统模块（运行期动态下线，无僵尸）。
+        # 即便指定插件未进入运行态，也按 owner=pid 兜底卸载其可能残留的模块。
+        stopped_ids = list(plugins.keys())
+        if pid and pid not in stopped_ids:
+            stopped_ids.append(pid)
+        self._unregister_plugin_modules(stopped_ids)
         # 清空对象
         if pid:
             # 清空指定插件
@@ -582,6 +594,30 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 logger.info(f"插件 {plugin_id} 共清除 {len(modules_to_remove)} 个模块缓存：{modules_to_remove}")
             else:
                 logger.debug(f"插件 {plugin_id} 没有找到需要清除的模块缓存")
+
+    def _register_plugin_modules(self, pid: Optional[str] = None):
+        """
+        将运行态插件经 provides_modules() 声明的系统模块注册到 ModuleManager（owner=plugin_id），
+        随即进入 chain 分发。仅注册已启用插件（聚合器按 get_state 过滤）。pid 为空时处理全部插件。
+        """
+        provided = plugin_metadata.get_plugin_provided_modules(self._running_plugins, pid)
+        for plugin_id, module_classes in provided.items():
+            for module_cls in module_classes:
+                try:
+                    ModuleManager().register_module(module_cls, owner=plugin_id)
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 模块 "
+                                 f"{getattr(module_cls, '__name__', module_cls)} 出错：{str(err)}")
+
+    def _unregister_plugin_modules(self, plugin_ids: List[str]):
+        """
+        卸载指定插件注册到 ModuleManager 的系统模块，停止其运行实例，无僵尸残留。
+        """
+        for plugin_id in plugin_ids:
+            try:
+                ModuleManager().unregister_modules(owner=plugin_id)
+            except Exception as err:
+                logger.error(f"卸载插件 {plugin_id} 模块出错：{str(err)}")
 
     def sync(self) -> List[str]:
         """

--- a/tests/test_plugin_module_registration.py
+++ b/tests/test_plugin_module_registration.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S4 回归测试：PluginManager 生命周期 ↔ ModuleManager 注册接线（运行期动态上下线）。
+
+验证：
+  1. _register_plugin_modules() 把运行态插件经 provides_modules 声明的模块注册进 ModuleManager
+     （owner=plugin_id），随即进入 chain 分发；
+  2. 未启用插件(get_state=False)的模块不被注册；
+  3. _unregister_plugin_modules([pid]) 卸载该插件的模块；
+  4. stop(pid) 卸载该插件注册的模块（无僵尸）；
+  5. 运行期 init_plugin(pid) 重同步：插件由启用转禁用后，其模块被下线。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_manager import PluginManager
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType, DownloaderType
+
+
+class _PluginDownloaderModule(_ModuleBase):
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        return DownloaderType.Qbittorrent
+
+    @staticmethod
+    def get_priority() -> int:
+        return 99
+
+    def download(self, *args, **kwargs):
+        return "plugin-download"
+
+
+class _FakePlugin:
+    plugin_version = "1.0"
+
+    def __init__(self, state=True):
+        self._state = state
+
+    def get_state(self) -> bool:
+        return self._state
+
+    def get_name(self) -> str:
+        return "FakePlugin"
+
+    def init_plugin(self, conf=None):
+        pass
+
+    def provides_modules(self):
+        return [_PluginDownloaderModule]
+
+    def provides_storages(self):
+        return []
+
+
+_PID = "test.plugin.q1s4"
+
+
+class PluginModuleRegistrationTest(TestCase):
+
+    def setUp(self):
+        self.pm = PluginManager()
+        self.mm = ModuleManager()
+        # 保存并隔离运行态插件字典，避免污染真实单例
+        self._saved_running = dict(self.pm._running_plugins)
+
+    def tearDown(self):
+        self.mm.unregister_modules(_PID)
+        self.pm._running_plugins = self._saved_running
+
+    def _running_module_types(self):
+        return [type(m) for m in self.mm.get_running_modules("download")]
+
+    def test_register_via_helper(self):
+        self.pm._running_plugins = {_PID: _FakePlugin(state=True)}
+        self.pm._register_plugin_modules()
+        self.assertIn("_PluginDownloaderModule", self.mm.get_external_module_ids(_PID))
+        self.assertIn(_PluginDownloaderModule, self._running_module_types())
+
+    def test_disabled_not_registered(self):
+        self.pm._running_plugins = {_PID: _FakePlugin(state=False)}
+        self.pm._register_plugin_modules()
+        self.assertEqual(self.mm.get_external_module_ids(_PID), [])
+        self.assertNotIn(_PluginDownloaderModule, self._running_module_types())
+
+    def test_unregister_via_helper(self):
+        self.pm._running_plugins = {_PID: _FakePlugin(state=True)}
+        self.pm._register_plugin_modules()
+        self.pm._unregister_plugin_modules([_PID])
+        self.assertEqual(self.mm.get_external_module_ids(_PID), [])
+        self.assertNotIn(_PluginDownloaderModule, self._running_module_types())
+
+    def test_stop_unregisters(self):
+        self.pm._running_plugins = {_PID: _FakePlugin(state=True)}
+        self.pm._register_plugin_modules()
+        self.assertIn(_PluginDownloaderModule, self._running_module_types())
+        # 停止该插件应一并卸载其模块
+        self.pm.stop(_PID)
+        self.assertEqual(self.mm.get_external_module_ids(_PID), [])
+        self.assertNotIn(_PluginDownloaderModule, self._running_module_types())
+
+    def test_runtime_disable_resync(self):
+        fake = _FakePlugin(state=True)
+        self.pm._running_plugins = {_PID: fake}
+        self.pm._register_plugin_modules()
+        self.assertIn(_PluginDownloaderModule, self._running_module_types())
+        # 运行期把插件切到禁用，再触发 init_plugin 重同步 → 模块下线
+        fake._state = False
+        self.pm.init_plugin(_PID, {})
+        self.assertNotIn(_PluginDownloaderModule, self._running_module_types())
+        self.assertEqual(self.mm.get_external_module_ids(_PID), [])


### PR DESCRIPTION
## Q1 路线图 · S4（栈式叠在 #52 之上）

把 S3 的声明式扩展点接通到 S1 的二级注册——插件 `provides_modules` 声明的系统模块**随插件启停在运行期动态上/下线**，正规化取代 p115 的 monkey-patch。范围决策：运行期动态上下线（已确认）。

## 改动

- 新增 `_register_plugin_modules(pid)` / `_unregister_plugin_modules(ids)`：经 S3 聚合器收集后逐类 `ModuleManager().register_module(cls, owner=plugin_id)` / `unregister_modules`
- `start(pid)` 末尾统一注册（`register_module` 即上线，无需 reload）；仅注册已启用插件
- `stop(pid)` 卸载这些插件注册的模块；pid 未进运行态也按 `owner=pid` 兜底卸载，无僵尸
- 管理器级 `init_plugin(pid)` 末尾幂等重同步（先 unregister 再 register），覆盖运行期**启用/禁用/配置变更**
- `reload_plugin = stop + start`，自动复用本接线

## 运行期并发

注册路径全程经 S1 的 `RLock` 保护；分发生成器快照迭代——运行期上下线与 chain 分发并发安全。

## 测试

- `tests/test_plugin_module_registration.py` 5 例（helper 注册 / 禁用不注册 / 卸载 / `stop` 卸载 / 运行期禁用重同步）全绿
- plugin 相关 79 例回归零破坏（`test_plugin_endpoint.py` 因缺 `jieba_next` 依赖在 collection 失败，属预存基线，与本 PR 无关）

## 后续

- S5 存储器开放（`FileManager.register_storage` + 接通 `provides_storages`）
- S6 消息渠道能力矩阵开放注册（`ChannelCapabilityManager`）