### PR TITLE
feat(Q1 S6): 消息渠道能力矩阵开放注册（ChannelCapabilityManager）

### DIFF
--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -619,12 +619,24 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     except Exception as err:
                         logger.error(f"注册插件 {plugin_id} 存储器 "
                                      f"{getattr(storage_cls, '__name__', storage_cls)} 出错：{str(err)}")
+        # 注册插件经 provides_channel_capabilities 声明的消息渠道能力矩阵
+        provided_caps = plugin_metadata.get_plugin_provided_channel_capabilities(self._running_plugins, pid)
+        if provided_caps:
+            from app.schemas.message import ChannelCapabilityManager
+            for plugin_id, caps_list in provided_caps.items():
+                for caps in caps_list:
+                    try:
+                        ChannelCapabilityManager.register_capabilities(
+                            getattr(caps, "channel", None), caps, owner=plugin_id)
+                    except Exception as err:
+                        logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """
         卸载指定插件注册到 ModuleManager 的系统模块，停止其运行实例，无僵尸残留。
         """
         from app.modules.filemanager import FileManagerModule
+        from app.schemas.message import ChannelCapabilityManager
         for plugin_id in plugin_ids:
             try:
                 ModuleManager().unregister_modules(owner=plugin_id)
@@ -634,6 +646,10 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 FileManagerModule.unregister_storages(owner=plugin_id)
             except Exception as err:
                 logger.error(f"卸载插件 {plugin_id} 存储器出错：{str(err)}")
+            try:
+                ChannelCapabilityManager.unregister_capabilities(owner=plugin_id)
+            except Exception as err:
+                logger.error(f"卸载插件 {plugin_id} 渠道能力出错：{str(err)}")
 
     def sync(self) -> List[str]:
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -182,6 +182,32 @@ def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> 
                 logger.error(f"获取插件 {plugin_id} 注册存储器出错：{str(e)}")
     return ret_storages
 
+def get_plugin_provided_channel_capabilities(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+    """
+    聚合插件经 provides_channel_capabilities() 声明【新增】的消息渠道能力矩阵，
+    按 plugin_id(owner) 归集。供 PluginManager 启停时统一向 ChannelCapabilityManager
+    注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [ChannelCapabilities, ...]
+    }
+    """
+    ret_caps: Dict[str, List[Any]] = {}
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_channel_capabilities") \
+                and ObjectUtils.check_method(plugin.provides_channel_capabilities):
+            try:
+                if not plugin.get_state():
+                    continue
+                caps = plugin.provides_channel_capabilities() or []
+                if caps:
+                    ret_caps[plugin_id] = list(caps)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册渠道能力出错：{str(e)}")
+    return ret_caps
+
 def get_plugin_actions(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     获取插件动作

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -223,6 +223,17 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_channel_capabilities(self) -> List[Any]:
+        """
+        声明本插件新增的消息渠道的能力矩阵（配合 provides_modules 新增消息渠道模块使用）。
+        返回 ChannelCapabilities 实例列表，每个实例的 channel 字段为该渠道的字符串 id
+        （无需扩展封闭 MessageChannel 枚举）。由框架注册到 ChannelCapabilityManager，
+        使插件渠道获得正确的按钮/Markdown/分段等能力声明（不声明则走降级默认）。默认不新增。
+
+        [ChannelCapabilities(channel="mychannel", capabilities={...}), ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -515,12 +515,53 @@ class ChannelCapabilityManager:
         ),
     }
 
+    # 外部(插件)注册的渠道能力，按字符串 channel id 归集（避免扩展封闭 MessageChannel 枚举）
+    _external_capabilities: Dict[str, ChannelCapabilities] = {}
+    # 外部能力的来源记账：owner -> [channel_key, ...]，供按来源精确卸载
+    _external_owners: Dict[str, List[str]] = {}
+
+    @staticmethod
+    def _coerce_channel(channel) -> Optional[str]:
+        """将渠道（MessageChannel 枚举或字符串）归一化为字符串 id，None 原样返回 None。"""
+        if channel is None:
+            return None
+        if isinstance(channel, Enum):
+            return str(channel.value)
+        return str(channel)
+
     @classmethod
     def get_capabilities(cls, channel: MessageChannel) -> Optional[ChannelCapabilities]:
         """
-        获取渠道能力
+        获取渠道能力。先查内建（按 MessageChannel 枚举），未命中再查外部(插件)注册
+        （按字符串 channel id 容错匹配），使插件新增渠道也能声明能力矩阵。
         """
-        return cls._capabilities.get(channel)
+        caps = cls._capabilities.get(channel)
+        if caps is not None:
+            return caps
+        return cls._external_capabilities.get(cls._coerce_channel(channel))
+
+    @classmethod
+    def register_capabilities(cls, channel, capabilities: ChannelCapabilities, owner: str) -> bool:
+        """
+        注册一个外部(插件)渠道的能力矩阵，按 owner 记账以便精确卸载。
+        channel 可为字符串或 MessageChannel；按字符串 id 存储与匹配，无需扩展封闭枚举。
+        """
+        key = cls._coerce_channel(channel)
+        if not key or not owner or capabilities is None:
+            return False
+        cls._external_capabilities[key] = capabilities
+        cls._external_owners.setdefault(owner, [])
+        if key not in cls._external_owners[owner]:
+            cls._external_owners[owner].append(key)
+        return True
+
+    @classmethod
+    def unregister_capabilities(cls, owner: str) -> None:
+        """卸载某来源(owner)注册的全部外部渠道能力。"""
+        if not owner:
+            return
+        for key in cls._external_owners.pop(owner, []):
+            cls._external_capabilities.pop(key, None)
 
     @classmethod
     def supports_capability(

--- a/tests/test_channel_capability_open.py
+++ b/tests/test_channel_capability_open.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+Q1-S6 回归测试：ChannelCapabilityManager 消息渠道能力矩阵开放注册。
+
+验证：
+  1. register_capabilities(channel, caps, owner) 后，get_capabilities/supports_* 能查到插件渠道
+     （按字符串 channel id 容错匹配，无需扩展封闭 MessageChannel 枚举）；
+  2. unregister_capabilities(owner) 后插件渠道能力下线；
+  3. 内建渠道（如 Telegram）能力不受影响；
+  4. PluginManager._register/_unregister_plugin_modules 接通 provides_channel_capabilities。
+"""
+from unittest import TestCase
+
+from app.helper.plugin_manager import PluginManager
+from app.schemas.message import (
+    ChannelCapabilityManager,
+    ChannelCapabilities,
+    ChannelCapability,
+)
+from app.schemas.types import MessageChannel
+
+
+_OWNER = "test.plugin.q1s6"
+_CHANNEL = "mychannel"
+
+
+def _make_caps():
+    return ChannelCapabilities(
+        channel=_CHANNEL,
+        capabilities={ChannelCapability.INLINE_BUTTONS, ChannelCapability.MARKDOWN},
+        max_buttons_per_row=3,
+    )
+
+
+class _FakeChannelPlugin:
+    def __init__(self, caps):
+        self._caps = caps
+
+    def get_state(self) -> bool:
+        return True
+
+    def get_name(self) -> str:
+        return "FakeChannelPlugin"
+
+    def provides_modules(self):
+        return []
+
+    def provides_storages(self):
+        return []
+
+    def provides_channel_capabilities(self):
+        return [self._caps]
+
+
+class ChannelCapabilityOpenTest(TestCase):
+
+    def tearDown(self):
+        ChannelCapabilityManager.unregister_capabilities(_OWNER)
+
+    def test_register_and_lookup(self):
+        caps = _make_caps()
+        ok = ChannelCapabilityManager.register_capabilities(_CHANNEL, caps, owner=_OWNER)
+        self.assertTrue(ok)
+        self.assertIs(ChannelCapabilityManager.get_capabilities(_CHANNEL), caps)
+        self.assertTrue(ChannelCapabilityManager.supports_buttons(_CHANNEL))
+        self.assertTrue(ChannelCapabilityManager.supports_markdown(_CHANNEL))
+        self.assertEqual(ChannelCapabilityManager.get_max_buttons_per_row(_CHANNEL), 3)
+
+    def test_unregister(self):
+        ChannelCapabilityManager.register_capabilities(_CHANNEL, _make_caps(), owner=_OWNER)
+        ChannelCapabilityManager.unregister_capabilities(_OWNER)
+        self.assertIsNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
+        # 未注册渠道走降级默认
+        self.assertFalse(ChannelCapabilityManager.supports_buttons(_CHANNEL))
+
+    def test_builtin_channel_unaffected(self):
+        before = ChannelCapabilityManager.get_capabilities(MessageChannel.Telegram)
+        self.assertIsNotNone(before)
+        self.assertTrue(ChannelCapabilityManager.supports_buttons(MessageChannel.Telegram))
+        ChannelCapabilityManager.register_capabilities(_CHANNEL, _make_caps(), owner=_OWNER)
+        self.assertIs(ChannelCapabilityManager.get_capabilities(MessageChannel.Telegram), before)
+        self.assertTrue(ChannelCapabilityManager.supports_buttons(MessageChannel.Telegram))
+
+    def test_plugin_manager_wires_capabilities(self):
+        pm = PluginManager()
+        saved = dict(pm._running_plugins)
+        caps = _make_caps()
+        try:
+            pm._running_plugins = {_OWNER: _FakeChannelPlugin(caps)}
+            pm._register_plugin_modules()
+            self.assertIs(ChannelCapabilityManager.get_capabilities(_CHANNEL), caps)
+            pm._unregister_plugin_modules([_OWNER])
+            self.assertIsNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
+        finally:
+            pm._running_plugins = saved
+            ChannelCapabilityManager.unregister_capabilities(_OWNER)


### PR DESCRIPTION
## Q1 路线图 · S6 / 收官（栈式叠在 #54 之上）

落实「全部含消息渠道」范围决策。插件经 `provides_modules` 新增消息渠道模块后（S1–S4 已让其参与分发），本步让它也能**声明能力矩阵**（按钮 / Markdown / 分段长度等），不再受 `ChannelCapabilityManager` 硬编码限制。未声明的插件渠道仍走原有降级默认。

## 改动

- `ChannelCapabilityManager` 新增 `_external_capabilities` / `_external_owners` + `register_capabilities` / `unregister_capabilities` + `_coerce_channel`
  - `get_capabilities` 先查内建枚举、未命中再查外部（按字符串 channel id 容错匹配，**无需扩展封闭 `MessageChannel` 枚举**）
  - `schemas.message` 不在 `app.modules` 下、不被 reload，类级注册表天然稳定（无 S5 的类对象分叉问题）
- `_PluginBase.provides_channel_capabilities()` 默认 `[]`
- `plugin_metadata.get_plugin_provided_channel_capabilities` 聚合器（仿 `provides_storages`）
- `PluginManager._register/_unregister_plugin_modules` 接通（owner=plugin_id）

## 兼容

20 个 `get_capabilities` 调用方零影响：内建路径不变，仅内建返回 `None` 时加外部回退。

## 测试

- `tests/test_channel_capability_open.py` 4 例（注册查找 / 卸载 / 内建不受影响 / PluginManager 接线）全绿
- S1–S5 + metadata 相关 41 例回归零破坏

## Q1 收官

至此 S1–S6 全部完成，模块层对插件**开放注册**端到端打通：下载器 / 媒体服务器 / 消息渠道 / 存储器均可由插件声明式新增并参与分发，正规化取代 p115 的 monkey-patch。