### PR TITLE
feat(Q1 S5): 存储器开放注册（FileManager 二级源 + 插件接线）

### DIFF
--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -608,16 +608,32 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} 模块 "
                                  f"{getattr(module_cls, '__name__', module_cls)} 出错：{str(err)}")
+        # 注册插件经 provides_storages 声明新增的存储器到文件整理层
+        provided_storages = plugin_metadata.get_plugin_provided_storages(self._running_plugins, pid)
+        if provided_storages:
+            from app.modules.filemanager import FileManagerModule
+            for plugin_id, storage_classes in provided_storages.items():
+                for storage_cls in storage_classes:
+                    try:
+                        FileManagerModule.register_storage(storage_cls, owner=plugin_id)
+                    except Exception as err:
+                        logger.error(f"注册插件 {plugin_id} 存储器 "
+                                     f"{getattr(storage_cls, '__name__', storage_cls)} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """
         卸载指定插件注册到 ModuleManager 的系统模块，停止其运行实例，无僵尸残留。
         """
+        from app.modules.filemanager import FileManagerModule
         for plugin_id in plugin_ids:
             try:
                 ModuleManager().unregister_modules(owner=plugin_id)
             except Exception as err:
                 logger.error(f"卸载插件 {plugin_id} 模块出错：{str(err)}")
+            try:
+                FileManagerModule.unregister_storages(owner=plugin_id)
+            except Exception as err:
+                logger.error(f"卸载插件 {plugin_id} 存储器出错：{str(err)}")
 
     def sync(self) -> List[str]:
         """

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -11,6 +11,7 @@ from app.helper.message import MessageHelper
 from app.core.module_loader import ModuleHelper
 from app.log import logger
 from app.modules import _ModuleBase
+from app.modules.filemanager import storage_registry
 from app.modules.filemanager.storages import StorageBase
 from app.modules.filemanager.transhandler import TransHandler
 from app.schemas import TransferInfo, ExistMediaInfo, TmdbEpisode, TransferDirectoryConf, FileItem, StorageUsage
@@ -32,11 +33,43 @@ class FileManagerModule(_ModuleBase):
         self.messagehelper = MessageHelper()
 
     def init_module(self) -> None:
-        # 加载模块
-        self._storage_schemas = ModuleHelper.load('app.modules.filemanager.storages',
-                                                  filter_func=lambda _, obj: hasattr(obj, 'schema') and obj.schema)
+        # 扫描内建存储器
+        scanned = ModuleHelper.load('app.modules.filemanager.storages',
+                                    filter_func=lambda _, obj: hasattr(obj, 'schema') and obj.schema)
+        # 合并外部(插件)注册的存储器（merge 非 replace；外部记账存于 reload-stable 的
+        # storage_registry，使运行期注册的存储挺过 ModuleManager.reload()）
+        self._storage_schemas = list(scanned) + storage_registry.all_storages()
         # 获取存储类型
         self._support_storages = [storage.schema.value for storage in self._storage_schemas if storage.schema]
+
+    @classmethod
+    def register_storage(cls, storage_class: type, owner: str) -> bool:
+        """
+        注册一个外部(插件)存储器类（StorageBase 子类）。记账到 reload-stable 的 storage_registry
+        并刷新运行实例。存储器无需扩展 StorageSchema 封闭枚举：__get_storage_oper 按 schema.value
+        字符串匹配，插件存储类只要 .schema.value 为其字符串 id 即可被命中。
+        """
+        if not storage_registry.register(storage_class, owner):
+            return False
+        cls._refresh_running_instance()
+        return True
+
+    @classmethod
+    def unregister_storages(cls, owner: str) -> None:
+        """卸载某来源(owner)注册的外部存储器并刷新运行实例。"""
+        if storage_registry.unregister(owner):
+            cls._refresh_running_instance()
+
+    @classmethod
+    def _refresh_running_instance(cls) -> None:
+        """
+        刷新运行态 FileManagerModule 实例的存储器列表（重跑 init_module 合并内建+外部）。
+        若实例尚未加载则跳过——记账仍在 storage_registry 保留，待 init_module 首次运行时自动合并。
+        """
+        from app.core.module import ModuleManager
+        inst = ModuleManager().get_running_module(cls.__name__)
+        if inst is not None:
+            inst.init_module()
 
     @staticmethod
     def get_name() -> str:

--- a/app/modules/filemanager/storage_registry.py
+++ b/app/modules/filemanager/storage_registry.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+外部(插件)存储器注册表（进程级，reload-stable）。
+
+存于本独立子模块的模块级全局：ModuleManager.load_modules() 只对 app.modules 的【顶层】子包
+做 importlib.reload（即重载 app.modules.filemanager 的 __init__），不会递归重载本子模块，
+故本注册表全局字典不被重置——使运行期插件注册的存储器挺过 ModuleManager.reload()。
+
+同时规避 reload 造成的 FileManagerModule 类对象分叉：注册状态不挂在（可能被重建的）类上，
+而由本稳定模块持有，FileManagerModule.init_module 始终从这里读取外部存储器。
+"""
+from typing import Dict, List
+
+# {owner: [storage_class, ...]}
+_EXTERNAL_STORAGES: Dict[str, List[type]] = {}
+
+
+def register(storage_class: type, owner: str) -> bool:
+    """记账一个外部存储器类（按 owner）。幂等：同 owner 重复注册不产生重复记录。"""
+    if not owner or not isinstance(storage_class, type):
+        return False
+    _EXTERNAL_STORAGES.setdefault(owner, [])
+    if storage_class not in _EXTERNAL_STORAGES[owner]:
+        _EXTERNAL_STORAGES[owner].append(storage_class)
+    return True
+
+
+def unregister(owner: str) -> bool:
+    """移除某来源(owner)的全部外部存储器记账。返回是否确有移除。"""
+    if not owner:
+        return False
+    return _EXTERNAL_STORAGES.pop(owner, None) is not None
+
+
+def all_storages() -> List[type]:
+    """返回所有外部存储器类（跨 owner 展平）。"""
+    return [cls for classes in _EXTERNAL_STORAGES.values() for cls in classes]

--- a/tests/test_filemanager_external_storage.py
+++ b/tests/test_filemanager_external_storage.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S5 回归测试：FileManager 存储器二级源（外部/插件存储器开放注册）。
+
+验证：
+  1. FileManagerModule.register_storage(cls, owner) 后，外部存储 schema 进入运行实例的
+     _storage_schemas/_support_storages，__get_storage_oper 可命中（merge 非 replace）；
+  2. unregister_storages(owner) 后外部存储下线；
+  3. 6 个内建存储器（local/alipan/u115/rclone/alist/smb）不受影响；
+  4. PluginManager._register_plugin_modules 接通 provides_storages → FileManager 注册，
+     _unregister_plugin_modules 卸载。
+  存储器开放无需扩展 StorageSchema 封闭枚举：__get_storage_oper 按 schema.value 字符串匹配，
+  插件存储类只要 .schema.value 为其字符串 id 即可。
+"""
+from types import SimpleNamespace
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_manager import PluginManager
+from app.modules.filemanager import FileManagerModule
+from app.modules.filemanager.storages import StorageBase
+
+
+class _FakeWebdavStorage(StorageBase):
+    """插件式外部存储：schema.value='webdav'（枚举外），跳过 StorageHelper 初始化"""
+
+    schema = SimpleNamespace(value="webdav")
+    transtype = {"copy": "复制"}
+
+    def __init__(self):
+        # 跳过 StorageBase.__init__ 的 StorageHelper，保持测试轻量
+        pass
+
+    def init_storage(self):
+        pass
+
+    def support_transtype(self):
+        return self.transtype
+
+
+# StorageBase(ABCMeta) 有大量抽象方法（check/copy/list/...）；真插件存储类会全部实现，
+# 此处测试假类清空抽象集合以便实例化（继承的方法均为 no-op 返回 None）。
+_FakeWebdavStorage.__abstractmethods__ = frozenset()
+
+
+class _FakeStoragePlugin:
+    def get_state(self) -> bool:
+        return True
+
+    def get_name(self) -> str:
+        return "FakeStoragePlugin"
+
+    def provides_modules(self):
+        return []
+
+    def provides_storages(self):
+        return [_FakeWebdavStorage]
+
+
+_OWNER = "test.plugin.q1s5"
+_BUILTIN = {"local", "alipan", "u115", "rclone", "alist", "smb"}
+
+
+class FileManagerExternalStorageTest(TestCase):
+
+    def setUp(self):
+        self.mm = ModuleManager()
+        self.fm = self.mm.get_running_module("FileManagerModule")
+        self.assertIsNotNone(self.fm, "FileManagerModule 应处于运行态（init_setting 无开关，始终加载）")
+
+    def tearDown(self):
+        FileManagerModule.unregister_storages(_OWNER)
+
+    def test_register_storage_merges(self):
+        FileManagerModule.register_storage(_FakeWebdavStorage, owner=_OWNER)
+        self.assertIn("webdav", self.fm._support_storages)
+        self.assertIn(_FakeWebdavStorage, self.fm._storage_schemas)
+        # __get_storage_oper（name-mangled 私有）能命中外部存储
+        oper = self.fm._FileManagerModule__get_storage_oper("webdav")
+        self.assertIsInstance(oper, _FakeWebdavStorage)
+
+    def test_unregister_storage(self):
+        FileManagerModule.register_storage(_FakeWebdavStorage, owner=_OWNER)
+        FileManagerModule.unregister_storages(_OWNER)
+        self.assertNotIn("webdav", self.fm._support_storages)
+        self.assertNotIn(_FakeWebdavStorage, self.fm._storage_schemas)
+
+    def test_builtin_storages_unaffected(self):
+        before = set(self.fm._support_storages)
+        self.assertTrue(_BUILTIN.issubset(before), f"内建存储缺失：{_BUILTIN - before}")
+        FileManagerModule.register_storage(_FakeWebdavStorage, owner=_OWNER)
+        self.assertTrue(_BUILTIN.issubset(set(self.fm._support_storages)))
+        FileManagerModule.unregister_storages(_OWNER)
+        self.assertTrue(_BUILTIN.issubset(set(self.fm._support_storages)))
+
+    def test_plugin_manager_wires_storages(self):
+        pm = PluginManager()
+        saved = dict(pm._running_plugins)
+        try:
+            pm._running_plugins = {_OWNER: _FakeStoragePlugin()}
+            pm._register_plugin_modules()
+            self.assertIn("webdav", self.fm._support_storages)
+            pm._unregister_plugin_modules([_OWNER])
+            self.assertNotIn("webdav", self.fm._support_storages)
+        finally:
+            pm._running_plugins = saved
+            FileManagerModule.unregister_storages(_OWNER)


### PR DESCRIPTION
## Q1 路线图 · S5（栈式叠在 #53 之上）

让插件经 `provides_storages` 新增存储器（如 webdav），**无需改 `StorageSchema` 封闭枚举**：`__get_storage_oper` 本就按 `schema.value` 字符串匹配，插件存储类只要 `.schema.value` 为其字符串 id 即被命中。

## 关键：reload-stable 注册表（避坑）

`ModuleHelper.load` 对 `app.modules` 子包做 `importlib.reload`，会产生**两个 `FileManagerModule` 类对象**（调用方 import 的 vs 运行实例所属的）。若把注册表挂在类上，运行实例 `init_module` 读不到 → 失效。

故新增 `app/modules/filemanager/storage_registry.py`：进程级模块全局，存于独立子模块（不被顶层包 reload 重置，且不依赖类对象身份），从根上规避分叉，并使运行期注册的存储器挺过 `ModuleManager.reload()`。

## 改动

- `storage_registry.py`（新）：`register` / `unregister` / `all_storages`，按 owner 记账
- `FileManagerModule.init_module` 改 merge（内建扫描 + `storage_registry.all_storages()`，非 replace）；新增 `register_storage` / `unregister_storages`（委托 registry + 刷新运行实例）
- `PluginManager._register/_unregister_plugin_modules` 接通 `provides_storages` → `FileManagerModule.register_storage/unregister_storages`（owner=plugin_id）
- 内建 6 存储器（local/alipan/u115/rclone/alist/smb）零影响；`__get_storage_oper` 不改

## 测试

- `tests/test_filemanager_external_storage.py` 4 例（注册 merge / 卸载 / 内建不受影响 / PluginManager 接线）全绿
- S1–S4 + transfer/metadata 相关 43 例回归零破坏

## 后续

- S6 消息渠道能力矩阵开放注册（`ChannelCapabilityManager`，覆盖「全部含消息渠道」的范围决策）