### PR TITLE
chore: 集成上游 v2 2.13.12 同步到 v3-python

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -527,7 +527,7 @@ class MoviePilotAgent:
     @property
     def is_background(self) -> bool:
         """
-        是否为后台任务模式（无渠道信息，如定时唤醒）
+        是否为无需回传捕获内容的后台任务模式。
         """
         return (not self.channel or not self.source) and not callable(self.output_callback)
 
@@ -547,6 +547,13 @@ class MoviePilotAgent:
         否则会让这类高频后台调用持续带入无关动态上下文，影响缓存命中率。
         """
         return self.session_id.startswith(HEARTBEAT_SESSION_PREFIX)
+
+    @property
+    def has_message_context(self) -> bool:
+        """
+        是否具备真实消息渠道上下文。
+        """
+        return bool(self.channel and self.source)
 
     async def _is_system_admin_context(self) -> bool:
         """
@@ -1035,7 +1042,7 @@ class MoviePilotAgent:
                 UsageMiddleware(on_usage=self._record_usage),
             ]
 
-            if not self.is_heartbeat_session:
+            if self.has_message_context:
                 middlewares.insert(
                     4,
                     ActivityLogMiddleware(

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -15,6 +15,7 @@ from langchain.agents.middleware import (
 from langchain_core.messages import (  # noqa: F401
     HumanMessage,
     BaseMessage,
+    SystemMessage,
 )
 
 import warnings
@@ -49,6 +50,7 @@ from app.agent.tools.factory import MoviePilotToolFactory
 from app.chain import ChainBase
 from app.core.config import settings
 from app.core.event import eventmanager
+from app.db.agentchat_oper import AgentChatOper
 from app.db.user_oper import UserOper
 from app.log import logger
 from app.schemas import AgentLLMProviderEventData, AgentTokensUsageEventData, Notification, NotificationType
@@ -222,6 +224,11 @@ HEARTBEAT_SESSION_PREFIX = "__agent_heartbeat_"
 UNSUPPORTED_IMAGE_INPUT_MESSAGE = "当前模型不支持图片输入，请更换支持图片输入的模型，或在系统设置中关闭图片输入支持后重试。"
 AGENT_EXECUTION_ERROR_PREFIX = "智能助手执行失败"
 AGENT_EXECUTION_ERROR_MESSAGE = "智能助手执行失败，请稍后重试。"
+AGENT_DISPLAY_HISTORY_SKIP_CHANNELS = {MessageChannel.WebAgent.value}
+AGENT_CHAT_TITLE_PROMPT = (
+    "你是 MoviePilot 智能助手的会话标题生成器。请根据用户的第一条消息生成一个简洁中文标题，"
+    "不超过 18 个汉字或 36 个英文字符，只输出标题本身，不要引号、编号或解释。"
+)
 
 
 class MoviePilotAgent:
@@ -261,6 +268,129 @@ class MoviePilotAgent:
 
         # 流式token管理
         self.stream_handler = StreamingHandler()
+
+    @staticmethod
+    def _current_timestamp_ms() -> int:
+        """返回当前毫秒时间戳。"""
+        return int(datetime.now().timestamp() * 1000)
+
+    @classmethod
+    def build_display_message(
+            cls,
+            role: str,
+            content: str = "",
+            attachments: Optional[List[dict]] = None,
+            status: str = "done",
+    ) -> dict[str, Any]:
+        """
+        构造可展示的 Agent 会话消息。
+        """
+        return {
+            "id": f"{role}-{uuid.uuid4().hex}",
+            "role": role,
+            "content": content or "",
+            "createdAt": cls._current_timestamp_ms(),
+            "status": status,
+            "tools": [],
+            "attachments": attachments or [],
+            "choices": [],
+        }
+
+    def _should_save_display_history(self) -> bool:
+        """
+        判断当前 Agent 是否由通用渠道保存展示历史。
+        """
+        return bool(
+            self.channel
+            and self.source
+            and self.channel not in AGENT_DISPLAY_HISTORY_SKIP_CHANNELS
+        )
+
+    def _save_display_history_messages(self, messages: List[dict]) -> None:
+        """
+        将一组可见消息追加到 Agent 会话历史表。
+        """
+        if not messages or not self._should_save_display_history():
+            return
+        try:
+            AgentChatOper().append_display_messages(
+                session_id=self.session_id,
+                user_id=self.user_id,
+                username=self.username,
+                channel=self.channel,
+                source=self.source,
+                original_chat_id=self.original_chat_id,
+                messages=messages,
+            )
+        except Exception as e:
+            logger.debug(f"写入Agent展示历史失败: {e}")
+
+    def _save_assistant_display_message_once(self, message: str) -> None:
+        """
+        保存一条助手回复展示记录，并标记本轮已写入。
+        """
+        if not message or self._tool_context.get("assistant_display_saved"):
+            return
+        self._save_display_history_messages(
+            [self.build_display_message(role="assistant", content=message)]
+        )
+        self._tool_context["assistant_display_saved"] = True
+
+    @staticmethod
+    def _sanitize_chat_title(value: str) -> str:
+        """清理模型返回的会话标题。"""
+        title = str(value or "").strip()
+        title = re.sub(r"^[#\-*\d.、\s]+", "", title)
+        title = title.strip("「」『』“”\"'` \n\t")
+        title = re.sub(r"\s+", " ", title)
+        return title[:120]
+
+    async def _generate_chat_title(self, message: str) -> str:
+        """
+        使用当前 Agent 模型生成会话标题。
+        """
+        if not str(message or "").strip():
+            return ""
+        model = await self._initialize_llm(streaming=False)
+        response = await model.ainvoke(
+            [
+                SystemMessage(content=AGENT_CHAT_TITLE_PROMPT),
+                HumanMessage(content=str(message).strip()[:1000]),
+            ]
+        )
+        content = LLMHelper._extract_text_content(getattr(response, "content", response))
+        return self._sanitize_chat_title(content)
+
+    async def prepare_chat_title(self, message: str) -> None:
+        """
+        首次对话时生成并保存会话标题。
+        """
+        if self._tool_context.get("chat_title_prepared"):
+            return
+        self._tool_context["chat_title_prepared"] = True
+        try:
+            chat = await run_in_threadpool(
+                AgentChatOper().get,
+                session_id=self.session_id,
+                user_id=self.user_id,
+            )
+            if chat and AgentChatOper.has_custom_title(chat.title):
+                return
+            title = await self._generate_chat_title(message)
+            if not title:
+                return
+            await run_in_threadpool(
+                AgentChatOper().update_title_if_empty,
+                session_id=self.session_id,
+                user_id=self.user_id,
+                title=title,
+                username=self.username,
+                channel=self.channel,
+                source=self.source,
+                original_chat_id=self.original_chat_id,
+            )
+        except Exception as e:
+            logger.debug(f"生成Agent会话标题失败: {e}")
 
     @staticmethod
     def _coerce_int(value: Any) -> Optional[int]:
@@ -937,6 +1067,7 @@ class MoviePilotAgent:
         """
         处理用户消息，流式推理并返回 Agent 回复
         """
+        user_display_saved = False
         try:
             logger.info(
                 f"Agent推理: session_id={self.session_id}, input={message}, "
@@ -975,6 +1106,21 @@ class MoviePilotAgent:
             for img in images or []:
                 content.append({"type": "image_url", "image_url": {"url": img}})
             messages.append(HumanMessage(content=content))
+            await self.prepare_chat_title(message)
+            self._save_display_history_messages(
+                [
+                    self.build_display_message(
+                        role="user",
+                        content=message,
+                        attachments=self._build_input_display_attachments(
+                            images=images,
+                            files=files,
+                            has_audio_input=has_audio_input,
+                        ),
+                    )
+                ]
+            )
+            user_display_saved = True
 
             # 执行推理
             result = await self._execute_agent(messages)
@@ -985,10 +1131,62 @@ class MoviePilotAgent:
         except Exception as e:
             error_message = f"处理消息时发生错误: {str(e)}"
             logger.error(error_message)
+            if not user_display_saved:
+                self._save_display_history_messages(
+                    [self.build_display_message(role="user", content=message)]
+                )
             if not self.should_dispatch_reply:
                 raise
             await self.send_agent_message(error_message)
             return error_message
+
+    @staticmethod
+    def _guess_file_attachment_kind(mime_type: Optional[str], fallback: str = "file") -> str:
+        """
+        根据 MIME 类型推断展示附件类型。
+        """
+        if mime_type and mime_type.startswith("image/"):
+            return "image"
+        if mime_type and mime_type.startswith("audio/"):
+            return "audio"
+        return fallback
+
+    def _build_input_display_attachments(
+            self,
+            images: Optional[List[str]] = None,
+            files: Optional[List[dict]] = None,
+            has_audio_input: bool = False,
+    ) -> List[dict]:
+        """
+        构造用户输入附件的展示记录。
+        """
+        attachments: List[dict] = []
+        for index, image in enumerate(images or [], start=1):
+            attachments.append(
+                {
+                    "kind": "image",
+                    "url": image,
+                    "download_url": image,
+                    "name": f"image-{index}",
+                    "mime_type": "image/*",
+                }
+            )
+        for index, file in enumerate(files or [], start=1):
+            ref = file.get("ref") or file.get("local_path") or ""
+            mime_type = file.get("mime_type")
+            fallback = "audio" if has_audio_input and mime_type == "audio/*" else "file"
+            attachments.append(
+                {
+                    "kind": self._guess_file_attachment_kind(mime_type, fallback=fallback),
+                    "url": ref,
+                    "download_url": ref,
+                    "name": file.get("name") or f"attachment-{index}",
+                    "mime_type": mime_type,
+                    "size": file.get("size"),
+                    "local_path": file.get("local_path"),
+                }
+            )
+        return attachments
 
     async def _stream_agent_tokens(
             self, agent, messages: dict, config: dict, on_token: Callable[[str], None]
@@ -1157,6 +1355,17 @@ class MoviePilotAgent:
                         # 非流式渠道：发送最终回复
                         await self.send_agent_message(final_text)
 
+            display_text = self._streamed_output
+            if not display_text:
+                final_messages = agent.get_state(agent_config).values.get(
+                    "messages", []
+                )
+                for msg in reversed(final_messages):
+                    if hasattr(msg, "type") and msg.type == "ai" and msg.content:
+                        display_text = self._extract_text_content(msg.content).strip()
+                        break
+            self._save_assistant_display_message_once(display_text)
+
             # 保存消息
             memory_manager.save_agent_messages(
                 session_id=self.session_id,
@@ -1193,6 +1402,7 @@ class MoviePilotAgent:
         """
         通过原渠道发送消息给用户
         """
+        self._save_assistant_display_message_once(message)
         await AgentChain().async_post_message(
             Notification(
                 channel=self.channel,

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -56,7 +56,7 @@ from app.log import logger
 from app.schemas import AgentLLMProviderEventData, AgentTokensUsageEventData, Notification, NotificationType
 from app.schemas.message import ChannelCapabilityManager, ChannelCapability
 from app.schemas.types import ChainEventType, EventType, MessageChannel, ReplyMode
-from app.utils.identity import SYSTEM_INTERNAL_USER_ID
+from app.utils.identity import SYSTEM_INTERNAL_USER_ID, is_internal_user_id
 
 
 class AgentChain(ChainBase):
@@ -220,6 +220,7 @@ class _ThinkTagStripper:
 # ReplyMode 已迁移至 app.schemas.types(打断 chain↔agent 循环 S4),此处经 import 顶层 re-export 保持 `from app.agent import ReplyMode` 向后兼容
 
 
+INTERNAL_AGENT_SESSION_PREFIX = "__agent_"
 HEARTBEAT_SESSION_PREFIX = "__agent_heartbeat_"
 UNSUPPORTED_IMAGE_INPUT_MESSAGE = "当前模型不支持图片输入，请更换支持图片输入的模型，或在系统设置中关闭图片输入支持后重试。"
 AGENT_EXECUTION_ERROR_PREFIX = "智能助手执行失败"
@@ -306,6 +307,17 @@ class MoviePilotAgent:
             and self.channel not in AGENT_DISPLAY_HISTORY_SKIP_CHANNELS
         )
 
+    def _should_persist_agent_chat(self) -> bool:
+        """
+        判断当前 Agent 是否需要写入会话历史表。
+        """
+        if self.is_heartbeat_session:
+            return False
+        return not (
+            is_internal_user_id(self.user_id)
+            and self.session_id.startswith(INTERNAL_AGENT_SESSION_PREFIX)
+        )
+
     def _save_display_history_messages(self, messages: List[dict]) -> None:
         """
         将一组可见消息追加到 Agent 会话历史表。
@@ -365,6 +377,8 @@ class MoviePilotAgent:
         """
         首次对话时生成并保存会话标题。
         """
+        if not self._should_persist_agent_chat():
+            return
         if self._tool_context.get("chat_title_prepared"):
             return
         self._tool_context["chat_title_prepared"] = True
@@ -1366,12 +1380,12 @@ class MoviePilotAgent:
                         break
             self._save_assistant_display_message_once(display_text)
 
-            # 保存消息
-            memory_manager.save_agent_messages(
-                session_id=self.session_id,
-                user_id=self.user_id,
-                messages=agent.get_state(agent_config).values.get("messages", []),
-            )
+            if self._should_persist_agent_chat():
+                memory_manager.save_agent_messages(
+                    session_id=self.session_id,
+                    user_id=self.user_id,
+                    messages=agent.get_state(agent_config).values.get("messages", []),
+                )
             execution_success = True
 
         except asyncio.CancelledError:

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -56,7 +56,7 @@ from app.log import logger
 from app.schemas import AgentLLMProviderEventData, AgentTokensUsageEventData, Notification, NotificationType
 from app.schemas.message import ChannelCapabilityManager, ChannelCapability
 from app.schemas.types import ChainEventType, EventType, MessageChannel, ReplyMode
-from app.utils.identity import SYSTEM_INTERNAL_USER_ID, is_internal_user_id
+from app.utils.identity import SYSTEM_INTERNAL_USER_ID
 
 
 class AgentChain(ChainBase):
@@ -220,7 +220,6 @@ class _ThinkTagStripper:
 # ReplyMode 已迁移至 app.schemas.types(打断 chain↔agent 循环 S4),此处经 import 顶层 re-export 保持 `from app.agent import ReplyMode` 向后兼容
 
 
-INTERNAL_AGENT_SESSION_PREFIX = "__agent_"
 HEARTBEAT_SESSION_PREFIX = "__agent_heartbeat_"
 UNSUPPORTED_IMAGE_INPUT_MESSAGE = "当前模型不支持图片输入，请更换支持图片输入的模型，或在系统设置中关闭图片输入支持后重试。"
 AGENT_EXECUTION_ERROR_PREFIX = "智能助手执行失败"
@@ -311,12 +310,7 @@ class MoviePilotAgent:
         """
         判断当前 Agent 是否需要写入会话历史表。
         """
-        if self.is_heartbeat_session:
-            return False
-        return not (
-            is_internal_user_id(self.user_id)
-            and self.session_id.startswith(INTERNAL_AGENT_SESSION_PREFIX)
-        )
+        return bool(self.channel and self.source)
 
     def _save_display_history_messages(self, messages: List[dict]) -> None:
         """

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -239,7 +239,6 @@ class MoviePilotAgent:
             original_message_id: Optional[str] = None,
             original_chat_id: Optional[str] = None,
             replay_mode: ReplyMode = ReplyMode.DISPATCH,
-            persist_output_message: bool = True,
             allow_message_tools: bool = True,
             output_callback: Optional[Callable[[str], None]] = None,
     ):
@@ -251,7 +250,6 @@ class MoviePilotAgent:
         self.original_message_id = original_message_id
         self.original_chat_id = original_chat_id
         self.reply_mode = replay_mode
-        self.persist_output_message = persist_output_message
         self.allow_message_tools = allow_message_tools
         self.output_callback = output_callback
         self._tool_context: Dict[str, object] = {}
@@ -775,8 +773,6 @@ class MoviePilotAgent:
         title = "MoviePilot助手" if self.is_background else ""
         if self.should_dispatch_reply:
             await self.send_agent_message(message, title=title)
-        elif self.persist_output_message:
-            await self._save_agent_message_to_db(message, title=title)
 
     def _emit_output(self, text: str):
         """
@@ -1119,19 +1115,6 @@ class MoviePilotAgent:
                             and not self._tool_context.get("user_reply_sent")
                     ):
                         await self.send_agent_message(remaining_text)
-                    elif (
-                            remaining_text
-                            and self.persist_output_message
-                            and not self._tool_context.get("user_reply_sent")
-                    ):
-                        title = "MoviePilot助手" if self.is_background else ""
-                        await self._save_agent_message_to_db(
-                            remaining_text,
-                            title=title,
-                        )
-                elif streamed_text and self.persist_output_message:
-                    # 流式输出已发送全部内容，但未记录到数据库，补充保存消息记录
-                    await self._save_agent_message_to_db(streamed_text)
 
             else:
                 # 非流式模式：后台任务或渠道不支持消息编辑
@@ -1173,13 +1156,6 @@ class MoviePilotAgent:
                     else:
                         # 非流式渠道：发送最终回复
                         await self.send_agent_message(final_text)
-                elif (
-                        final_text
-                        and self.persist_output_message
-                        and not self._tool_context.get("user_reply_sent")
-                ):
-                    title = "MoviePilot助手" if self.is_background else ""
-                    await self._save_agent_message_to_db(final_text, title=title)
 
             # 保存消息
             memory_manager.save_agent_messages(
@@ -1231,26 +1207,6 @@ class MoviePilotAgent:
             )
         )
 
-    async def _save_agent_message_to_db(self, message: str, title: str = ""):
-        """
-        仅保存Agent回复消息到数据库和SSE队列（不重新发送到渠道）
-        用于流式输出场景：消息已通过 send_direct_message/edit_message 发送给用户，
-        但未记录到数据库中，此方法补充保存消息历史记录。
-        """
-        chain = AgentChain()
-        notification = Notification(
-            channel=self.channel,
-            source=self.source,
-            userid=self.user_id,
-            username=self.username,
-            title=title,
-            text=message,
-        )
-        # 保存到SSE消息队列（供前端展示）
-        chain.messagehelper.put(notification, role="user", title=title)
-        # 保存到数据库
-        await chain.messageoper.async_add(**notification.model_dump())
-
     async def cleanup(self):
         """
         清理智能体资源
@@ -1277,7 +1233,6 @@ class _MessageTask:
     original_chat_id: Optional[str] = None
     processing_status: Optional[dict] = None
     reply_mode: ReplyMode = ReplyMode.DISPATCH
-    persist_output_message: bool = True
     allow_message_tools: bool = True
 
 
@@ -1423,7 +1378,6 @@ class AgentManager:
             original_message_id: Optional[str] = None,
             original_chat_id: Optional[str] = None,
             reply_mode: ReplyMode = ReplyMode.DISPATCH,
-            persist_output_message: bool = True,
             allow_message_tools: bool = True,
     ) -> str:
         """
@@ -1443,7 +1397,6 @@ class AgentManager:
             original_message_id=original_message_id,
             original_chat_id=original_chat_id,
             reply_mode=reply_mode,
-            persist_output_message=persist_output_message,
             allow_message_tools=allow_message_tools,
         )
         self._record_session_activity(session_id, user_id)
@@ -1554,7 +1507,6 @@ class AgentManager:
                 original_message_id=task.original_message_id,
                 original_chat_id=task.original_chat_id,
                 replay_mode=task.reply_mode,
-                persist_output_message=task.persist_output_message,
                 allow_message_tools=task.allow_message_tools,
             )
             self.active_agents[session_id] = agent
@@ -1570,7 +1522,6 @@ class AgentManager:
             agent.original_message_id = task.original_message_id
             agent.original_chat_id = task.original_chat_id
             agent.reply_mode = task.reply_mode
-            agent.persist_output_message = task.persist_output_message
             agent.allow_message_tools = task.allow_message_tools
 
         process_kwargs = {
@@ -1649,7 +1600,6 @@ class AgentManager:
             session_prefix: str = "__agent_background",
             output_callback: Optional[Callable[[str], None]] = None,
             reply_mode: ReplyMode = ReplyMode.CAPTURE_ONLY,
-            persist_output_message: bool = True,
             allow_message_tools: Optional[bool] = None,
     ) -> None:
         """
@@ -1670,7 +1620,6 @@ class AgentManager:
             source=None,
             username=settings.SUPERUSER,
             replay_mode=reply_mode,
-            persist_output_message=persist_output_message,
             output_callback=output_callback,
             allow_message_tools=allow_message_tools,
         )
@@ -1716,7 +1665,6 @@ class AgentManager:
                 source=None,
                 username=settings.SUPERUSER,
                 reply_mode=ReplyMode.CAPTURE_ONLY,
-                persist_output_message=False,
                 allow_message_tools=True,
             )
 

--- a/app/agent/memory/__init__.py
+++ b/app/agent/memory/__init__.py
@@ -4,9 +4,10 @@ import asyncio
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import BaseMessage, messages_from_dict, messages_to_dict
 
 from app.core.config import settings
+from app.db.agentchat_oper import AgentChatOper
 from app.log import logger
 from app.schemas.agent import ConversationMemory
 
@@ -70,24 +71,43 @@ class MemoryManager:
             self, session_id: str, user_id: str
     ) -> List[BaseMessage]:
         """
-        为Agent获取最近的消息（仅内存缓存）
+        为Agent获取最近的消息。
 
-        如果消息Token数量超过模型最大上下文长度的阀值，会自动进行摘要裁剪
+        优先使用内存缓存，缓存不存在时从数据库恢复上一轮持久化的原始 messages。
         """
         memory = self.get_memory(session_id, user_id)
-        if not memory:
+        if memory:
+            return memory.messages
+
+        try:
+            chat = AgentChatOper().get(session_id=session_id, user_id=user_id)
+            if not chat:
+                chat = AgentChatOper().get(session_id=session_id)
+        except Exception as e:
+            logger.debug(f"读取持久化Agent会话失败: {e}")
+            return []
+        if not chat or not chat.agent_messages:
             return []
 
-        # 获取所有消息
+        try:
+            messages = messages_from_dict(chat.agent_messages)
+        except Exception as e:
+            logger.debug(f"恢复持久化Agent消息失败: {e}")
+            return []
+
+        memory = ConversationMemory(
+            session_id=session_id,
+            user_id=user_id,
+            messages=messages,
+        )
+        self.save_memory(memory)
         return memory.messages
 
     def save_agent_messages(
             self, session_id: str, user_id: str, messages: List[BaseMessage]
     ):
         """
-        保存Agent消息（仅内存缓存）
-
-        注意：Redis中的记忆通过TTL机制自动过期，这里只更新内存缓存，Redis会在下次访问时自动过期
+        保存Agent消息到内存缓存与持久化会话表。
         """
         memory = self.get_memory(session_id, user_id)
         if not memory:
@@ -98,6 +118,14 @@ class MemoryManager:
 
         # 更新内存缓存
         self.save_memory(memory)
+        try:
+            AgentChatOper().save_agent_messages(
+                session_id=session_id,
+                user_id=user_id,
+                messages=messages_to_dict(messages),
+            )
+        except Exception as e:
+            logger.debug(f"持久化Agent消息失败: {e}")
 
     def save_memory(self, memory: ConversationMemory):
         """

--- a/app/agent/middleware/activity_log.py
+++ b/app/agent/middleware/activity_log.py
@@ -47,11 +47,6 @@ MAX_LOG_FILE_SIZE = 256 * 1024
 # 提取本轮对话上下文的最大字符数（避免过长的对话消耗太多 token）
 MAX_CONTEXT_FOR_SUMMARY = 4000
 
-TRIVIAL_USER_TEXT_PATTERN = re.compile(
-    r"^\s*(你好|您好|hi|hello|hey|谢谢|谢了|多谢|ok|好的|收到|嗯|嗯嗯|是的|对|可以|行|好)\s*[。.!！]?\s*$",
-    re.IGNORECASE,
-)
-
 SUMMARY_SKIP_MARKER = "SKIP"
 
 # LLM 总结的提示词
@@ -343,15 +338,7 @@ def _should_skip_activity_summary(round_messages: list) -> bool:
     if has_tool_activity:
         return False
 
-    user_text_parts = []
-    for msg in round_messages:
-        if not isinstance(msg, HumanMessage):
-            continue
-        content = msg.content if isinstance(msg.content, str) else str(msg.content)
-        if content:
-            user_text_parts.append(content)
-    user_text = " ".join(user_text_parts).strip()
-    return bool(user_text and TRIVIAL_USER_TEXT_PATTERN.match(user_text))
+    return True
 
 
 async def _summarize_with_llm(conversation_text: str) -> Optional[str]:

--- a/app/agent/middleware/activity_log.py
+++ b/app/agent/middleware/activity_log.py
@@ -3,13 +3,14 @@
 
 按日期存储在 CONFIG_PATH/agent/activity/YYYY-MM-DD.md 中，
 每次 Agent 执行完毕后自动调用 LLM 对本轮对话生成简洁的活动摘要，
-并在每次 Agent 启动时加载近几天的活动日志注入系统提示词。
+并在每次 Agent 启动时注入轻量索引，完整日志由工具按需查询。
 """
 
 import re
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
-from typing import Annotated, Any, NotRequired, TypedDict
+from pathlib import Path
+from typing import Annotated, Any, NotRequired, Optional, TypedDict
 
 from anyio import Path as AsyncPath
 from langchain.agents.middleware.types import (
@@ -30,8 +31,15 @@ from app.log import logger
 # 活动日志保留天数
 DEFAULT_RETENTION_DAYS = 7
 
-# 注入系统提示词时加载的天数
+# 注入系统提示词时索引的天数
 PROMPT_LOAD_DAYS = 3
+
+# 工具默认查询的天数
+DEFAULT_QUERY_DAYS = 7
+
+# 工具单次返回的最大条数
+DEFAULT_QUERY_LIMIT = 20
+MAX_QUERY_LIMIT = 50
 
 # 每日日志文件最大大小 (256KB)
 MAX_LOG_FILE_SIZE = 256 * 1024
@@ -39,20 +47,194 @@ MAX_LOG_FILE_SIZE = 256 * 1024
 # 提取本轮对话上下文的最大字符数（避免过长的对话消耗太多 token）
 MAX_CONTEXT_FOR_SUMMARY = 4000
 
+TRIVIAL_USER_TEXT_PATTERN = re.compile(
+    r"^\s*(你好|您好|hi|hello|hey|谢谢|谢了|多谢|ok|好的|收到|嗯|嗯嗯|是的|对|可以|行|好)\s*[。.!！]?\s*$",
+    re.IGNORECASE,
+)
+
+SUMMARY_SKIP_MARKER = "SKIP"
+
 # LLM 总结的提示词
-SUMMARY_PROMPT = """请根据以下 AI 助手与用户的对话记录，生成一条简洁的活动摘要（中文，一句话，不超过80字）。
-摘要应包含：用户的需求是什么、助手做了什么、结果如何。
-只输出摘要内容，不要加任何前缀、标点序号或解释。
+SUMMARY_PROMPT = """请判断以下 AI 助手与用户的对话是否值得写入 MoviePilot 活动日志。
+
+如果本轮只是问候、寒暄、感谢、确认、闲聊、没有实际任务、没有工具动作、任务没有推进、纯粹的格式纠正或无意义空转，请只输出：SKIP
+
+如果值得记录，请输出一条中文单行活动摘要，要求：
+- 40 到 160 个汉字左右，信息密度高，不要写成泛泛一句话。
+- 只输出摘要正文，不要标题、编号、Markdown、JSON 或解释。
+- 尽量包含：用户目标、关键对象（影片/剧集/站点/路径/任务/设置）、助手采取的关键动作或工具、结果状态、失败原因或下一步。
+- 如果有明确 ID、路径、站点名、任务状态、成功/失败数量，请保留关键值。
+- 不要记录 API Key、Cookie、Token、密码等敏感信息；如出现请写成“敏感信息已省略”。
+
+推荐格式示例：
+用户要求整理 `/downloads/Show`，助手识别为《示例剧》TMDB 12345，并提交 transfer_file 整理，结果成功。
+用户排查下载失败，助手查询 qBittorrent 任务和站点状态，发现 tracker 超时，建议更换站点或重试。
 
 对话记录：
 {conversation}"""
+
+ACTIVITY_ENTRY_PATTERN = re.compile(r"^-\s+\*\*(?P<time>\d{2}:\d{2})\*\*\s+(?P<summary>.+)$")
+
+
+def _coerce_query_limit(limit: Optional[int]) -> int:
+    """规范化活动日志查询条数。"""
+    if limit is None:
+        return DEFAULT_QUERY_LIMIT
+    try:
+        value = int(limit)
+    except (TypeError, ValueError):
+        return DEFAULT_QUERY_LIMIT
+    return min(max(value, 1), MAX_QUERY_LIMIT)
+
+
+def _build_log_path(activity_dir: str, date_str: str) -> Path:
+    """构建指定日期的活动日志路径。"""
+    return Path(activity_dir) / f"{date_str}.md"
+
+
+def _iter_recent_dates(days: int) -> list[str]:
+    """返回从今天开始向前的日期字符串列表。"""
+    normalized_days = max(1, int(days or 1))
+    today = datetime.now().date()
+    return [
+        (today - timedelta(days=index)).strftime("%Y-%m-%d")
+        for index in range(normalized_days)
+    ]
+
+
+def _parse_activity_entries(date_str: str, content: str) -> list[dict[str, str]]:
+    """从单日活动日志 Markdown 中解析活动条目。"""
+    entries: list[dict[str, str]] = []
+    for line in content.splitlines():
+        match = ACTIVITY_ENTRY_PATTERN.match(line.strip())
+        if not match:
+            continue
+        entries.append(
+            {
+                "date": date_str,
+                "time": match.group("time"),
+                "summary": match.group("summary").strip(),
+            }
+        )
+    return entries
+
+
+def _activity_summary_matches_keyword(
+    summary: str,
+    keyword: str,
+    regex_pattern: Optional[re.Pattern[str]],
+) -> bool:
+    """判断活动摘要是否命中普通关键词或正则表达式。"""
+    if regex_pattern:
+        return bool(regex_pattern.search(summary))
+    return keyword.lower() in summary.lower()
+
+
+def load_activity_log_index(activity_dir: str, days: int = PROMPT_LOAD_DAYS) -> dict[str, str]:
+    """加载近期活动日志索引，不返回完整日志正文。"""
+    index: dict[str, str] = {}
+    for date_str in _iter_recent_dates(days):
+        log_path = _build_log_path(activity_dir, date_str)
+        if not log_path.is_file():
+            continue
+        try:
+            content = log_path.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"读取活动日志索引失败 {log_path}: {e}")
+            continue
+        entry_count = len(_parse_activity_entries(date_str, content))
+        if entry_count:
+            index[date_str] = f"{entry_count} 条活动记录"
+    return index
+
+
+def query_activity_logs(
+    activity_dir: str,
+    *,
+    keyword: Optional[str] = None,
+    use_regex: bool = False,
+    date: Optional[str] = None,
+    days: int = DEFAULT_QUERY_DAYS,
+    limit: Optional[int] = DEFAULT_QUERY_LIMIT,
+) -> dict[str, Any]:
+    """
+    查询活动日志条目。
+
+    :param activity_dir: 活动日志目录
+    :param keyword: 可选关键词，按摘要文本过滤
+    :param use_regex: 是否将关键词按正则表达式匹配
+    :param date: 可选日期，格式为 ``YYYY-MM-DD``
+    :param days: 未指定日期时向前查询的天数
+    :param limit: 返回条数上限
+    :return: 查询结果载荷
+    """
+    normalized_limit = _coerce_query_limit(limit)
+    normalized_keyword = str(keyword or "").strip()
+    normalized_use_regex = bool(use_regex)
+    regex_pattern: Optional[re.Pattern[str]] = None
+    if normalized_keyword and normalized_use_regex:
+        try:
+            regex_pattern = re.compile(normalized_keyword, re.IGNORECASE)
+        except re.error as err:
+            return {
+                "success": False,
+                "message": f"无效的活动日志正则表达式: {err}",
+                "activity_dir": activity_dir,
+                "keyword": normalized_keyword,
+                "use_regex": normalized_use_regex,
+                "date": date,
+                "days": days if not date else None,
+                "searched_dates": [],
+                "total_count": 0,
+                "returned_count": 0,
+                "truncated": False,
+                "entries": [],
+            }
+    date_candidates = [date] if date else _iter_recent_dates(days)
+    entries: list[dict[str, str]] = []
+    searched_dates: list[str] = []
+
+    for date_str in date_candidates:
+        if not date_str:
+            continue
+        searched_dates.append(date_str)
+        log_path = _build_log_path(activity_dir, date_str)
+        if not log_path.is_file():
+            continue
+        try:
+            content = log_path.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"读取活动日志失败 {log_path}: {e}")
+            continue
+        for entry in _parse_activity_entries(date_str, content):
+            if normalized_keyword and not _activity_summary_matches_keyword(
+                entry["summary"], normalized_keyword, regex_pattern
+            ):
+                continue
+            entries.append(entry)
+
+    entries.sort(key=lambda item: (item["date"], item["time"]), reverse=True)
+    total_count = len(entries)
+    return {
+        "success": True,
+        "activity_dir": activity_dir,
+        "keyword": normalized_keyword or None,
+        "use_regex": normalized_use_regex,
+        "date": date,
+        "days": days if not date else None,
+        "searched_dates": searched_dates,
+        "total_count": total_count,
+        "returned_count": min(total_count, normalized_limit),
+        "truncated": total_count > normalized_limit,
+        "entries": entries[:normalized_limit],
+    }
 
 
 class ActivityLogState(AgentState):
     """ActivityLogMiddleware 的状态模型。"""
 
     activity_log_contents: NotRequired[Annotated[dict[str, str], PrivateStateAttr]]
-    """将日期字符串映射到日志内容的字典。标记为私有，不包含在最终代理状态中。"""
+    """将日期字符串映射到日志索引摘要的字典。标记为私有，不包含在最终代理状态中。"""
 
 
 class ActivityLogStateUpdate(TypedDict):
@@ -61,7 +243,7 @@ class ActivityLogStateUpdate(TypedDict):
     activity_log_contents: dict[str, str]
 
 
-def _extract_last_round(messages: list) -> list | None:
+def _extract_last_round(messages: list) -> Optional[list]:
     """从完整消息列表中提取最后一轮交互。
 
     从最后一条 HumanMessage 到消息末尾即为本轮交互。
@@ -148,7 +330,31 @@ def _format_conversation_for_summary(round_messages: list) -> str:
     return "\n".join(lines)
 
 
-async def _summarize_with_llm(conversation_text: str) -> str | None:
+def _should_skip_activity_summary(round_messages: list) -> bool:
+    """判断本轮交互是否无需生成活动日志。"""
+    if not round_messages:
+        return True
+
+    has_tool_activity = any(
+        isinstance(msg, ToolMessage)
+        or (isinstance(msg, AIMessage) and bool(getattr(msg, "tool_calls", None)))
+        for msg in round_messages
+    )
+    if has_tool_activity:
+        return False
+
+    user_text_parts = []
+    for msg in round_messages:
+        if not isinstance(msg, HumanMessage):
+            continue
+        content = msg.content if isinstance(msg.content, str) else str(msg.content)
+        if content:
+            user_text_parts.append(content)
+    user_text = " ".join(user_text_parts).strip()
+    return bool(user_text and TRIVIAL_USER_TEXT_PATTERN.match(user_text))
+
+
+async def _summarize_with_llm(conversation_text: str) -> Optional[str]:
     """调用 LLM 对对话文本生成活动摘要。
 
     参数：
@@ -166,50 +372,47 @@ async def _summarize_with_llm(conversation_text: str) -> str | None:
         summary = response.content.strip()
         # 清理模型可能输出的前缀（如 "摘要：" "总结："）
         summary = re.sub(r"^(摘要|总结|活动记录)[：:]\s*", "", summary)
+        if summary.strip().upper() == SUMMARY_SKIP_MARKER:
+            return None
         return summary if summary else None
     except Exception as e:
-        logger.debug("LLM summarization failed: %s", e)
+        logger.debug(f"LLM 活动摘要生成失败: {e}")
         return None
 
 
 ACTIVITY_LOG_SYSTEM_PROMPT = """<activity_log>
-{activity_log}
-</activity_log>
+<activity_log_index>
+{activity_log_index}
+</activity_log_index>
 
 <activity_log_guidelines>
-    The above <activity_log> contains a record of your recent interactions with the user, automatically maintained by the system.
-    
+    Activity logs are automatically maintained by the system and are available for continuity, but full log contents are not injected into context by default.
+
     **How to use this information:**
-    - Reference past activities when relevant to provide continuity (e.g., "之前帮你订阅了《XXX》，现在有更新了")
-    - Use activity history to understand ongoing tasks and user patterns
-    - When the user asks "你之前帮我做了什么" or similar questions, refer to this log
-    - Activity logs are automatically recorded after each interaction - you do NOT need to manually update them
-    
-    **What is automatically logged:**
-    - Each user interaction: what was asked, which tools were used, and the outcome
-    - Timestamps for all activities
-    - The log is organized by date for easy reference
-    
-    **Important:**
-    - Activity logs are READ-ONLY from your perspective - the system manages them automatically
-    - Do not attempt to edit or write to activity log files
-    - For long-term preferences and knowledge, continue to use MEMORY.md
-    - Activity logs are retained for {retention_days} days and then automatically cleaned up
+    - The <activity_log_index> above only lists which recent dates have activity records and how many entries exist.
+    - Use `query_activity_log` when the user asks about previous work, asks to continue a prior task, or when recent activity is clearly relevant to the current request.
+    - To find related logs, start with a broad search: use the exact date if known; otherwise query recent days with a short keyword, or omit `keyword` and inspect the latest entries. If there are no matches, retry with a larger `days` value or a shorter object/path fragment.
+    - `query_activity_log.keyword` is a plain substring by default. Set `use_regex=true` only when matching alternatives or patterns such as multiple titles, paths, or task IDs.
+    - Do not query activity logs for routine standalone tasks such as file organization, media recognition, downloads, subscriptions, or diagnostics unless the user explicitly references prior activity.
+    - Activity logs are read-only from your perspective. Do not attempt to edit or write to activity log files.
+    - For long-term preferences and knowledge, continue to use MEMORY.md.
+    - Activity logs are retained for {retention_days} days and then automatically cleaned up.
 </activity_log_guidelines>
+</activity_log>
 """
 
 
 class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, ResponseT]):  # noqa
-    """自动记录和加载 Agent 活动日志的中间件。
+    """自动记录 Agent 活动日志并注入轻量索引的中间件。
 
-    - abefore_agent: 加载近几天的活动日志
-    - awrap_model_call: 将活动日志注入系统提示词
+    - abefore_agent: 加载近几天的活动日志索引
+    - awrap_model_call: 将活动日志索引和检索规则注入系统提示词
     - aafter_agent: 从本次对话中提取摘要并追加到当日日志文件
 
     参数：
         activity_dir: 活动日志存储目录路径。
         retention_days: 日志保留天数（默认 7 天）。
-        prompt_load_days: 注入系统提示词时加载的天数（默认 3 天）。
+        prompt_load_days: 注入系统提示词时索引的天数（默认 3 天）。
     """
 
     state_schema = ActivityLogState
@@ -230,10 +433,10 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
         return AsyncPath(self.activity_dir) / f"{date_str}.md"
 
     def _format_activity_log(self, contents: dict[str, str]) -> str:
-        """格式化活动日志用于系统提示词注入。"""
+        """格式化活动日志索引用于系统提示词注入。"""
         if not contents:
             return ACTIVITY_LOG_SYSTEM_PROMPT.format(
-                activity_log="(暂无活动记录)",
+                activity_log_index="(近期暂无活动日志索引。需要历史上下文时可调用 query_activity_log。)",
                 retention_days=self.retention_days,
             )
 
@@ -247,35 +450,22 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
 
         if not sections:
             return ACTIVITY_LOG_SYSTEM_PROMPT.format(
-                activity_log="(暂无活动记录)",
+                activity_log_index="(近期暂无活动日志索引。需要历史上下文时可调用 query_activity_log。)",
                 retention_days=self.retention_days,
             )
 
-        log_body = "\n\n".join(sections)
+        log_body = "\n".join(sections)
         return ACTIVITY_LOG_SYSTEM_PROMPT.format(
-            activity_log=log_body,
+            activity_log_index=log_body,
             retention_days=self.retention_days,
         )
 
     async def _load_recent_logs(self) -> dict[str, str]:
-        """加载近几天的活动日志。"""
-        contents: dict[str, str] = {}
-        today = datetime.now().date()
-
-        for i in range(self.prompt_load_days):
-            date = today - timedelta(days=i)
-            date_str = date.strftime("%Y-%m-%d")
-            log_path = self._get_log_path(date_str)
-
-            if await log_path.exists():
-                try:
-                    content = await log_path.read_text(encoding="utf-8")
-                    contents[date_str] = content
-                    logger.debug("Loaded activity log for %s", date_str)
-                except Exception as e:
-                    logger.warning("Failed to load activity log %s: %s", date_str, e)
-
-        return contents
+        """加载近几天的活动日志索引。"""
+        return load_activity_log_index(
+            activity_dir=self.activity_dir,
+            days=self.prompt_load_days,
+        )
 
     async def _append_activity(self, summary: str) -> None:
         """将一条活动记录追加到当日日志文件。"""
@@ -340,7 +530,7 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
 
     async def abefore_agent(
         self, state: ActivityLogState, runtime: Runtime
-    ) -> ActivityLogStateUpdate | None:
+    ) -> Optional[ActivityLogStateUpdate]:
         """在 Agent 执行前加载近期活动日志。"""
         # 如果已经加载则跳过
         if "activity_log_contents" in state:
@@ -376,7 +566,7 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
 
     async def aafter_agent(
         self, state: ActivityLogState, runtime: Runtime
-    ) -> dict[str, Any] | None:
+    ) -> Optional[dict[str, Any]]:
         """Agent 执行完毕后，调用 LLM 对本轮对话生成摘要并追加到当日活动日志。"""
         try:
             messages = state.get("messages", [])
@@ -386,6 +576,8 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
             # 提取本轮交互
             round_messages = _extract_last_round(messages)
             if not round_messages:
+                return None
+            if _should_skip_activity_summary(round_messages):
                 return None
 
             # 格式化对话文本
@@ -403,4 +595,8 @@ class ActivityLogMiddleware(AgentMiddleware[ActivityLogState, ContextT, Response
         return None
 
 
-__all__ = ["ActivityLogMiddleware"]
+__all__ = [
+    "ActivityLogMiddleware",
+    "load_activity_log_index",
+    "query_activity_logs",
+]

--- a/app/agent/middleware/tool_selection.py
+++ b/app/agent/middleware/tool_selection.py
@@ -1,5 +1,6 @@
 """MoviePilot 自定义工具筛选中间件。"""
 
+from dataclasses import replace
 import json
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, NotRequired
@@ -19,136 +20,38 @@ from langchain.agents.middleware.tool_selection import (
     LLMToolSelectorMiddleware,
 )
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph.runtime import Runtime
 from typing_extensions import TypedDict  # noqa
 
+from app.agent.tools.tags import ToolTag
 from app.log import logger
 
 MIN_SELECTED_TOOL_COUNT = 4
+RECENT_SELECTION_CONTEXT_MESSAGE_LIMIT = 6
+RECENT_SELECTION_CONTEXT_MAX_CHARS = 6000
+RECENT_SELECTION_CONTEXT_TRUNCATION_PREFIX = "..."
+TOOL_GROUP_EXCLUDED_TAGS = frozenset(
+    {
+        ToolTag.AgentTool.value,
+        ToolTag.Read.value,
+        ToolTag.Write.value,
+        ToolTag.Admin.value,
+        ToolTag.Message.value,
+        ToolTag.UserInteraction.value,
+        ToolTag.TerminalResponse.value,
+    }
+)
 
 MOVIEPILOT_TOOL_SELECTION_HINT = """
 
 MoviePilot tool-chain hints:
-- For media search and download tasks, keep related steps together when relevant:
-  search_media, search_torrents, get_search_results, add_download_tasks, query_download_tasks.
-- For file organization and library transfer tasks, keep related steps together when relevant:
-  list_directory, query_directory_settings, recognize_media, query_library_exists, transfer_file, query_transfer_history, scrape_metadata.
-- For subscription tasks, keep related steps together when relevant:
-  search_subscribe, add_subscribe, query_subscribes, update_subscribe, query_subscribe_history, query_popular_subscribes.
-- For download management tasks, keep related steps together when relevant:
-  query_download_tasks, update_download_tasks, delete_download_tasks, query_downloaders.
-- For site diagnostics or maintenance tasks, keep related steps together when relevant:
-  query_sites, query_site_userdata, test_site, update_site, update_site_cookie.
-- For scheduler and workflow tasks, keep related steps together when relevant:
-  query_schedulers, run_scheduler, query_workflows, run_workflow, query_episode_schedule.
-- For plugin tasks, keep related steps together when relevant:
-  query_installed_plugins, query_market_plugins, query_plugin_capabilities, query_plugin_config, update_plugin_config, query_plugin_data, install_plugin, uninstall_plugin, reload_plugin.
-- For rule, identifier, or system setting tasks, keep related steps together when relevant:
-  query_rule_groups, query_builtin_filter_rules, query_custom_filter_rules, add_custom_filter_rule, update_custom_filter_rule, delete_custom_filter_rule, add_rule_group, update_rule_group, delete_rule_group, query_custom_identifiers, update_custom_identifiers, query_system_settings, update_system_settings.
-- Prefer including the likely next-step tools in the same workflow instead of selecting only the first tool.
+- Tools with the same capability tag belong to the same functional group.
+- For multi-step MoviePilot tasks, keep same-tag tools together when relevant.
+- Prefer selecting likely next-step tools in the same capability group instead of selecting only the first tool.
 """
-
-TOOL_CHAIN_GROUPS = (
-    (
-        "media_download",
-        (
-            "search_media",
-            "search_torrents",
-            "get_search_results",
-            "add_download_tasks",
-            "query_download_tasks",
-            "query_downloaders",
-        ),
-    ),
-    (
-        "library_transfer",
-        (
-            "list_directory",
-            "query_directory_settings",
-            "recognize_media",
-            "query_library_exists",
-            "transfer_file",
-            "query_transfer_history",
-            "scrape_metadata",
-        ),
-    ),
-    (
-        "subscription",
-        (
-            "search_subscribe",
-            "add_subscribe",
-            "query_subscribes",
-            "update_subscribe",
-            "delete_subscribe",
-            "query_subscribe_history",
-            "query_popular_subscribes",
-            "query_subscribe_shares",
-        ),
-    ),
-    (
-        "download_management",
-        (
-            "query_download_tasks",
-            "update_download_tasks",
-            "delete_download_tasks",
-            "query_downloaders",
-        ),
-    ),
-    (
-        "site_management",
-        (
-            "query_sites",
-            "query_site_userdata",
-            "test_site",
-            "update_site",
-            "update_site_cookie",
-        ),
-    ),
-    (
-        "workflow_scheduler",
-        (
-            "query_schedulers",
-            "run_scheduler",
-            "query_workflows",
-            "run_workflow",
-            "query_episode_schedule",
-        ),
-    ),
-    (
-        "plugin_management",
-        (
-            "query_installed_plugins",
-            "query_market_plugins",
-            "query_plugin_capabilities",
-            "query_plugin_config",
-            "update_plugin_config",
-            "query_plugin_data",
-            "install_plugin",
-            "uninstall_plugin",
-            "reload_plugin",
-        ),
-    ),
-    (
-        "rule_settings",
-        (
-            "query_rule_groups",
-            "query_builtin_filter_rules",
-            "query_custom_filter_rules",
-            "add_custom_filter_rule",
-            "update_custom_filter_rule",
-            "delete_custom_filter_rule",
-            "add_rule_group",
-            "update_rule_group",
-            "delete_rule_group",
-            "query_custom_identifiers",
-            "update_custom_identifiers",
-            "query_system_settings",
-            "update_system_settings",
-        ),
-    ),
-)
 
 
 class ToolSelectionState(AgentState):
@@ -203,6 +106,73 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
         )
         self.selection_tools = selection_tools or []
 
+    @classmethod
+    def _render_recent_conversation_context(
+            cls,
+            messages: list[Any],
+    ) -> tuple[str, int]:
+        """渲染最近对话上下文，供工具筛选模型理解多轮追问。"""
+        rendered_messages = []
+        for message in messages:
+            if isinstance(message, HumanMessage):
+                role = "User"
+            elif isinstance(message, AIMessage):
+                role = "Assistant"
+            else:
+                continue
+
+            content = cls._extract_text_content(message.content).strip()
+            if not content:
+                continue
+            rendered_messages.append(f"{role}: {content}")
+
+        recent_messages = rendered_messages[-RECENT_SELECTION_CONTEXT_MESSAGE_LIMIT:]
+        context = "\n\n".join(recent_messages)
+        if len(context) > RECENT_SELECTION_CONTEXT_MAX_CHARS:
+            context = (
+                f"{RECENT_SELECTION_CONTEXT_TRUNCATION_PREFIX}"
+                f"{context[-RECENT_SELECTION_CONTEXT_MAX_CHARS:]}"
+            )
+        return context, len(recent_messages)
+
+    @classmethod
+    def _build_contextual_user_message(
+            cls,
+            messages: list[Any],
+            last_user_message: HumanMessage,
+    ) -> HumanMessage:
+        """根据最近对话构造工具筛选专用用户消息。"""
+        context, message_count = cls._render_recent_conversation_context(messages)
+        if message_count <= 1:
+            return last_user_message
+
+        return HumanMessage(
+            content=(
+                "Recent conversation context for tool selection:\n"
+                f"{context}\n\n"
+                "Select tools for the latest user instruction. Use prior assistant "
+                "messages and earlier user requests when the latest user message "
+                "depends on previous context."
+            )
+        )
+
+    def _prepare_selection_request(
+            self,
+            request: ModelRequest[ContextT],
+    ) -> Any | None:
+        """准备带最近对话上下文的工具筛选请求。"""
+        selection_request = super()._prepare_selection_request(request)
+        if selection_request is None:
+            return None
+
+        contextual_user_message = self._build_contextual_user_message(
+            messages=request.messages,
+            last_user_message=selection_request.last_user_message,
+        )
+        if contextual_user_message is selection_request.last_user_message:
+            return selection_request
+        return replace(selection_request, last_user_message=contextual_user_message)
+
     @staticmethod
     def _append_tool_selection_hint(system_prompt: str) -> str:
         """追加 MoviePilot 工具组选择提示，避免复杂链路只选中首个工具。"""
@@ -216,34 +186,123 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
             return min(self.max_tools, len(valid_tool_names))
         return len(valid_tool_names)
 
+    @staticmethod
+    def _normalize_tool_tags(tool: BaseTool) -> list[str]:
+        """读取工具的业务标签，过滤掉无法表达工具组的通用标签。"""
+        tags = getattr(tool, "tags", None) or []
+        if isinstance(tags, str):
+            tags = [tags]
+
+        normalized_tags = []
+        for tag in tags:
+            tag_value = getattr(tag, "value", tag)
+            if not tag_value:
+                continue
+            tag_name = str(tag_value)
+            if tag_name in TOOL_GROUP_EXCLUDED_TAGS or tag_name in normalized_tags:
+                continue
+            normalized_tags.append(tag_name)
+        return normalized_tags
+
+    @classmethod
+    def _build_tool_groups(
+            cls,
+            available_tools: list[BaseTool],
+            valid_tool_names: list[str],
+    ) -> list[tuple[str, list[str]]]:
+        """根据工具标签构造能力组，保留当前工具列表中的稳定顺序。"""
+        valid_tool_set = set(valid_tool_names)
+        tool_groups: dict[str, list[str]] = {}
+        for tool in available_tools:
+            tool_name = getattr(tool, "name", None)
+            if not tool_name or tool_name not in valid_tool_set:
+                continue
+            for tag in cls._normalize_tool_tags(tool):
+                group_tool_names = tool_groups.setdefault(tag, [])
+                if tool_name not in group_tool_names:
+                    group_tool_names.append(tool_name)
+
+        return [
+            (tag, tool_names)
+            for tag, tool_names in tool_groups.items()
+            if len(tool_names) > 1
+        ]
+
+    @classmethod
+    def _get_matched_tool_groups(
+            cls,
+            selected_names: list[str],
+            available_tools: list[BaseTool],
+            valid_tool_names: list[str],
+    ) -> list[tuple[str, list[str]]]:
+        """返回已选工具命中的标签能力组。"""
+        groups_by_tag = {
+            tag: tool_names
+            for tag, tool_names in cls._build_tool_groups(
+                available_tools=available_tools,
+                valid_tool_names=valid_tool_names,
+            )
+        }
+        tools_by_name = {
+            tool.name: tool
+            for tool in available_tools
+            if getattr(tool, "name", None)
+        }
+        matched_groups: list[tuple[str, list[str]]] = []
+        seen_tags = set()
+        for tool_name in selected_names:
+            tool = tools_by_name.get(tool_name)
+            if not tool:
+                continue
+            for tag in cls._normalize_tool_tags(tool):
+                if tag in seen_tags or tag not in groups_by_tag:
+                    continue
+                matched_groups.append((tag, groups_by_tag[tag]))
+                seen_tags.add(tag)
+        return matched_groups
+
     def _complete_low_count_selection(
             self,
             selected_tool_names: list[str],
             valid_tool_names: list[str],
+            available_tools: list[BaseTool],
     ) -> list[str]:
         """
-        当模型只选出极少工具时，按 MoviePilot 常见工具链补齐相邻工具。
+        当模型只选出极少工具时，按工具标签补齐同组工具。
 
-        这只补齐已经命中的工具组，不会把所有工具组都展开，因此能降低
-        “选了搜索工具但漏了结果/下载工具”这类链式任务失败概率。
+        工具标签是工具自身声明的能力归属。这里只补齐已经命中的标签组，
+        不会把所有工具组都展开。
         """
         limit = self._get_tool_selection_limit(valid_tool_names)
-        target_count = min(MIN_SELECTED_TOOL_COUNT, limit)
         selected_names = [
             tool_name
             for tool_name in selected_tool_names
             if tool_name in valid_tool_names
         ]
-        if len(selected_names) >= target_count:
-            return selected_names[:limit]
-
         selected_set = set(selected_names)
         valid_tool_set = set(valid_tool_names)
         completed_names = list(selected_names)
+        matched_groups = self._get_matched_tool_groups(
+            selected_names=selected_names,
+            available_tools=available_tools,
+            valid_tool_names=valid_tool_names,
+        )
+        if not matched_groups:
+            return completed_names[:limit]
 
-        for _, group_tool_names in TOOL_CHAIN_GROUPS:
-            if not selected_set.intersection(group_tool_names):
-                continue
+        matched_group_tool_names = {
+            tool_name
+            for _, group_tool_names in matched_groups
+            for tool_name in group_tool_names
+        }
+        target_count = min(
+            max(MIN_SELECTED_TOOL_COUNT, len(matched_group_tool_names)),
+            limit,
+        )
+        if len(selected_names) >= target_count:
+            return selected_names[:limit]
+
+        for _, group_tool_names in matched_groups:
             for tool_name in group_tool_names:
                 if tool_name in selected_set or tool_name not in valid_tool_set:
                     continue
@@ -285,6 +344,7 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
                 if isinstance(tool_name, str)
             ],
             valid_tool_names=valid_tool_names,
+            available_tools=available_tools,
         )
         return super()._process_selection_response(
             response,
@@ -382,12 +442,35 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
             raise ValueError("工具筛选 JSON 顶层必须是对象")
         return payload
 
-    @staticmethod
-    def _render_tool_list(available_tools: list[Any]) -> str:
+    @classmethod
+    def _render_tool_list(cls, available_tools: list[Any]) -> str:
         """把工具名和描述渲染成稳定的文本列表。"""
-        return "\n".join(
-            f"- {tool.name}: {tool.description}" for tool in available_tools
+        lines = []
+        for tool in available_tools:
+            tags = cls._normalize_tool_tags(tool)
+            tag_text = f" [group tags: {', '.join(tags)}]" if tags else ""
+            lines.append(f"- {tool.name}{tag_text}: {tool.description}")
+        return "\n".join(lines)
+
+    @classmethod
+    def _render_tool_groups(cls, available_tools: list[BaseTool]) -> str:
+        """把当前可用工具按标签渲染成能力组提示。"""
+        valid_tool_names = [
+            tool.name
+            for tool in available_tools
+            if getattr(tool, "name", None)
+        ]
+        groups = cls._build_tool_groups(
+            available_tools=available_tools,
+            valid_tool_names=valid_tool_names,
         )
+        if not groups:
+            return ""
+        rendered_groups = "\n".join(
+            f"- {tag}: {', '.join(tool_names)}"
+            for tag, tool_names in groups
+        )
+        return f"Capability groups from tool tags:\n{rendered_groups}\n\n"
 
     def _build_deepseek_selection_prompt(self, selection_request: Any) -> str:
         """
@@ -408,8 +491,10 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
             "- The `tools` field must be a JSON array of strings.\n"
             "- Only use tool names from the allowed list below.\n"
             "- Order tools by relevance, with the most relevant first.\n"
+            "- Tools sharing the same capability tag are in the same group; include same-group tools together when relevant.\n"
             f"{limit_instruction}\n"
             "- Do not add explanations, markdown, or extra keys.\n\n"
+            f"{self._render_tool_groups(selection_request.available_tools)}"
             "Allowed tools:\n"
             f"{self._render_tool_list(selection_request.available_tools)}"
         )

--- a/app/agent/middleware/tool_selection.py
+++ b/app/agent/middleware/tool_selection.py
@@ -26,6 +26,130 @@ from typing_extensions import TypedDict  # noqa
 
 from app.log import logger
 
+MIN_SELECTED_TOOL_COUNT = 4
+
+MOVIEPILOT_TOOL_SELECTION_HINT = """
+
+MoviePilot tool-chain hints:
+- For media search and download tasks, keep related steps together when relevant:
+  search_media, search_torrents, get_search_results, add_download_tasks, query_download_tasks.
+- For file organization and library transfer tasks, keep related steps together when relevant:
+  list_directory, query_directory_settings, recognize_media, query_library_exists, transfer_file, query_transfer_history, scrape_metadata.
+- For subscription tasks, keep related steps together when relevant:
+  search_subscribe, add_subscribe, query_subscribes, update_subscribe, query_subscribe_history, query_popular_subscribes.
+- For download management tasks, keep related steps together when relevant:
+  query_download_tasks, update_download_tasks, delete_download_tasks, query_downloaders.
+- For site diagnostics or maintenance tasks, keep related steps together when relevant:
+  query_sites, query_site_userdata, test_site, update_site, update_site_cookie.
+- For scheduler and workflow tasks, keep related steps together when relevant:
+  query_schedulers, run_scheduler, query_workflows, run_workflow, query_episode_schedule.
+- For plugin tasks, keep related steps together when relevant:
+  query_installed_plugins, query_market_plugins, query_plugin_capabilities, query_plugin_config, update_plugin_config, query_plugin_data, install_plugin, uninstall_plugin, reload_plugin.
+- For rule, identifier, or system setting tasks, keep related steps together when relevant:
+  query_rule_groups, query_builtin_filter_rules, query_custom_filter_rules, add_custom_filter_rule, update_custom_filter_rule, delete_custom_filter_rule, add_rule_group, update_rule_group, delete_rule_group, query_custom_identifiers, update_custom_identifiers, query_system_settings, update_system_settings.
+- Prefer including the likely next-step tools in the same workflow instead of selecting only the first tool.
+"""
+
+TOOL_CHAIN_GROUPS = (
+    (
+        "media_download",
+        (
+            "search_media",
+            "search_torrents",
+            "get_search_results",
+            "add_download_tasks",
+            "query_download_tasks",
+            "query_downloaders",
+        ),
+    ),
+    (
+        "library_transfer",
+        (
+            "list_directory",
+            "query_directory_settings",
+            "recognize_media",
+            "query_library_exists",
+            "transfer_file",
+            "query_transfer_history",
+            "scrape_metadata",
+        ),
+    ),
+    (
+        "subscription",
+        (
+            "search_subscribe",
+            "add_subscribe",
+            "query_subscribes",
+            "update_subscribe",
+            "delete_subscribe",
+            "query_subscribe_history",
+            "query_popular_subscribes",
+            "query_subscribe_shares",
+        ),
+    ),
+    (
+        "download_management",
+        (
+            "query_download_tasks",
+            "update_download_tasks",
+            "delete_download_tasks",
+            "query_downloaders",
+        ),
+    ),
+    (
+        "site_management",
+        (
+            "query_sites",
+            "query_site_userdata",
+            "test_site",
+            "update_site",
+            "update_site_cookie",
+        ),
+    ),
+    (
+        "workflow_scheduler",
+        (
+            "query_schedulers",
+            "run_scheduler",
+            "query_workflows",
+            "run_workflow",
+            "query_episode_schedule",
+        ),
+    ),
+    (
+        "plugin_management",
+        (
+            "query_installed_plugins",
+            "query_market_plugins",
+            "query_plugin_capabilities",
+            "query_plugin_config",
+            "update_plugin_config",
+            "query_plugin_data",
+            "install_plugin",
+            "uninstall_plugin",
+            "reload_plugin",
+        ),
+    ),
+    (
+        "rule_settings",
+        (
+            "query_rule_groups",
+            "query_builtin_filter_rules",
+            "query_custom_filter_rules",
+            "add_custom_filter_rule",
+            "update_custom_filter_rule",
+            "delete_custom_filter_rule",
+            "add_rule_group",
+            "update_rule_group",
+            "delete_rule_group",
+            "query_custom_identifiers",
+            "update_custom_identifiers",
+            "query_system_settings",
+            "update_system_settings",
+        ),
+    ),
+)
+
 
 class ToolSelectionState(AgentState):
     """工具筛选中间件私有状态。"""
@@ -73,11 +197,62 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
     ) -> None:
         super().__init__(
             model=model,
-            system_prompt=system_prompt,
+            system_prompt=self._append_tool_selection_hint(system_prompt),
             max_tools=max_tools,
             always_include=always_include,
         )
         self.selection_tools = selection_tools or []
+
+    @staticmethod
+    def _append_tool_selection_hint(system_prompt: str) -> str:
+        """追加 MoviePilot 工具组选择提示，避免复杂链路只选中首个工具。"""
+        if "MoviePilot tool-chain hints:" in system_prompt:
+            return system_prompt
+        return f"{system_prompt.rstrip()}{MOVIEPILOT_TOOL_SELECTION_HINT}"
+
+    def _get_tool_selection_limit(self, valid_tool_names: list[str]) -> int:
+        """计算补齐筛选结果时允许使用的工具数量上限。"""
+        if self.max_tools:
+            return min(self.max_tools, len(valid_tool_names))
+        return len(valid_tool_names)
+
+    def _complete_low_count_selection(
+            self,
+            selected_tool_names: list[str],
+            valid_tool_names: list[str],
+    ) -> list[str]:
+        """
+        当模型只选出极少工具时，按 MoviePilot 常见工具链补齐相邻工具。
+
+        这只补齐已经命中的工具组，不会把所有工具组都展开，因此能降低
+        “选了搜索工具但漏了结果/下载工具”这类链式任务失败概率。
+        """
+        limit = self._get_tool_selection_limit(valid_tool_names)
+        target_count = min(MIN_SELECTED_TOOL_COUNT, limit)
+        selected_names = [
+            tool_name
+            for tool_name in selected_tool_names
+            if tool_name in valid_tool_names
+        ]
+        if len(selected_names) >= target_count:
+            return selected_names[:limit]
+
+        selected_set = set(selected_names)
+        valid_tool_set = set(valid_tool_names)
+        completed_names = list(selected_names)
+
+        for _, group_tool_names in TOOL_CHAIN_GROUPS:
+            if not selected_set.intersection(group_tool_names):
+                continue
+            for tool_name in group_tool_names:
+                if tool_name in selected_set or tool_name not in valid_tool_set:
+                    continue
+                completed_names.append(tool_name)
+                selected_set.add(tool_name)
+                if len(completed_names) >= target_count:
+                    return completed_names[:limit]
+
+        return completed_names[:limit]
 
     def _process_selection_response(
             self,
@@ -103,6 +278,14 @@ class ToolSelectorMiddleware(LLMToolSelectorMiddleware):
                 tools=[*available_tools, *always_included_tools, *provider_tools]
             )
 
+        response["tools"] = self._complete_low_count_selection(
+            selected_tool_names=[
+                tool_name
+                for tool_name in response.get("tools", [])
+                if isinstance(tool_name, str)
+            ],
+            valid_tool_names=valid_tool_names,
+        )
         return super()._process_selection_response(
             response,
             available_tools,

--- a/app/agent/tools/factory.py
+++ b/app/agent/tools/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Callable
+from typing import Callable, List, Optional, Type
 
 from app.agent.tools.impl.add_download_tasks import AddDownloadTasksTool
 from app.agent.tools.impl.add_subscribe import AddSubscribeTool
@@ -93,6 +93,86 @@ class MoviePilotToolFactory:
     MoviePilot工具工厂
     """
 
+    BUILTIN_TOOL_CLASSES: tuple[Type[MoviePilotTool], ...] = (
+        SearchMediaTool,
+        SearchPersonTool,
+        SearchPersonCreditsTool,
+        RecognizeMediaTool,
+        ScrapeMetadataTool,
+        QueryEpisodeScheduleTool,
+        QueryMediaDetailTool,
+        AddSubscribeTool,
+        UpdateSubscribeTool,
+        SearchSubscribeTool,
+        SearchTorrentsTool,
+        GetSearchResultsTool,
+        SearchWebTool,
+        RecognizeCaptchaTool,
+        AddDownloadTasksTool,
+        QuerySubscribesTool,
+        QuerySubscribeSharesTool,
+        QueryPopularSubscribesTool,
+        QueryBuiltinFilterRulesTool,
+        QueryCustomFilterRulesTool,
+        QueryRuleGroupsTool,
+        AddCustomFilterRuleTool,
+        UpdateCustomFilterRuleTool,
+        DeleteCustomFilterRuleTool,
+        AddRuleGroupTool,
+        UpdateRuleGroupTool,
+        DeleteRuleGroupTool,
+        QuerySubscribeHistoryTool,
+        DeleteSubscribeTool,
+        QueryDownloadTasksTool,
+        DeleteDownloadTasksTool,
+        DeleteDownloadHistoryTool,
+        DeleteTransferHistoryTool,
+        UpdateDownloadTasksTool,
+        QueryDownloadersTool,
+        QuerySitesTool,
+        UpdateSiteTool,
+        QuerySiteUserdataTool,
+        TestSiteTool,
+        UpdateSiteCookieTool,
+        GetRecommendationsTool,
+        QueryLibraryExistsTool,
+        QueryLibraryLatestTool,
+        QueryDirectorySettingsTool,
+        ListDirectoryTool,
+        QueryTransferHistoryTool,
+        TransferFileTool,
+        SendMessageTool,
+        QuerySchedulersTool,
+        RunSchedulerTool,
+        QueryWorkflowsTool,
+        RunWorkflowTool,
+        QueryPersonasTool,
+        SwitchPersonaTool,
+        UpdatePersonaDefinitionTool,
+        ExecuteCommandTool,
+        EditFileTool,
+        WriteFileTool,
+        ReadFileTool,
+        BrowseWebpageTool,
+        QueryInstalledPluginsTool,
+        QueryMarketPluginsTool,
+        QueryPluginCapabilitiesTool,
+        QueryPluginConfigTool,
+        UpdatePluginConfigTool,
+        ReloadPluginTool,
+        QueryPluginDataTool,
+        InstallPluginTool,
+        UninstallPluginTool,
+        RunSlashCommandTool,
+        ListSlashCommandsTool,
+        QueryActivityLogTool,
+        QueryDoctorReportTool,
+        QueryCustomIdentifiersTool,
+        UpdateCustomIdentifiersTool,
+        QuerySystemSettingsTool,
+        UpdateSystemSettingsTool,
+    )
+
     # 这些通用工具需要始终保留，避免大工具集裁剪后让 Agent 丢失基础的
     # 文件系统、命令执行、历史检索或交互确认能力。AskUserChoiceTool 仅在支持按钮
     # 的渠道中才会实际注入，因此后续会再按已加载工具做一次求交集。
@@ -107,7 +187,7 @@ class MoviePilotToolFactory:
     )
 
     @staticmethod
-    def _should_enable_choice_tool(channel: str = None) -> bool:
+    def _should_enable_choice_tool(channel: Optional[str] = None) -> bool:
         if not channel:
             return False
         try:
@@ -137,8 +217,24 @@ class MoviePilotToolFactory:
             if tool_name in available_tool_names
         ]
 
-    @staticmethod
+    @classmethod
+    def _get_builtin_tool_classes(
+        cls, channel: Optional[str] = None
+    ) -> list[Type[MoviePilotTool]]:
+        """
+        返回当前渠道可用的内置工具类清单。
+        """
+        tool_definitions = list(cls.BUILTIN_TOOL_CLASSES)
+        if cls._should_enable_choice_tool(channel):
+            tool_definitions.append(AskUserChoiceTool)
+        tool_definitions.append(SendLocalFileTool)
+        if AgentCapabilityManager.supports_audio_output():
+            tool_definitions.append(SendVoiceMessageTool)
+        return tool_definitions
+
+    @classmethod
     def create_tools(
+        cls,
         session_id: str,
         user_id: str,
         channel: str = None,
@@ -152,90 +248,7 @@ class MoviePilotToolFactory:
         创建MoviePilot工具列表
         """
         tools = []
-        tool_definitions = [
-            SearchMediaTool,
-            SearchPersonTool,
-            SearchPersonCreditsTool,
-            RecognizeMediaTool,
-            ScrapeMetadataTool,
-            QueryEpisodeScheduleTool,
-            QueryMediaDetailTool,
-            AddSubscribeTool,
-            UpdateSubscribeTool,
-            SearchSubscribeTool,
-            SearchTorrentsTool,
-            GetSearchResultsTool,
-            SearchWebTool,
-            RecognizeCaptchaTool,
-            AddDownloadTasksTool,
-            QuerySubscribesTool,
-            QuerySubscribeSharesTool,
-            QueryPopularSubscribesTool,
-            QueryBuiltinFilterRulesTool,
-            QueryCustomFilterRulesTool,
-            QueryRuleGroupsTool,
-            AddCustomFilterRuleTool,
-            UpdateCustomFilterRuleTool,
-            DeleteCustomFilterRuleTool,
-            AddRuleGroupTool,
-            UpdateRuleGroupTool,
-            DeleteRuleGroupTool,
-            QuerySubscribeHistoryTool,
-            DeleteSubscribeTool,
-            QueryDownloadTasksTool,
-            DeleteDownloadTasksTool,
-            DeleteDownloadHistoryTool,
-            DeleteTransferHistoryTool,
-            UpdateDownloadTasksTool,
-            QueryDownloadersTool,
-            QuerySitesTool,
-            UpdateSiteTool,
-            QuerySiteUserdataTool,
-            TestSiteTool,
-            UpdateSiteCookieTool,
-            GetRecommendationsTool,
-            QueryLibraryExistsTool,
-            QueryLibraryLatestTool,
-            QueryDirectorySettingsTool,
-            ListDirectoryTool,
-            QueryTransferHistoryTool,
-            TransferFileTool,
-            SendMessageTool,
-            QuerySchedulersTool,
-            RunSchedulerTool,
-            QueryWorkflowsTool,
-            RunWorkflowTool,
-            QueryPersonasTool,
-            SwitchPersonaTool,
-            UpdatePersonaDefinitionTool,
-            ExecuteCommandTool,
-            EditFileTool,
-            WriteFileTool,
-            ReadFileTool,
-            BrowseWebpageTool,
-            QueryInstalledPluginsTool,
-            QueryMarketPluginsTool,
-            QueryPluginCapabilitiesTool,
-            QueryPluginConfigTool,
-            UpdatePluginConfigTool,
-            ReloadPluginTool,
-            QueryPluginDataTool,
-            InstallPluginTool,
-            UninstallPluginTool,
-            RunSlashCommandTool,
-            ListSlashCommandsTool,
-            QueryActivityLogTool,
-            QueryDoctorReportTool,
-            QueryCustomIdentifiersTool,
-            UpdateCustomIdentifiersTool,
-            QuerySystemSettingsTool,
-            UpdateSystemSettingsTool,
-        ]
-        if MoviePilotToolFactory._should_enable_choice_tool(channel):
-            tool_definitions.append(AskUserChoiceTool)
-        tool_definitions.append(SendLocalFileTool)
-        if AgentCapabilityManager.supports_audio_output():
-            tool_definitions.append(SendVoiceMessageTool)
+        tool_definitions = cls._get_builtin_tool_classes(channel)
         # 创建内置工具
         for ToolClass in tool_definitions:
             tool = ToolClass(session_id=session_id, user_id=user_id)
@@ -282,9 +295,9 @@ class MoviePilotToolFactory:
 
         builtin_tools_count = len(tool_definitions)
         if plugin_tools_count > 0:
-            logger.info(
+            logger.debug(
                 f"成功创建 {len(tools)} 个MoviePilot工具（内置工具: {builtin_tools_count} 个，插件工具: {plugin_tools_count} 个）"
             )
         else:
-            logger.info(f"成功创建 {len(tools)} 个MoviePilot工具")
+            logger.debug(f"成功创建 {len(tools)} 个MoviePilot工具")
         return tools

--- a/app/agent/tools/factory.py
+++ b/app/agent/tools/factory.py
@@ -75,6 +75,7 @@ from app.agent.tools.impl.uninstall_plugin import UninstallPluginTool
 from app.agent.tools.impl.run_slash_command import RunSlashCommandTool
 from app.agent.tools.impl.list_slash_commands import ListSlashCommandsTool
 from app.agent.tools.impl.query_custom_identifiers import QueryCustomIdentifiersTool
+from app.agent.tools.impl.query_activity_log import QueryActivityLogTool
 from app.agent.tools.impl.query_doctor_report import QueryDoctorReportTool
 from app.agent.tools.impl.update_custom_identifiers import UpdateCustomIdentifiersTool
 from app.agent.tools.impl.query_system_settings import QuerySystemSettingsTool
@@ -93,7 +94,7 @@ class MoviePilotToolFactory:
     """
 
     # 这些通用工具需要始终保留，避免大工具集裁剪后让 Agent 丢失基础的
-    # 文件系统、命令执行、主动消息发送或交互确认能力。AskUserChoiceTool 仅在支持按钮
+    # 文件系统、命令执行、历史检索或交互确认能力。AskUserChoiceTool 仅在支持按钮
     # 的渠道中才会实际注入，因此后续会再按已加载工具做一次求交集。
     TOOL_SELECTOR_ALWAYS_INCLUDE_NAMES = (
         "list_directory",
@@ -101,8 +102,7 @@ class MoviePilotToolFactory:
         "read_file",
         "edit_file",
         "execute_command",
-        "query_doctor_report",
-        "send_message",
+        "query_activity_log",
         "ask_user_choice",
     )
 
@@ -224,6 +224,7 @@ class MoviePilotToolFactory:
             UninstallPluginTool,
             RunSlashCommandTool,
             ListSlashCommandsTool,
+            QueryActivityLogTool,
             QueryDoctorReportTool,
             QueryCustomIdentifiersTool,
             UpdateCustomIdentifiersTool,

--- a/app/agent/tools/impl/query_activity_log.py
+++ b/app/agent/tools/impl/query_activity_log.py
@@ -1,0 +1,120 @@
+"""查询 Agent 活动日志工具。"""
+
+import json
+from typing import Optional, Type
+
+from pydantic import BaseModel, Field
+
+from app.agent.middleware.activity_log import (
+    DEFAULT_QUERY_DAYS,
+    DEFAULT_QUERY_LIMIT,
+    query_activity_logs,
+)
+from app.agent.runtime import agent_runtime_manager
+from app.agent.tools.base import MoviePilotTool
+from app.agent.tools.tags import ToolTag
+from app.log import logger
+
+
+class QueryActivityLogInput(BaseModel):
+    """查询活动日志工具的输入参数模型。"""
+
+    explanation: Optional[str] = Field(
+        None,
+        description="Clear explanation of why this tool is being used in the current context",
+    )
+    keyword: Optional[str] = Field(
+        None,
+        description=(
+            "Optional plain-text keyword to filter activity summaries. Use short title, path, site, task, "
+            "or status fragments; omit it to inspect latest entries."
+        ),
+    )
+    use_regex: Optional[bool] = Field(
+        False,
+        description=(
+            "Whether to treat keyword as a regular expression. Defaults to false; enable only for "
+            "alternative or pattern matching."
+        ),
+    )
+    date: Optional[str] = Field(
+        None,
+        description="Optional exact date in YYYY-MM-DD format. If omitted, recent days are searched.",
+    )
+    days: Optional[int] = Field(
+        DEFAULT_QUERY_DAYS,
+        description="Number of recent days to search when date is not specified.",
+    )
+    limit: Optional[int] = Field(
+        DEFAULT_QUERY_LIMIT,
+        description="Maximum number of activity entries to return.",
+    )
+
+
+class QueryActivityLogTool(MoviePilotTool):
+    """
+    Agent 活动日志只读查询工具。
+    """
+
+    name: str = "query_activity_log"
+    tags: list[str] = [
+        ToolTag.Read,
+        ToolTag.System,
+    ]
+    description: str = (
+        "Query recent MoviePilot Agent activity logs on demand. Use this when the user asks what was done before, "
+        "asks to continue a previous task, or explicitly references recent agent activity. Supports keyword, date, "
+        "recent-day window, limit, and optional regex filters. If a keyword search returns no results, retry with "
+        "a shorter keyword, a larger days window, or no keyword to inspect recent entries."
+    )
+    args_schema: Type[BaseModel] = QueryActivityLogInput
+
+    def get_tool_message(self, **kwargs) -> Optional[str]:
+        """根据查询参数生成友好的提示消息。"""
+        keyword = kwargs.get("keyword")
+        date = kwargs.get("date")
+        if date and keyword:
+            return f"查询活动日志: {date} / {keyword}"
+        if date:
+            return f"查询活动日志: {date}"
+        if keyword:
+            return f"搜索活动日志: {keyword}"
+        return "查询近期活动日志"
+
+    async def run(
+        self,
+        keyword: Optional[str] = None,
+        use_regex: Optional[bool] = False,
+        date: Optional[str] = None,
+        days: Optional[int] = DEFAULT_QUERY_DAYS,
+        limit: Optional[int] = DEFAULT_QUERY_LIMIT,
+        **kwargs,
+    ) -> str:
+        """
+        查询活动日志并返回 JSON 字符串。
+        """
+        logger.info(
+            f"执行工具: {self.name}, keyword={keyword}, use_regex={use_regex}, date={date}, "
+            f"days={days}, limit={limit}"
+        )
+        try:
+            payload = await self.run_blocking(
+                "default",
+                query_activity_logs,
+                str(agent_runtime_manager.activity_dir),
+                keyword=keyword,
+                use_regex=bool(use_regex),
+                date=date,
+                days=days or DEFAULT_QUERY_DAYS,
+                limit=limit,
+            )
+            return json.dumps(payload, ensure_ascii=False, indent=2)
+        except Exception as err:
+            logger.error(f"查询活动日志失败: {err}", exc_info=True)
+            return json.dumps(
+                {
+                    "success": False,
+                    "message": f"查询活动日志时发生错误: {str(err)}",
+                },
+                ensure_ascii=False,
+            )

--- a/app/agent/tools/impl/recognize_captcha.py
+++ b/app/agent/tools/impl/recognize_captcha.py
@@ -52,6 +52,7 @@ class RecognizeCaptchaTool(MoviePilotTool):
     tags: list[str] = [
         ToolTag.Read,
         ToolTag.Web,
+        ToolTag.Site,
     ]
     description: str = (
         "Recognize a graphic captcha image and return the captcha text. "
@@ -69,6 +70,21 @@ class RecognizeCaptchaTool(MoviePilotTool):
         if image_url.lower().startswith("data:image/"):
             return "识别图形验证码: data image"
         return f"识别图形验证码: {image_url}"
+
+    @staticmethod
+    def _format_image_url_for_log(image_url: str) -> str:
+        """生成验证码图片地址的安全日志摘要，避免 data URL 图片刷屏。"""
+        clean_url = (image_url or "").strip()
+        if not clean_url:
+            return ""
+        if clean_url.lower().startswith("data:image/"):
+            metadata, separator, data = clean_url.partition(",")
+            if separator:
+                return f"{metadata},<base64:{len(data)} chars>"
+            return f"data:image,<invalid:{len(clean_url)} chars>"
+        if len(clean_url) > 300:
+            return f"{clean_url[:300]}...(已截断，总长度: {len(clean_url)})"
+        return clean_url
 
     @staticmethod
     def _recognize_captcha_sync(
@@ -117,7 +133,10 @@ class RecognizeCaptchaTool(MoviePilotTool):
         :param allow_private_network: 是否允许访问本机或私网地址
         :return: JSON 格式的识别结果
         """
-        logger.info(f"执行工具: {self.name}, 参数: image_url={image_url}")
+        logger.info(
+            f"执行工具: {self.name}, "
+            f"参数: image_url={self._format_image_url_for_log(image_url)}"
+        )
 
         try:
             captcha_text = await self.run_blocking(

--- a/app/agent/tools/impl/send_message.py
+++ b/app/agent/tools/impl/send_message.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, Field, model_validator
 from app.agent.tools.base import MoviePilotTool
 from app.agent.tools.tags import ToolTag
 from app.log import logger
+from app.schemas import Notification
+from app.schemas.types import NotificationType
 
 
 class SendMessageInput(BaseModel):
@@ -77,7 +79,18 @@ class SendMessageTool(MoviePilotTool):
             f"执行工具: {self.name}, 参数: title={title}, message={text}, image_url={image_url}"
         )
         try:
-            await self.send_tool_message(text, title=title, image=image_url)
+            await self.send_notification_message(
+                Notification(
+                    channel=self._channel,
+                    source=self._source,
+                    mtype=NotificationType.Other,
+                    userid=self._user_id,
+                    username=self._username,
+                    title=title,
+                    text=text,
+                    image=image_url,
+                )
+            )
             return "消息已发送"
         except Exception as e:
             logger.error(f"发送消息失败: {e}")

--- a/app/agent/tools/impl/transfer_file.py
+++ b/app/agent/tools/impl/transfer_file.py
@@ -66,6 +66,19 @@ class TransferFileTool(MoviePilotTool):
     args_schema: Type[BaseModel] = TransferFileInput
     require_admin: bool = True
 
+    @staticmethod
+    def _get_fileitem_type(file_path: str, storage: Optional[str] = "local") -> str:
+        """
+        判断待整理路径的文件类型。
+
+        :param file_path: 已规范化的源文件或目录路径
+        :param storage: 源存储类型
+        :return: ``dir`` 或 ``file``
+        """
+        if (storage or "local") == "local" and Path(file_path).is_dir():
+            return "dir"
+        return "dir" if file_path.endswith("/") else "file"
+
     def get_tool_message(self, **kwargs) -> Optional[str]:
         """根据整理参数生成友好的提示消息"""
         file_path = kwargs.get("file_path", "")
@@ -119,7 +132,7 @@ class TransferFileTool(MoviePilotTool):
         fileitem = FileItem(
             storage=storage or "local",
             path=file_path,
-            type="dir" if file_path.endswith("/") else "file",
+            type=TransferFileTool._get_fileitem_type(file_path, storage),
         )
         target_path_obj = Path(target_path) if target_path else None
 

--- a/app/api/endpoints/agent.py
+++ b/app/api/endpoints/agent.py
@@ -10,13 +10,18 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import schemas
 from app.agent import MoviePilotAgent, ReplyMode, StreamingHandler
 from app.agent.llm.capability import AgentCapabilityManager
 from app.core.config import global_vars, settings
+from app.db import get_async_db
+from app.db.agentchat_oper import AgentChatOper
 from app.db.models import User
+from app.db.models.agentchat import AgentChat
 from app.db.user_oper import UserOper, get_current_active_user
 from app.helper.interaction import agent_interaction_manager
 from app.log import logger
@@ -152,9 +157,120 @@ def _build_web_agent_session_id(user: User, session_id: Optional[str]) -> str:
     :return: 可用于 Agent 记忆隔离的服务端会话 ID
     """
     seed = str(session_id or "").strip() or uuid.uuid4().hex
+    if seed.startswith(WEB_AGENT_SESSION_PREFIX):
+        return seed
+    try:
+        existing_chat = AgentChatOper().get(session_id=seed)
+        if existing_chat and _can_access_agent_chat(existing_chat, user):
+            return seed
+    except Exception as e:
+        logger.debug(f"读取WebAgent历史会话失败: {e}")
     user_part = user.name or str(user.id)
     digest = hashlib.sha256(f"{user_part}:{seed}".encode("utf-8")).hexdigest()
     return f"{WEB_AGENT_SESSION_PREFIX}{digest[:32]}"
+
+
+def _can_access_agent_chat(chat: AgentChat, user: User) -> bool:
+    """
+    判断当前登录用户是否可以访问指定 Agent 会话。
+
+    超级用户可查看所有渠道历史；普通用户仅能查看 user_id 或 username 匹配自己的会话。
+    """
+    if not chat or not user:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    user_id = str(user.id)
+    username = str(user.name or "")
+    return chat.user_id == user_id or (bool(username) and chat.username == username)
+
+
+async def _get_accessible_agent_chat(
+    oper: AgentChatOper, session_id: str, user: User
+) -> Optional[AgentChat]:
+    """
+    读取当前用户可访问的 Agent 会话。
+    """
+    chat = await oper.async_get(session_id=session_id)
+    if not chat or not _can_access_agent_chat(chat, user):
+        return None
+    return chat
+
+
+def _apply_web_agent_display_event(event: dict, assistant_message: dict) -> None:
+    """
+    将 WebAgent SSE 事件同步应用到服务端展示消息快照。
+    """
+    event_type = event.get("type")
+    if event_type == "delta":
+        assistant_message["content"] += event.get("content") or ""
+    elif event_type == "tool":
+        for tool in assistant_message["tools"]:
+            tool["status"] = "done"
+        assistant_message["tools"].append(
+            {
+                "id": f"tool-{uuid.uuid4().hex}",
+                "message": str(event.get("message") or "").replace("=>", "", 1).strip(),
+                "status": "running",
+            }
+        )
+    elif event_type == "attachment" and event.get("attachment"):
+        assistant_message["attachments"].append(event["attachment"])
+    elif event_type == "choice" and event.get("choice"):
+        assistant_message["choices"].append({**event["choice"], "status": "pending"})
+    elif event_type == "error":
+        assistant_message["status"] = "error"
+        assistant_message["content"] = (
+            assistant_message["content"]
+            or event.get("message")
+            or "智能助手响应失败"
+        )
+        for tool in assistant_message["tools"]:
+            tool["status"] = "done"
+    elif event_type == "done":
+        if assistant_message.get("status") != "error":
+            assistant_message["status"] = "done"
+        for tool in assistant_message["tools"]:
+            tool["status"] = "done"
+
+
+def _save_web_agent_display_snapshot(
+    *,
+    session_id: str,
+    current_user: User,
+    messages: list[dict],
+    client_session_id: Optional[str] = None,
+) -> None:
+    """
+    保存 WebAgent 当前展示消息快照。
+    """
+    try:
+        oper = AgentChatOper()
+        existing_chat = oper.get(session_id=session_id)
+        AgentChatOper().save_display_messages(
+            session_id=session_id,
+            user_id=(existing_chat.user_id if existing_chat else str(current_user.id)),
+            username=(existing_chat.username if existing_chat else current_user.name),
+            channel=(
+                existing_chat.channel
+                if existing_chat and existing_chat.channel
+                else MessageChannel.WebAgent
+            ),
+            source=(
+                existing_chat.source
+                if existing_chat and existing_chat.source
+                else WEB_AGENT_SOURCE
+            ),
+            original_chat_id=existing_chat.original_chat_id if existing_chat else None,
+            client_session_id=(
+                existing_chat.client_session_id
+                if existing_chat and existing_chat.client_session_id
+                else client_session_id
+            ),
+            messages=messages,
+        )
+    except Exception as e:
+        logger.debug(f"保存WebAgent展示历史失败: {e}")
 
 
 def _build_web_agent_sse(event_type: str, data: Optional[dict] = None) -> str:
@@ -297,6 +413,52 @@ def _build_web_agent_url_attachment(
         "name": name,
         "mime_type": mime_type,
     }
+
+
+def _build_web_agent_input_attachments(
+    images: list[str],
+    files: list[dict],
+    audio_refs: list[str],
+) -> list[dict]:
+    """
+    构造 WebAgent 用户输入附件展示记录。
+    """
+    attachments = []
+    for index, image in enumerate(images or [], start=1):
+        attachments.append(
+            {
+                "kind": "image",
+                "url": image,
+                "download_url": image,
+                "name": f"image-{index}",
+                "mime_type": "image/*",
+            }
+        )
+    for index, file in enumerate(files or [], start=1):
+        ref = file.get("ref") or file.get("url") or file.get("local_path") or ""
+        mime_type = file.get("mime_type")
+        attachments.append(
+            {
+                "kind": _guess_web_agent_attachment_kind(mime_type),
+                "url": ref,
+                "download_url": ref,
+                "name": file.get("name") or f"attachment-{index}",
+                "mime_type": mime_type,
+                "size": file.get("size"),
+                "local_path": file.get("local_path"),
+            }
+        )
+    for index, audio_ref in enumerate(audio_refs or [], start=1):
+        attachments.append(
+            {
+                "kind": "audio",
+                "url": audio_ref,
+                "download_url": audio_ref,
+                "name": f"voice-{index}",
+                "mime_type": "audio/*",
+            }
+        )
+    return attachments
 
 
 def _register_web_agent_file(
@@ -790,6 +952,116 @@ async def web_agent_callback(
     return schemas.Response(success=True, data=result)
 
 
+@router.get("/sessions", summary="获取 Agent 历史会话", response_model=schemas.Response)
+async def list_agent_chat_sessions(
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_async_db),
+    page: Optional[int] = 1,
+    count: Optional[int] = 30,
+) -> schemas.Response:
+    """
+    获取当前用户可访问的 Agent 历史会话列表。
+
+    :param current_user: 当前登录用户
+    :param db: 异步数据库会话
+    :param page: 页码
+    :param count: 每页数量
+    :return: 会话摘要列表
+    """
+    user_id = None if current_user.is_superuser else str(current_user.id)
+    username = None if current_user.is_superuser else current_user.name
+    chats = await AgentChatOper(db).async_list_by_page(
+        page=page,
+        count=count,
+        user_id=user_id,
+        username=username,
+    )
+    return schemas.Response(
+        success=True,
+        data=[AgentChatOper.to_summary(chat) for chat in chats],
+    )
+
+
+@router.get("/sessions/{session_id}", summary="获取 Agent 历史会话详情", response_model=schemas.Response)
+async def get_agent_chat_session(
+    session_id: str,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_async_db),
+) -> schemas.Response:
+    """
+    获取一条 Agent 历史会话详情。
+
+    :param session_id: Agent 会话 ID
+    :param current_user: 当前登录用户
+    :param db: 异步数据库会话
+    :return: 会话详情
+    """
+    chat = await _get_accessible_agent_chat(AgentChatOper(db), session_id, current_user)
+    if not chat:
+        return schemas.Response(success=False, message="会话不存在或无权访问")
+    return schemas.Response(success=True, data=AgentChatOper.to_detail(chat))
+
+
+@router.put("/sessions/{session_id}/display", summary="保存 Agent 展示会话", response_model=schemas.Response)
+async def save_agent_chat_display(
+    session_id: str,
+    payload: schemas.AgentChatDisplaySaveRequest,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_async_db),
+) -> schemas.Response:
+    """
+    保存前端聚合后的 Agent 展示消息。
+
+    :param session_id: Agent 会话 ID
+    :param payload: 展示消息保存请求
+    :param current_user: 当前登录用户
+    :param db: 异步数据库会话
+    :return: 保存后的会话摘要
+    """
+    oper = AgentChatOper(db)
+    existing_chat = await oper.async_get(session_id=session_id)
+    if existing_chat and not _can_access_agent_chat(existing_chat, current_user):
+        return schemas.Response(success=False, message="会话不存在或无权访问")
+
+    messages = [
+        message.model_dump(exclude_none=True)
+        for message in payload.messages
+    ]
+    await run_in_threadpool(
+        _save_web_agent_display_snapshot,
+        session_id=session_id,
+        current_user=current_user,
+        messages=messages,
+        client_session_id=existing_chat.client_session_id if existing_chat else session_id,
+    )
+    chat = await oper.async_get(session_id=session_id)
+    if not chat:
+        return schemas.Response(success=False, message="会话保存失败")
+    return schemas.Response(success=True, data=AgentChatOper.to_summary(chat))
+
+
+@router.delete("/sessions/{session_id}", summary="删除 Agent 历史会话", response_model=schemas.Response)
+async def delete_agent_chat_session(
+    session_id: str,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_async_db),
+) -> schemas.Response:
+    """
+    删除一条 Agent 历史会话。
+
+    :param session_id: Agent 会话 ID
+    :param current_user: 当前登录用户
+    :param db: 异步数据库会话
+    :return: 删除结果
+    """
+    oper = AgentChatOper(db)
+    chat = await _get_accessible_agent_chat(oper, session_id, current_user)
+    if not chat:
+        return schemas.Response(success=False, message="会话不存在或无权访问")
+    deleted = await oper.async_delete(session_id=session_id)
+    return schemas.Response(success=deleted, message="删除成功" if deleted else "删除失败")
+
+
 @router.post("/stream", summary="Web智能助手流式对话")
 async def web_agent_stream(
     payload: schemas.AgentWebChatRequest,
@@ -843,6 +1115,28 @@ async def web_agent_stream(
     session_id = _build_web_agent_session_id(current_user, payload.session_id)
     event_queue: asyncio.Queue = asyncio.Queue()
     last_output = ""
+    user_attachments = _build_web_agent_input_attachments(
+        images=payload.images or [],
+        files=[
+            file.model_dump(exclude_none=True)
+            for file in (payload.files or [])
+        ],
+        audio_refs=payload.audio_refs or [],
+    )
+    display_messages = []
+    if payload.echo_user:
+        display_messages.append(
+            MoviePilotAgent.build_display_message(
+                role="user",
+                content=prompt,
+                attachments=user_attachments,
+            )
+        )
+    assistant_display_message = MoviePilotAgent.build_display_message(
+        role="assistant",
+        status="streaming",
+    )
+    display_messages.append(assistant_display_message)
 
     def output_callback(output: str) -> None:
         """
@@ -852,6 +1146,7 @@ async def web_agent_stream(
         delta = output[len(last_output):] if output.startswith(last_output) else output
         last_output = output
         for item in _split_web_agent_output(delta):
+            _apply_web_agent_display_event(item, assistant_display_message)
             event_queue.put_nowait(item)
 
     def notification_callback(notification: schemas.Notification) -> None:
@@ -859,6 +1154,7 @@ async def web_agent_stream(
         接收 Agent 工具主动发送的 Web 通知。
         """
         for item in _build_web_agent_notification_events(notification):
+            _apply_web_agent_display_event(item, assistant_display_message)
             event_queue.put_nowait(item)
 
     async def event_generator() -> AsyncIterator[str]:
@@ -897,17 +1193,29 @@ async def web_agent_stream(
                 )
             except Exception as err:
                 logger.error(f"Web智能助手执行失败: {str(err)}")
-                await event_queue.put(
-                    {"type": "error", "message": f"智能助手执行失败: {str(err)}"}
-                )
+                error_event = {
+                    "type": "error",
+                    "message": f"智能助手执行失败: {str(err)}",
+                }
+                _apply_web_agent_display_event(error_event, assistant_display_message)
+                await event_queue.put(error_event)
             finally:
-                await event_queue.put({"type": "done"})
+                done_event = {"type": "done"}
+                _apply_web_agent_display_event(done_event, assistant_display_message)
+                await run_in_threadpool(
+                    _save_web_agent_display_snapshot,
+                    session_id=session_id,
+                    current_user=current_user,
+                    messages=display_messages,
+                    client_session_id=payload.session_id or session_id,
+                )
+                await event_queue.put(done_event)
 
         task = asyncio.create_task(run_agent())
         try:
             yield _build_web_agent_sse(
                 "start",
-                {"session_id": payload.session_id or session_id},
+                {"session_id": session_id},
             )
             while not global_vars.is_system_stopped:
                 if await request.is_disconnected():

--- a/app/api/endpoints/agent.py
+++ b/app/api/endpoints/agent.py
@@ -881,7 +881,6 @@ async def web_agent_stream(
             source=WEB_AGENT_SOURCE,
             username=current_user.name,
             replay_mode=ReplyMode.CAPTURE_ONLY,
-            persist_output_message=False,
             allow_message_tools=True,
             output_callback=output_callback,
             notification_callback=notification_callback,

--- a/app/api/endpoints/history.py
+++ b/app/api/endpoints/history.py
@@ -70,7 +70,6 @@ def _start_ai_redo_task(history_id: int, prompt: str, progress_key: str):
                 session_prefix=f"__agent_manual_redo_{history_id}",
                 output_callback=update_output,
                 reply_mode=ReplyMode.CAPTURE_ONLY,
-                persist_output_message=False,
                 allow_message_tools=False,
             )
             progress.update(
@@ -116,7 +115,6 @@ def _start_batch_ai_redo_task(
                 session_prefix="__agent_manual_redo_batch",
                 output_callback=update_output,
                 reply_mode=ReplyMode.CAPTURE_ONLY,
-                persist_output_message=False,
                 allow_message_tools=False,
             )
             progress.update(

--- a/app/api/endpoints/message.py
+++ b/app/api/endpoints/message.py
@@ -12,7 +12,7 @@ from app.core.config import settings, global_vars
 from app.core.security import verify_token, verify_apitoken
 from app.db import get_async_db
 from app.db.models import User
-from app.db.models.message import Message
+from app.db.message_oper import MessageOper
 from app.db.user_oper import get_current_active_superuser
 from app.helper.service import ServiceConfigHelper
 from app.helper.webpush import is_webpush_subscription_gone
@@ -120,7 +120,7 @@ async def get_web_message(
     获取WEB消息列表
     """
     ret_messages = []
-    messages = await Message.async_list_by_page(db, page=page, count=count)
+    messages = await MessageOper(db).async_list_by_page(page=page, count=count)
     for message in messages:
         try:
             ret_messages.append(message.to_dict())
@@ -128,6 +128,20 @@ async def get_web_message(
             logger.error(f"获取WEB消息列表失败: {str(e)}")
             continue
     return ret_messages
+
+
+@router.get("/notification", summary="获取通知消息", response_model=List[schemas.NotificationHistoryItem])
+async def get_notification_message(
+    _: schemas.TokenPayload = Depends(verify_token),
+    db: AsyncSession = Depends(get_async_db),
+    page: Optional[int] = 1,
+    count: Optional[int] = 20,
+):
+    """
+    获取系统发送的通知消息列表。
+    """
+    messages = await MessageOper(db).async_list_sent_by_page(page=page, count=count)
+    return [schemas.NotificationHistoryItem(**message.to_dict()) for message in messages]
 
 
 def wechat_verify(

--- a/app/api/endpoints/openai.py
+++ b/app/api/endpoints/openai.py
@@ -56,9 +56,6 @@ class _CollectingMoviePilotAgent(MoviePilotAgent):
             if self.stream_mode:
                 self.stream_handler.emit(text)
 
-    async def _save_agent_message_to_db(self, message: str, title: str = ""):
-        return None
-
 
 class _OpenAIStreamingHandler(StreamingHandler):
     """

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -347,6 +347,8 @@ async def plugin_releases(
 ) -> dict:
     """
     查询指定插件可直接安装的 GitHub Release 版本。
+
+    市场元数据只读取请求仓库的当前 package，避免版本历史请求触发全部市场缓存读取。
     """
     if not repo_url:
         return {
@@ -357,35 +359,32 @@ async def plugin_releases(
         }
 
     plugin_manager = PluginManager()
-    online_plugins = await plugin_manager.async_get_online_plugins(force=force)
+    market_plugins = await plugin_manager.async_get_plugins_from_market(
+        repo_url, settings.VERSION_FLAG, force
+    )
     market_plugin = next(
         (
             plugin
-            for plugin in online_plugins
-            if plugin.id == plugin_id and plugin.repo_url == repo_url
+            for plugin in market_plugins or []
+            if plugin.id == plugin_id
         ),
         None,
     )
-    if not market_plugin:
+    if not market_plugin and settings.VERSION_FLAG:
+        compatible_plugins = await plugin_manager.async_get_plugins_from_market(
+            repo_url, None, force
+        )
         market_plugin = next(
             (
                 plugin
-                for plugin in online_plugins
+                for plugin in compatible_plugins or []
                 if plugin.id == plugin_id
             ),
             None,
         )
 
-    installed_plugin = next(
-        (
-            plugin
-            for plugin in plugin_manager.get_local_plugins()
-            if plugin.id == plugin_id and plugin.installed
-        ),
-        None,
-    )
     latest_version = market_plugin.plugin_version if market_plugin else None
-    current_version = installed_plugin.plugin_version if installed_plugin else None
+    current_version = plugin_manager.get_local_plugin_version(plugin_id)
     if not getattr(market_plugin, "release", False):
         return {
             "release_supported": False,

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -11,6 +11,7 @@ from starlette.responses import StreamingResponse
 
 from app import schemas
 from app.command import Command
+from app.core.cache import async_fresh
 from app.core.config import settings
 from app.core.event import eventmanager
 from app.helper.plugin_manager import PluginManager
@@ -161,6 +162,7 @@ def _merge_plugin_market_metadata(
     """
     plugin.repo_url = market_plugin.repo_url or plugin.repo_url
     plugin.history = market_plugin.history or {}
+    plugin.release = market_plugin.release
     plugin.has_update = market_plugin.has_update
     plugin.system_version = market_plugin.system_version or plugin.system_version
     plugin.system_version_compatible = market_plugin.system_version_compatible
@@ -336,6 +338,80 @@ async def plugin_history(
     return plugin
 
 
+@router.get("/releases/{plugin_id}", summary="获取插件Release版本", response_model=dict)
+async def plugin_releases(
+    plugin_id: str,
+    _: User = Depends(get_current_active_superuser_async),
+    repo_url: Optional[str] = "",
+    force: bool = False,
+) -> dict:
+    """
+    查询指定插件可直接安装的 GitHub Release 版本。
+    """
+    if not repo_url:
+        return {
+            "release_supported": False,
+            "latest_version": None,
+            "current_version": None,
+            "items": [],
+        }
+
+    plugin_manager = PluginManager()
+    online_plugins = await plugin_manager.async_get_online_plugins(force=force)
+    market_plugin = next(
+        (
+            plugin
+            for plugin in online_plugins
+            if plugin.id == plugin_id and plugin.repo_url == repo_url
+        ),
+        None,
+    )
+    if not market_plugin:
+        market_plugin = next(
+            (
+                plugin
+                for plugin in online_plugins
+                if plugin.id == plugin_id
+            ),
+            None,
+        )
+
+    installed_plugin = next(
+        (
+            plugin
+            for plugin in plugin_manager.get_local_plugins()
+            if plugin.id == plugin_id and plugin.installed
+        ),
+        None,
+    )
+    latest_version = market_plugin.plugin_version if market_plugin else None
+    current_version = installed_plugin.plugin_version if installed_plugin else None
+    if not getattr(market_plugin, "release", False):
+        return {
+            "release_supported": False,
+            "latest_version": latest_version,
+            "current_version": current_version,
+            "items": [],
+        }
+
+    async with async_fresh(force):
+        release_items = await PluginHelper().async_get_plugin_release_versions(plugin_id, repo_url)
+    items = []
+    for item in release_items:
+        version = item.get("version")
+        copied_item = item.copy()
+        copied_item["is_latest"] = bool(latest_version and version == latest_version)
+        copied_item["is_current"] = bool(current_version and version == current_version)
+        items.append(copied_item)
+
+    return {
+        "release_supported": bool(items),
+        "latest_version": latest_version,
+        "current_version": current_version,
+        "items": items,
+    }
+
+
 @router.get("/statistic", summary="插件安装统计", response_model=dict)
 async def statistic(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -364,6 +440,7 @@ def reload_plugin(
 async def install(
     plugin_id: str,
     repo_url: Optional[str] = "",
+    release_version: Optional[str] = None,
     force: Optional[bool] = False,
     _: User = Depends(get_current_active_superuser_async),
 ) -> Any:
@@ -386,7 +463,7 @@ async def install(
         # 插件不存在或需要强制安装，下载安装并注册插件
         if repo_url:
             state, msg = await plugin_helper.async_install(
-                pid=plugin_id, repo_url=repo_url, force_install=force
+                pid=plugin_id, repo_url=repo_url, release_version=release_version, force_install=force
             )
             # 安装失败则直接响应
             if not state:

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -688,6 +688,7 @@ async def get_user_global_setting(_: User = Depends(get_current_active_user_asyn
     info = settings.model_dump(
         include={
             "AI_AGENT_ENABLE",
+            "AI_AGENT_HIDE_ENTRY",
             "LLM_SUPPORT_AUDIO_INPUT",
             "LLM_SUPPORT_AUDIO_OUTPUT",
             "RECOGNIZE_SOURCE",

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1493,8 +1493,6 @@ class ChainBase(metaclass=ABCMeta):
         if not message:
             logger.warning("消息为空，跳过发送")
             return
-        # 保存消息
-        self.messagehelper.put(message, role="user", title=message.title)
         self.messageoper.add(**message.model_dump())
         dispatch_message = self._normalize_notification_for_dispatch(message)
         # 发送消息按设置隔离
@@ -1610,8 +1608,6 @@ class ChainBase(metaclass=ABCMeta):
         if not message:
             logger.warning("消息为空，跳过发送")
             return
-        # 保存消息
-        self.messagehelper.put(message, role="user", title=message.title)
         await self.messageoper.async_add(**message.model_dump())
         dispatch_message = self._normalize_notification_for_dispatch(message)
         # 发送消息按设置隔离
@@ -1703,9 +1699,6 @@ class ChainBase(metaclass=ABCMeta):
         :return: 成功或失败
         """
         note_list = [media.to_dict() for media in medias]
-        self.messagehelper.put(
-            message, role="user", note=note_list, title=message.title
-        )
         self.messageoper.add(**message.model_dump(), note=note_list)
         dispatch_message = self._normalize_notification_for_dispatch(message)
         return self.messagequeue.send_message(
@@ -1725,9 +1718,6 @@ class ChainBase(metaclass=ABCMeta):
         :return: 成功或失败
         """
         note_list = [torrent.torrent_info.to_dict() for torrent in torrents]
-        self.messagehelper.put(
-            message, role="user", note=note_list, title=message.title
-        )
         self.messageoper.add(**message.model_dump(), note=note_list)
         dispatch_message = self._normalize_notification_for_dispatch(message)
         return self.messagequeue.send_message(

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1493,7 +1493,8 @@ class ChainBase(metaclass=ABCMeta):
         if not message:
             logger.warning("消息为空，跳过发送")
             return
-        self.messageoper.add(**message.model_dump())
+        if message.save_history:
+            self.messageoper.add(**message.model_dump())
         dispatch_message = self._normalize_notification_for_dispatch(message)
         # 发送消息按设置隔离
         if not dispatch_message.userid and dispatch_message.mtype:
@@ -1608,7 +1609,8 @@ class ChainBase(metaclass=ABCMeta):
         if not message:
             logger.warning("消息为空，跳过发送")
             return
-        await self.messageoper.async_add(**message.model_dump())
+        if message.save_history:
+            await self.messageoper.async_add(**message.model_dump())
         dispatch_message = self._normalize_notification_for_dispatch(message)
         # 发送消息按设置隔离
         if not dispatch_message.userid and dispatch_message.mtype:
@@ -1699,7 +1701,8 @@ class ChainBase(metaclass=ABCMeta):
         :return: 成功或失败
         """
         note_list = [media.to_dict() for media in medias]
-        self.messageoper.add(**message.model_dump(), note=note_list)
+        if message.save_history:
+            self.messageoper.add(**message.model_dump(), note=note_list)
         dispatch_message = self._normalize_notification_for_dispatch(message)
         return self.messagequeue.send_message(
             "post_medias_message",
@@ -1718,7 +1721,8 @@ class ChainBase(metaclass=ABCMeta):
         :return: 成功或失败
         """
         note_list = [torrent.torrent_info.to_dict() for torrent in torrents]
-        self.messageoper.add(**message.model_dump(), note=note_list)
+        if message.save_history:
+            self.messageoper.add(**message.model_dump(), note=note_list)
         dispatch_message = self._normalize_notification_for_dispatch(message)
         return self.messagequeue.send_message(
             "post_torrents_message",

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -220,6 +220,13 @@ class ChainBase(metaclass=ABCMeta):
         )
         return dispatch_message
 
+    @staticmethod
+    def _build_notice_message_data(message: Notification) -> dict:
+        """
+        构造消息通知事件数据。
+        """
+        return {**message.model_dump(exclude={"save_history"}), "type": message.mtype}
+
     async def async_remove_cache(self, filename: str) -> None:
         """
         异步删除缓存，同时删除Redis和本地缓存
@@ -1555,7 +1562,7 @@ class ChainBase(metaclass=ABCMeta):
                     # 按设定发送
                     self.eventmanager.send_event(
                         etype=EventType.NoticeMessage,
-                        data={**send_message.model_dump(), "type": send_message.mtype},
+                        data=self._build_notice_message_data(send_message),
                     )
                     self.messagequeue.send_message(
                         "post_message", message=send_message, **kwargs
@@ -1565,7 +1572,7 @@ class ChainBase(metaclass=ABCMeta):
         # 发送消息事件
         self.eventmanager.send_event(
             etype=EventType.NoticeMessage,
-            data={**dispatch_message.model_dump(), "type": dispatch_message.mtype},
+            data=self._build_notice_message_data(dispatch_message),
         )
         # 按原消息发送
         self.messagequeue.send_message(
@@ -1671,7 +1678,7 @@ class ChainBase(metaclass=ABCMeta):
                     # 按设定发送
                     await self.eventmanager.async_send_event(
                         etype=EventType.NoticeMessage,
-                        data={**send_message.model_dump(), "type": send_message.mtype},
+                        data=self._build_notice_message_data(send_message),
                     )
                     await self.messagequeue.async_send_message(
                         "post_message", message=send_message, **kwargs
@@ -1681,7 +1688,7 @@ class ChainBase(metaclass=ABCMeta):
         # 发送消息事件
         await self.eventmanager.async_send_event(
             etype=EventType.NoticeMessage,
-            data={**dispatch_message.model_dump(), "type": dispatch_message.mtype},
+            data=self._build_notice_message_data(dispatch_message),
         )
         # 按原消息发送
         await self.messagequeue.async_send_message(

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -1344,7 +1344,8 @@ class DownloadChain(ChainBase):
                 mtype=NotificationType.Download,
                 title="没有正在下载的任务！",
                 userid=userid,
-                link=settings.MP_DOMAIN('#/downloading')
+                link=settings.MP_DOMAIN('#/downloading'),
+                save_history=False,
             ))
             return
         # 发送消息
@@ -1363,7 +1364,8 @@ class DownloadChain(ChainBase):
             title=title,
             text="\n".join(messages),
             userid=userid,
-            link=settings.MP_DOMAIN('#/downloading')
+            link=settings.MP_DOMAIN('#/downloading'),
+            save_history=False,
         ))
 
     def downloading(self, name: Optional[str] = None) -> List[DownloaderTorrent]:

--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -202,7 +202,15 @@ class MessageChain(ChainBase):
                     )
                     return
 
-            if not text.startswith("CALLBACK:"):
+            is_agent_message = self._is_agent_message(
+                userid=userid,
+                text=text,
+                images=images,
+                files=files,
+                has_audio_input=has_audio_input,
+            )
+
+            if not text.startswith("CALLBACK:") and not is_agent_message:
                 self._record_user_message(
                     channel=channel,
                     source=source,
@@ -211,14 +219,7 @@ class MessageChain(ChainBase):
                     text=text,
                 )
 
-            if not self._is_agent_message(
-                    channel=channel,
-                    userid=userid,
-                    text=text,
-                    images=images,
-                    files=files,
-                    has_audio_input=has_audio_input,
-            ):
+            if not is_agent_message:
                 processing_status = self._mark_message_processing_started(
                     channel=channel,
                     source=source,
@@ -435,7 +436,6 @@ class MessageChain(ChainBase):
 
     def _is_agent_message(
             self,
-            channel: MessageChannel,
             userid: Union[str, int],
             text: str,
             images: Optional[List[CommingMessage.MessageImage]] = None,
@@ -771,13 +771,6 @@ class MessageChain(ChainBase):
             selected_label=option.label,
         )
         self._bind_session_id(userid, request.session_id)
-        self._record_user_message(
-            channel=channel,
-            source=source,
-            userid=userid,
-            username=username,
-            text=selected_text,
-        )
         return self._handle_ai_message(
             text=selected_text,
             channel=channel,
@@ -959,7 +952,6 @@ class MessageChain(ChainBase):
                     session_prefix=f"__agent_manual_redo_{history_id}",
                     output_callback=_capture_output,
                     reply_mode=ReplyMode.CAPTURE_ONLY,
-                    persist_output_message=False,
                     allow_message_tools=False,
                 )
                 await self.async_post_message(

--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -32,10 +32,11 @@ from app.core.meta import MetaBase
 from app.db.models import TransferHistory
 from app.db.transferhistory_oper import TransferHistoryOper
 from app.db.user_oper import UserOper
+from app.helper.directory import DirectoryHelper
 from app.helper.interaction import agent_interaction_manager, media_interaction_manager, PendingMediaInteraction
 from app.helper.torrent import TorrentHelper
 from app.log import logger
-from app.schemas import Notification, CommingMessage, NotExistMediaInfo
+from app.schemas import CommingMessage, DownloadDirectory, FileURI, NotExistMediaInfo, Notification
 from app.schemas.message import ChannelCapabilityManager, ChannelCapability
 from app.schemas.types import EventType, MessageChannel, MediaType
 from app.utils.http import RequestUtils
@@ -2080,6 +2081,17 @@ class MediaInteractionChain(ChainBase):
             )
             return True
 
+        if action == "download-dir":
+            self._handle_download_dir_selection(
+                request=request,
+                page_index=index,
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+            )
+            return True
+
         return False
 
     def handle_text_interaction(
@@ -2125,7 +2137,16 @@ class MediaInteractionChain(ChainBase):
             request.source = source
             request.username = username
             index = int(normalized)
-            if request.phase == "torrent":
+            if request.phase == "download-dir":
+                self._handle_download_dir_selection(
+                    request=request,
+                    page_index=index,
+                    channel=channel,
+                    source=source,
+                    userid=userid,
+                    username=username,
+                )
+            elif request.phase == "torrent":
                 self._handle_torrent_selection(
                     request=request,
                     page_index=index,
@@ -2419,6 +2440,22 @@ class MediaInteractionChain(ChainBase):
         contexts = TorrentHelper().sort_torrents(contexts)
         if self._should_auto_download(userid):
             logger.info("用户 %s 在自动下载用户中，开始自动择优下载 ...", userid)
+            request.phase = "torrent"
+            request.page = 0
+            request.title = mediainfo.title
+            request.items = list(contexts)
+            if self._prompt_download_dir_selection(
+                    request=request,
+                    download_mode="auto",
+                    channel=channel,
+                    source=source,
+                    userid=userid,
+                    username=username,
+                    no_exists=no_exists,
+                    original_message_id=original_message_id,
+                    original_chat_id=original_chat_id,
+            ):
+                return
             self._auto_download(
                 request=request,
                 cache_list=contexts,
@@ -2513,6 +2550,15 @@ class MediaInteractionChain(ChainBase):
             return
 
         if page_index == 0:
+            if self._prompt_download_dir_selection(
+                    request=request,
+                    download_mode="auto",
+                    channel=channel,
+                    source=source,
+                    userid=userid,
+                    username=username,
+            ):
+                return
             self._auto_download(
                 request=request,
                 cache_list=request.items,
@@ -2539,6 +2585,16 @@ class MediaInteractionChain(ChainBase):
             return
 
         context: Context = page_items[page_index - 1]
+        if self._prompt_download_dir_selection(
+                request=request,
+                download_mode="single",
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+                context=context,
+        ):
+            return
         DownloadChain().download_single(
             context,
             channel=channel,
@@ -2546,6 +2602,163 @@ class MediaInteractionChain(ChainBase):
             userid=userid,
             username=username,
         )
+
+    def _prompt_download_dir_selection(
+            self,
+            request: PendingMediaInteraction,
+            download_mode: str,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            context: Optional[Context] = None,
+            no_exists: Optional[Dict[Union[int, str], Dict[int, NotExistMediaInfo]]] = None,
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
+    ) -> bool:
+        """
+        在下载前进入目录选择阶段；没有配置下载目录时保持原下载流程。
+        """
+        download_dirs = self._get_download_dirs()
+        if not download_dirs:
+            return False
+
+        request.pending_torrent_page = request.page
+        request.phase = "download-dir"
+        request.page = 0
+        request.download_dirs = download_dirs
+        request.pending_download_mode = download_mode
+        request.pending_download_context = context
+        request.pending_no_exists = no_exists
+        self._post_download_dirs_message(
+            request=request,
+            channel=channel,
+            source=source,
+            userid=userid,
+            original_message_id=original_message_id,
+            original_chat_id=original_chat_id,
+        )
+        return True
+
+    def _handle_download_dir_selection(
+            self,
+            request: PendingMediaInteraction,
+            page_index: Optional[int],
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+    ) -> None:
+        """
+        处理下载目录阶段的序号输入，并继续执行挂起的下载动作。
+        """
+        if request.phase != "download-dir":
+            self._post_invalid_input(
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+            )
+            return
+
+        page_items, page, _ = self._page_items(
+            items=request.download_dirs,
+            page=request.page,
+            page_size=self._page_size(request.channel),
+        )
+        request.page = page
+        if not page_index or page_index < 1 or page_index > len(page_items):
+            self._post_invalid_input(
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+            )
+            return
+
+        download_dir = page_items[page_index - 1]
+        save_path = download_dir.save_path or download_dir.download_path
+        if not save_path:
+            self._post_invalid_input(
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+                title="下载目录配置无效！",
+            )
+            return
+        self._execute_pending_download(
+            request=request,
+            channel=channel,
+            source=source,
+            userid=userid,
+            username=username,
+            save_path=save_path,
+        )
+
+    def _execute_pending_download(
+            self,
+            request: PendingMediaInteraction,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            save_path: str,
+    ) -> None:
+        """
+        使用用户确认的下载目录执行单资源下载或自动择优下载。
+        """
+        download_mode = request.pending_download_mode
+        if download_mode == "single" and request.pending_download_context:
+            context = request.pending_download_context
+            self._restore_torrent_phase(request)
+            DownloadChain().download_single(
+                context,
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+                save_path=save_path,
+            )
+            return
+
+        if download_mode == "auto":
+            cache_list = list(request.items or [])
+            no_exists = request.pending_no_exists
+            self._restore_torrent_phase(request)
+            self._auto_download(
+                request=request,
+                cache_list=cache_list,
+                channel=channel,
+                source=source,
+                userid=userid,
+                username=username,
+                no_exists=no_exists,
+                save_path=save_path,
+            )
+            return
+
+        self._restore_torrent_phase(request)
+        self._post_invalid_input(
+            channel=channel,
+            source=source,
+            userid=userid,
+            username=username,
+            title="下载操作已失效，请重新选择资源",
+        )
+
+    @staticmethod
+    def _restore_torrent_phase(request: PendingMediaInteraction) -> None:
+        """
+        下载动作完成或失效后恢复到资源列表阶段，便于用户继续选择其它资源。
+        """
+        request.phase = "torrent"
+        request.page = request.pending_torrent_page
+        request.download_dirs = []
+        request.pending_download_mode = None
+        request.pending_download_context = None
+        request.pending_no_exists = None
+        request.pending_torrent_page = 0
 
     def _auto_download(
             self,
@@ -2556,6 +2769,7 @@ class MediaInteractionChain(ChainBase):
             userid: Union[str, int],
             username: str,
             no_exists: Optional[Dict[Union[int, str], Dict[int, NotExistMediaInfo]]] = None,
+            save_path: Optional[str] = None,
     ) -> None:
         """
         自动择优下载当前资源列表，并在未完成时补建订阅。
@@ -2572,6 +2786,7 @@ class MediaInteractionChain(ChainBase):
         downloads, lefts = downloadchain.batch_download(
             contexts=cache_list,
             no_exists=no_exists,
+            save_path=save_path,
             channel=channel,
             source=source,
             userid=userid,
@@ -2622,7 +2837,16 @@ class MediaInteractionChain(ChainBase):
         """
         按当前阶段渲染媒体列表或资源列表。
         """
-        if request.phase == "torrent":
+        if request.phase == "download-dir":
+            self._post_download_dirs_message(
+                request=request,
+                channel=channel,
+                source=source,
+                userid=userid,
+                original_message_id=original_message_id,
+                original_chat_id=original_chat_id,
+            )
+        elif request.phase == "torrent":
             self._post_torrents_message(
                 request=request,
                 channel=channel,
@@ -2738,6 +2962,58 @@ class MediaInteractionChain(ChainBase):
             torrents=page_items,
         )
 
+    def _post_download_dirs_message(
+            self,
+            request: PendingMediaInteraction,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
+    ) -> None:
+        """
+        发送或更新下载目录选择列表。
+        """
+        page_items, page, total_pages = self._page_items(
+            items=request.download_dirs,
+            page=request.page,
+            page_size=self._page_size(channel),
+        )
+        request.page = page
+        total = len(request.download_dirs)
+        if self._supports_interactive_buttons(channel):
+            title = f"【{request.title}】请选择下载目录"
+            buttons = self._create_download_dir_buttons(
+                channel=channel,
+                request=request,
+                items=page_items,
+                total=total,
+                total_pages=total_pages,
+            )
+        else:
+            if total > self._page_size(channel):
+                title = f"【{request.title}】请选择下载目录，请回复对应数字（p: 上一页 n: 下一页）"
+            else:
+                title = f"【{request.title}】请选择下载目录，请回复对应数字"
+            buttons = None
+
+        text = "\n".join(
+            f"{index}. {self._format_download_dir_label(download_dir)}"
+            for index, download_dir in enumerate(page_items, start=1)
+        )
+        self.post_message(
+            Notification(
+                channel=channel,
+                source=source,
+                title=title,
+                text=text,
+                userid=userid,
+                buttons=buttons,
+                original_message_id=original_message_id,
+                original_chat_id=original_chat_id,
+            )
+        )
+
     def _create_media_buttons(
             self,
             channel: MessageChannel,
@@ -2836,16 +3112,70 @@ class MediaInteractionChain(ChainBase):
             buttons.extend(self._navigation_buttons(request, total_pages))
         return buttons
 
+    def _create_download_dir_buttons(
+            self,
+            channel: MessageChannel,
+            request: PendingMediaInteraction,
+            items: List[DownloadDirectory],
+            total: int,
+            total_pages: int,
+    ) -> List[List[Dict[str, str]]]:
+        """
+        为下载目录列表生成选择和翻页按钮。
+        """
+        buttons: List[List[Dict[str, str]]] = []
+        max_text_length = ChannelCapabilityManager.get_max_button_text_length(channel)
+        max_per_row = ChannelCapabilityManager.get_max_buttons_per_row(channel)
+
+        current_row: List[Dict[str, str]] = []
+        for index, download_dir in enumerate(items, start=1):
+            if max_per_row == 1:
+                button_text = f"{index}. {self._format_download_dir_label(download_dir)}"
+                if len(button_text) > max_text_length:
+                    button_text = button_text[: max_text_length - 3] + "..."
+                buttons.append(
+                    [
+                        {
+                            "text": button_text,
+                            "callback_data": f"media:{request.request_id}:download-dir:{index}",
+                        }
+                    ]
+                )
+                continue
+
+            current_row.append(
+                {
+                    "text": f"{index}",
+                    "callback_data": f"media:{request.request_id}:download-dir:{index}",
+                }
+            )
+            if len(current_row) == max_per_row or index == len(items):
+                buttons.append(current_row)
+                current_row = []
+
+        if total > self._page_size(channel):
+            buttons.extend(self._navigation_buttons(request, total_pages))
+        return buttons
+
     def _has_next_page(self, request: PendingMediaInteraction) -> bool:
         """
         判断当前视图是否还有下一页。
         """
         _, page, total_pages = self._page_items(
-            items=request.items,
+            items=self._get_current_phase_items(request),
             page=request.page,
             page_size=self._page_size(request.channel),
         )
         return page < total_pages - 1
+
+    @staticmethod
+    def _get_current_phase_items(request: PendingMediaInteraction) -> List[Any]:
+        """
+        获取当前阶段用于分页的数据列表。
+        """
+        if request.phase == "download-dir":
+            return request.download_dirs
+        return request.items
 
     @staticmethod
     def _navigation_buttons(
@@ -2889,6 +3219,39 @@ class MediaInteractionChain(ChainBase):
         start = page * page_size
         end = start + page_size
         return items[start:end], page, total_pages
+
+    @staticmethod
+    def _get_download_dirs() -> List[DownloadDirectory]:
+        """
+        获取可供消息交互选择的下载目录。
+        """
+        return [
+            DownloadDirectory(
+                name=dir_info.name,
+                storage=dir_info.storage or "local",
+                download_path=dir_info.download_path,
+                save_path=FileURI(
+                    storage=dir_info.storage or "local",
+                    path=dir_info.download_path,
+                ).uri,
+                priority=dir_info.priority,
+                media_type=dir_info.media_type,
+                media_category=dir_info.media_category,
+            )
+            for dir_info in DirectoryHelper().get_download_dirs()
+            if dir_info.download_path
+        ]
+
+    @staticmethod
+    def _format_download_dir_label(download_dir: DownloadDirectory) -> str:
+        """
+        格式化下载目录展示名称，优先显示用户配置的目录名称。
+        """
+        save_path = download_dir.save_path or download_dir.download_path or ""
+        name = download_dir.name or save_path or "下载目录"
+        if save_path and name != save_path:
+            return f"{name} ({save_path})"
+        return name
 
     def _page_size(self, channel: Optional[MessageChannel]) -> int:
         """

--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -199,6 +199,7 @@ class MessageChain(ChainBase):
                             userid=userid,
                             username=username,
                             title="语音识别失败，请稍后重试",
+                            save_history=False,
                         )
                     )
                     return
@@ -303,6 +304,7 @@ class MessageChain(ChainBase):
                         userid=userid,
                         username=username,
                         title="请输入要使用传统交互处理的内容",
+                        save_history=False,
                     )
                 )
                 return False
@@ -628,6 +630,7 @@ class MessageChain(ChainBase):
                 userid=userid,
                 username=username,
                 title="回调数据格式错误，请检查！",
+                save_history=False,
             )
         )
         return False
@@ -756,6 +759,7 @@ class MessageChain(ChainBase):
                     userid=userid,
                     username=username,
                     title="该选择已失效，请重新发起选择",
+                    save_history=False,
                 )
             )
             return False
@@ -828,6 +832,7 @@ class MessageChain(ChainBase):
                 userid=userid,
                 username=username,
                 title=f"开始重新整理记录 #{history_id} ...",
+                save_history=False,
             )
         )
 
@@ -841,6 +846,7 @@ class MessageChain(ChainBase):
                     username=username,
                     title=f"整理记录 #{history_id} 已重新整理",
                     link=settings.MP_DOMAIN("#/history"),
+                    save_history=False,
                 )
             )
             return
@@ -854,6 +860,7 @@ class MessageChain(ChainBase):
                 title="重新整理失败",
                 text=errmsg,
                 link=settings.MP_DOMAIN("#/history"),
+                save_history=False,
             )
         )
 
@@ -907,6 +914,7 @@ class MessageChain(ChainBase):
                     userid=userid,
                     username=username,
                     title="MoviePilot智能助手未启用，请在系统设置中启用",
+                    save_history=False,
                 )
             )
             return
@@ -922,6 +930,7 @@ class MessageChain(ChainBase):
                     title="重新整理失败",
                     text=f"整理记录 #{history_id} 不存在",
                     link=settings.MP_DOMAIN("#/history"),
+                    save_history=False,
                 )
             )
             return
@@ -937,6 +946,7 @@ class MessageChain(ChainBase):
                 title=f"已将整理记录 #{history_id} 交给智能助手处理",
                 text="处理完成后会在这里回复结果。",
                 link=settings.MP_DOMAIN("#/history"),
+                save_history=False,
             )
         )
 
@@ -965,6 +975,7 @@ class MessageChain(ChainBase):
                         text=final_output.strip()
                              or f"整理记录 #{history_id} 已由智能助手处理完成。",
                         link=settings.MP_DOMAIN("#/history"),
+                        save_history=False,
                     )
                 )
             except Exception as e:
@@ -977,6 +988,7 @@ class MessageChain(ChainBase):
                         title="智能助手整理失败",
                         text=str(e),
                         link=settings.MP_DOMAIN("#/history"),
+                        save_history=False,
                     )
                 )
 
@@ -1098,6 +1110,7 @@ class MessageChain(ChainBase):
                     source=source,
                     title="智能体会话已清除，下次将创建新的会话",
                     userid=userid,
+                    save_history=False,
                 )
             )
         else:
@@ -1107,6 +1120,7 @@ class MessageChain(ChainBase):
                     source=source,
                     title="您当前没有活跃的智能体会话",
                     userid=userid,
+                    save_history=False,
                 )
             )
 
@@ -1142,6 +1156,7 @@ class MessageChain(ChainBase):
                         source=source,
                         title="智能体推理已应急停止，会话记忆已保留，您可以继续对话",
                         userid=userid,
+                        save_history=False,
                     )
                 )
             else:
@@ -1151,6 +1166,7 @@ class MessageChain(ChainBase):
                         source=source,
                         title="当前没有正在执行的智能体任务",
                         userid=userid,
+                        save_history=False,
                     )
                 )
         else:
@@ -1160,6 +1176,7 @@ class MessageChain(ChainBase):
                     source=source,
                     title="您当前没有活跃的智能体会话",
                     userid=userid,
+                    save_history=False,
                 )
             )
 
@@ -1215,6 +1232,7 @@ class MessageChain(ChainBase):
                     source=source,
                     title="您当前没有活跃的智能体会话",
                     userid=userid,
+                    save_history=False,
                 )
             )
             return
@@ -1228,6 +1246,7 @@ class MessageChain(ChainBase):
                 title="当前智能体会话状态",
                 text=self._format_session_status_text(status),
                 userid=userid,
+                save_history=False,
             )
         )
 
@@ -1258,6 +1277,7 @@ class MessageChain(ChainBase):
                         userid=userid,
                         username=username,
                         title="MoviePilot智能助手未启用，请在系统设置中启用",
+                        save_history=False,
                     )
                 )
                 return False
@@ -1279,6 +1299,7 @@ class MessageChain(ChainBase):
                         userid=userid,
                         username=username,
                         title="请输入您的问题或需求",
+                        save_history=False,
                     )
                 )
                 return False
@@ -1302,6 +1323,7 @@ class MessageChain(ChainBase):
                             userid=userid,
                             username=username,
                             title="附件读取失败，请稍后重试",
+                            save_history=False,
                         )
                     )
                     return False
@@ -1320,6 +1342,7 @@ class MessageChain(ChainBase):
                             userid=userid,
                             username=username,
                             title="附件读取失败，请稍后重试",
+                            save_history=False,
                         )
                     )
                     return False
@@ -1340,6 +1363,7 @@ class MessageChain(ChainBase):
                         userid=userid,
                         username=username,
                         title="文件读取失败，请稍后重试",
+                        save_history=False,
                     )
                 )
                 return False
@@ -2007,6 +2031,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title="交互已失效，请重新搜索或订阅",
+                    save_history=False,
                 )
             )
             return True
@@ -2120,6 +2145,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title="媒体交互已结束",
+                    save_history=False,
                 )
             )
             return True
@@ -2287,6 +2313,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title=f"{meta.name} 没有找到对应的媒体信息！",
+                    save_history=False,
                 )
             )
             return
@@ -2391,6 +2418,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title=f"【{mediainfo.title_year}{request.meta.sea} 媒体库中已存在，如需重新下载请发送：搜索 名称 或 下载 名称】",
+                    save_history=False,
                 )
             )
             return
@@ -2410,6 +2438,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title=f"{mediainfo.title_year}：\n" + "\n".join(messages),
+                    save_history=False,
                 )
             )
 
@@ -2421,6 +2450,7 @@ class MediaInteractionChain(ChainBase):
                 userid=userid,
                 username=username,
                 title=f"开始搜索 {mediainfo.type.value} {mediainfo.title_year} ...",
+                save_history=False,
             )
         )
 
@@ -2433,6 +2463,7 @@ class MediaInteractionChain(ChainBase):
                     userid=userid,
                     username=username,
                     title=f"{mediainfo.title}{request.meta.sea} 未搜索到需要的资源！",
+                    save_history=False,
                 )
             )
             return
@@ -2506,6 +2537,7 @@ class MediaInteractionChain(ChainBase):
                         userid=userid,
                         username=username,
                         title=f"【{mediainfo.title_year}{request.meta.sea} 媒体库中已存在，如需洗版请发送：洗版 XXX】",
+                        save_history=False,
                     )
                 )
                 return
@@ -2909,6 +2941,7 @@ class MediaInteractionChain(ChainBase):
                 buttons=buttons,
                 original_message_id=original_message_id,
                 original_chat_id=original_chat_id,
+                save_history=False,
             ),
             medias=page_items,
         )
@@ -2958,6 +2991,7 @@ class MediaInteractionChain(ChainBase):
                 buttons=buttons,
                 original_message_id=original_message_id,
                 original_chat_id=original_chat_id,
+                save_history=False,
             ),
             torrents=page_items,
         )
@@ -3011,6 +3045,7 @@ class MediaInteractionChain(ChainBase):
                 buttons=buttons,
                 original_message_id=original_message_id,
                 original_chat_id=original_chat_id,
+                save_history=False,
             )
         )
 
@@ -3329,5 +3364,6 @@ class MediaInteractionChain(ChainBase):
                 userid=userid,
                 username=username,
                 title=title,
+                save_history=False,
             )
         )

--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -395,7 +395,6 @@ class SearchChain(ChainBase):
             session_prefix="__agent_search_recommend",
             output_callback=on_output,
             reply_mode=ReplyMode.CAPTURE_ONLY,
-            persist_output_message=False,
             allow_message_tools=False,
         )
         return full_output[0].strip()

--- a/app/chain/site.py
+++ b/app/chain/site.py
@@ -4,18 +4,10 @@ from datetime import datetime
 from typing import List, Optional, Tuple, Union, Dict
 from urllib.parse import urljoin
 
+from app.helper.sites import SitesHelper  # noqa
 from lxml import etree
 
 from app.chain import ChainBase
-from app.helper.interaction import (
-    SlashInteractionManager,
-    build_navigation_buttons,
-    format_markdown_table,
-    page_items,
-    supports_interaction_buttons,
-    supports_markdown,
-    update_or_post_message,
-)
 from app.core.config import global_vars, settings
 from app.core.event import Event, eventmanager
 from app.db.models.site import Site
@@ -25,15 +17,22 @@ from app.helper.browser import PlaywrightHelper
 from app.helper.cloudflare import under_challenge
 from app.helper.cookie import CookieHelper
 from app.helper.cookiecloud import CookieCloudHelper
+from app.helper.interaction import (
+    SlashInteractionManager,
+    build_navigation_buttons,
+    format_markdown_table,
+    page_items,
+    supports_interaction_buttons,
+    supports_markdown,
+    update_or_post_message,
+)
 from app.helper.rss import RssHelper
-from app.helper.sites import SitesHelper  # noqa
 from app.log import logger
 from app.schemas import MessageChannel, Notification, SiteUserData
 from app.schemas.types import EventType, NotificationType
 from app.utils.http import RequestUtils
 from app.utils.site import SiteUtils
 from app.utils.string import StringUtils
-
 
 site_interaction_manager = SlashInteractionManager()
 
@@ -359,7 +358,7 @@ class SiteChain(ChainBase):
             if global_vars.is_system_stopped:
                 logger.info("系统正在停止，中断CookieCloud同步")
                 return False, "系统正在停止，同步被中断"
-                
+
             # 索引器信息
             indexer = siteshelper.get_indexer(domain)
             # 数据库的站点信息
@@ -642,11 +641,11 @@ class SiteChain(ChainBase):
         return True, "连接成功"
 
     def remote_list(
-        self,
-        arg_str: str = "",
-        channel: MessageChannel = None,
-        userid: Union[str, int] = None,
-        source: Optional[str] = None,
+            self,
+            arg_str: str = "",
+            channel: MessageChannel = None,
+            userid: Union[str, int] = None,
+            source: Optional[str] = None,
     ):
         """
         /sites 统一入口。
@@ -660,11 +659,11 @@ class SiteChain(ChainBase):
         )
         normalized_arg = (arg_str or "").strip()
         if normalized_arg and self.handle_text_interaction(
-            channel=channel,
-            source=source,
-            userid=userid,
-            username="",
-            text=normalized_arg,
+                channel=channel,
+                source=source,
+                userid=userid,
+                username="",
+                text=normalized_arg,
         ):
             return
         self._render_site_interaction(
@@ -688,14 +687,14 @@ class SiteChain(ChainBase):
         return parts[1], parts[2]
 
     def handle_callback_interaction(
-        self,
-        callback_data: str,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
-        original_message_id: Optional[Union[str, int]] = None,
-        original_chat_id: Optional[str] = None,
+            self,
+            callback_data: str,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
     ) -> bool:
         """
         处理 /sites 按钮交互。
@@ -760,12 +759,12 @@ class SiteChain(ChainBase):
         return True
 
     def handle_text_interaction(
-        self,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
-        text: str,
+            self,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            text: str,
     ) -> bool:
         """
         处理 /sites 文本补充输入。
@@ -987,14 +986,14 @@ class SiteChain(ChainBase):
         return True
 
     def _render_site_interaction(
-        self,
-        request,
-        channel: MessageChannel,
-        source: Optional[str],
-        userid: Union[str, int],
-        username: Optional[str],
-        original_message_id: Optional[Union[str, int]] = None,
-        original_chat_id: Optional[str] = None,
+            self,
+            request,
+            channel: MessageChannel,
+            source: Optional[str],
+            userid: Union[str, int],
+            username: Optional[str],
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
     ) -> None:
         """
         渲染 /sites 当前页面。
@@ -1202,7 +1201,8 @@ class SiteChain(ChainBase):
             self.post_message(Notification(
                 channel=channel,
                 title=f"站点编号 {site_id} 不存在！",
-                userid=userid))
+                userid=userid,
+                save_history=False))
             return
         # 禁用站点
         siteoper.update(site_id, {
@@ -1229,7 +1229,9 @@ class SiteChain(ChainBase):
             if not site:
                 self.post_message(Notification(
                     channel=channel,
-                    title=f"站点编号 {site_id} 不存在！", userid=userid))
+                    title=f"站点编号 {site_id} 不存在！",
+                    userid=userid,
+                    save_history=False))
                 return
             # 禁用站点
             siteoper.update(site_id, {
@@ -1280,7 +1282,9 @@ class SiteChain(ChainBase):
             self.post_message(Notification(
                 channel=channel,
                 source=source,
-                title=err_title, userid=userid))
+                title=err_title,
+                userid=userid,
+                save_history=False))
             return
         arg_str = str(arg_str).strip()
         args = arg_str.split()
@@ -1292,14 +1296,18 @@ class SiteChain(ChainBase):
             self.post_message(Notification(
                 channel=channel,
                 source=source,
-                title=err_title, userid=userid))
+                title=err_title,
+                userid=userid,
+                save_history=False))
             return
         site_id = args[0]
         if not site_id.isdigit():
             self.post_message(Notification(
                 channel=channel,
                 source=source,
-                title=err_title, userid=userid))
+                title=err_title,
+                userid=userid,
+                save_history=False))
             return
         # 站点ID
         site_id = int(site_id)
@@ -1309,12 +1317,16 @@ class SiteChain(ChainBase):
             self.post_message(Notification(
                 channel=channel,
                 source=source,
-                title=f"站点编号 {site_id} 不存在！", userid=userid))
+                title=f"站点编号 {site_id} 不存在！",
+                userid=userid,
+                save_history=False))
             return
         self.post_message(Notification(
             channel=channel,
             source=source,
-            title=f"开始更新【{site_info.name}】Cookie&UA ...", userid=userid))
+            title=f"开始更新【{site_info.name}】Cookie&UA ...",
+            userid=userid,
+            save_history=False))
         # 用户名
         username = args[1]
         # 密码
@@ -1331,13 +1343,15 @@ class SiteChain(ChainBase):
                 source=source,
                 title=f"【{site_info.name}】 Cookie&UA更新失败！",
                 text=f"错误原因：{msg}",
-                userid=userid))
+                userid=userid,
+                save_history=False))
         else:
             self.post_message(Notification(
                 channel=channel,
                 source=source,
                 title=f"【{site_info.name}】 Cookie&UA更新成功",
-                userid=userid))
+                userid=userid,
+                save_history=False))
 
     def remote_refresh_userdatas(self, channel: MessageChannel,
                                  userid: Union[str, int] = None, source: Optional[str] = None):
@@ -1349,7 +1363,8 @@ class SiteChain(ChainBase):
             channel=channel,
             source=source,
             title="开始刷新站点数据 ...",
-            userid=userid
+            userid=userid,
+            save_history=False,
         ))
         # 刷新站点数据
         site_datas = self.refresh_userdatas()
@@ -1392,12 +1407,14 @@ class SiteChain(ChainBase):
                     source=source,
                     title="【站点数据统计】",
                     text="\n".join(sorted_messages),
-                    userid=userid
+                    userid=userid,
+                    save_history=False
                 ))
         else:
             self.post_message(Notification(
                 channel=channel,
                 source=source,
                 title="没有刷新到任何站点数据！",
-                userid=userid
+                userid=userid,
+                save_history=False,
             ))

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -12,15 +12,6 @@ from app.chain import ChainBase
 from app.chain.download import DownloadChain
 from app.chain.media import MediaChain
 from app.chain.search import SearchChain
-from app.helper.interaction import (
-    SlashInteractionManager,
-    build_navigation_buttons,
-    format_markdown_table,
-    page_items,
-    supports_interaction_buttons,
-    supports_markdown,
-    update_or_post_message,
-)
 from app.chain.tmdb import TmdbChain
 from app.chain.torrents import TorrentsChain
 from app.core.config import settings, global_vars
@@ -34,6 +25,15 @@ from app.db.models.subscribe import Subscribe
 from app.db.site_oper import SiteOper
 from app.db.subscribe_oper import SubscribeOper
 from app.db.systemconfig_oper import SystemConfigOper
+from app.helper.interaction import (
+    SlashInteractionManager,
+    build_navigation_buttons,
+    format_markdown_table,
+    page_items,
+    supports_interaction_buttons,
+    supports_markdown,
+    update_or_post_message,
+)
 from app.helper.server import MoviePilotServerHelper
 from app.helper.torrent import TorrentHelper
 from app.log import logger
@@ -41,7 +41,6 @@ from app.schemas import (MediaRecognizeConvertEventData, SubscribeEpisodesRefres
                          SubscribeCompletionCheckEventData)
 from app.schemas.types import MediaType, SystemConfigKey, MessageChannel, NotificationType, EventType, ChainEventType, \
     ContentType
-
 
 subscribe_interaction_manager = SlashInteractionManager()
 
@@ -365,9 +364,9 @@ class SubscribeChain(ChainBase):
         判断当前订阅是否启用了电视剧全集洗版。
         """
         return (
-            bool(subscribe.best_version_full)
-            and bool(subscribe.best_version)
-            and subscribe.type == MediaType.TV.value
+                bool(subscribe.best_version_full)
+                and bool(subscribe.best_version)
+                and subscribe.type == MediaType.TV.value
         )
 
     @classmethod
@@ -435,9 +434,9 @@ class SubscribeChain(ChainBase):
         构造分集洗版优先全集时使用的整季缺失范围。
         """
         if (
-            not subscribe.best_version
-            or cls.__is_full_best_version_enabled(subscribe)
-            or subscribe.type != MediaType.TV.value
+                not subscribe.best_version
+                or cls.__is_full_best_version_enabled(subscribe)
+                or subscribe.type != MediaType.TV.value
         ):
             return None
 
@@ -474,7 +473,7 @@ class SubscribeChain(ChainBase):
         full_season_contexts = [
             context for context in contexts
             if context.media_info.type == MediaType.TV
-            and self.__is_full_season_resource(meta=context.meta_info, subscribe=subscribe)
+               and self.__is_full_season_resource(meta=context.meta_info, subscribe=subscribe)
         ] if full_pack_no_exists else []
         full_pack_contexts = [
             context for context in full_season_contexts
@@ -1081,10 +1080,10 @@ class SubscribeChain(ChainBase):
                                 # 洗版
                                 if subscribe.best_version:
                                     if (
-                                        torrent_mediainfo.type == MediaType.TV
-                                        and not self.__is_full_season_best_version_resource(
-                                            meta=torrent_meta, subscribe=subscribe
-                                        )
+                                            torrent_mediainfo.type == MediaType.TV
+                                            and not self.__is_full_season_best_version_resource(
+                                        meta=torrent_meta, subscribe=subscribe
+                                    )
                                     ):
                                         logger.info(
                                             f"{subscribe.name} 正在全集洗版，{torrent_info.title} 不是全集资源"
@@ -1092,10 +1091,10 @@ class SubscribeChain(ChainBase):
                                         continue
                                     # 洗版时，不符合订阅集数的不要
                                     if (
-                                        torrent_mediainfo.type == MediaType.TV
-                                        and not self._is_episode_range_covered(
-                                            meta=torrent_meta, subscribe=subscribe
-                                        )
+                                            torrent_mediainfo.type == MediaType.TV
+                                            and not self._is_episode_range_covered(
+                                        meta=torrent_meta, subscribe=subscribe
+                                    )
                                     ):
                                         logger.info(
                                             f"{subscribe.name} 正在洗版，{torrent_info.title} 不符合订阅集数范围"
@@ -1116,9 +1115,9 @@ class SubscribeChain(ChainBase):
                                         # 防止标题元数据与实际种子文件错位导致同优先级集被重复下载。
                                         context.allowed_episodes = set(interested_episodes)
                                     if (
-                                        torrent_mediainfo.type != MediaType.TV
-                                        and subscribe.current_priority
-                                        and torrent_info.pri_order <= subscribe.current_priority
+                                            torrent_mediainfo.type != MediaType.TV
+                                            and subscribe.current_priority
+                                            and torrent_info.pri_order <= subscribe.current_priority
                                     ):
                                         logger.info(
                                             f'{subscribe.name} 正在洗版，{torrent_info.title} 优先级低于或等于已下载优先级')
@@ -1585,8 +1584,8 @@ class SubscribeChain(ChainBase):
                                                 continue
                                 else:
                                     if not self.__is_full_season_best_version_resource(
-                                        meta=torrent_meta,
-                                        subscribe=subscribe,
+                                            meta=torrent_meta,
+                                            subscribe=subscribe,
                                     ):
                                         logger.debug(
                                             f"{subscribe.name} 正在全集洗版，{torrent_info.title} 不是全集资源"
@@ -1594,11 +1593,11 @@ class SubscribeChain(ChainBase):
                                         continue
                                     # 洗版时，不符合订阅集数的不要
                                     if (
-                                        meta.type == MediaType.TV
-                                        and not self._is_episode_range_covered(
-                                            meta=torrent_meta,
-                                            subscribe=subscribe,
-                                        )
+                                            meta.type == MediaType.TV
+                                            and not self._is_episode_range_covered(
+                                        meta=torrent_meta,
+                                        subscribe=subscribe,
+                                    )
                                     ):
                                         logger.debug(
                                             f"{subscribe.name} 正在洗版，{torrent_info.title} 不符合订阅集数范围"
@@ -1642,9 +1641,9 @@ class SubscribeChain(ChainBase):
                                     # 避免 RSS / 订阅刷新场景下标题元数据与种子文件错位导致同优先级集重复下载。
                                     _context.allowed_episodes = set(interested_episodes)
                                 if (
-                                    meta.type != MediaType.TV
-                                    and subscribe.current_priority
-                                    and torrent_info.pri_order <= subscribe.current_priority
+                                        meta.type != MediaType.TV
+                                        and subscribe.current_priority
+                                        and torrent_info.pri_order <= subscribe.current_priority
                                 ):
                                     logger.info(
                                         f'{subscribe.name} 正在洗版，{torrent_info.title} 优先级低于或等于已下载优先级')
@@ -2087,11 +2086,11 @@ class SubscribeChain(ChainBase):
         })
 
     def remote_list(
-        self,
-        arg_str: str = "",
-        channel: MessageChannel = None,
-        userid: Union[str, int] = None,
-        source: Optional[str] = None,
+            self,
+            arg_str: str = "",
+            channel: MessageChannel = None,
+            userid: Union[str, int] = None,
+            source: Optional[str] = None,
     ):
         """
         /subscribes 统一入口。
@@ -2105,11 +2104,11 @@ class SubscribeChain(ChainBase):
         )
         normalized_arg = (arg_str or "").strip()
         if normalized_arg and self.handle_text_interaction(
-            channel=channel,
-            source=source,
-            userid=userid,
-            username="",
-            text=normalized_arg,
+                channel=channel,
+                source=source,
+                userid=userid,
+                username="",
+                text=normalized_arg,
         ):
             return
         self._render_subscribe_interaction(
@@ -2133,14 +2132,14 @@ class SubscribeChain(ChainBase):
         return parts[1], parts[2]
 
     def handle_callback_interaction(
-        self,
-        callback_data: str,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
-        original_message_id: Optional[Union[str, int]] = None,
-        original_chat_id: Optional[str] = None,
+            self,
+            callback_data: str,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
     ) -> bool:
         """
         处理 /subscribes 按钮交互。
@@ -2211,12 +2210,12 @@ class SubscribeChain(ChainBase):
         return True
 
     def handle_text_interaction(
-        self,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
-        text: str,
+            self,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
+            text: str,
     ) -> bool:
         """
         处理 /subscribes 文本补充输入。
@@ -2416,14 +2415,14 @@ class SubscribeChain(ChainBase):
         return True
 
     def _render_subscribe_interaction(
-        self,
-        request,
-        channel: MessageChannel,
-        source: Optional[str],
-        userid: Union[str, int],
-        username: Optional[str],
-        original_message_id: Optional[Union[str, int]] = None,
-        original_chat_id: Optional[str] = None,
+            self,
+            request,
+            channel: MessageChannel,
+            source: Optional[str],
+            userid: Union[str, int],
+            username: Optional[str],
+            original_message_id: Optional[Union[str, int]] = None,
+            original_chat_id: Optional[str] = None,
     ) -> None:
         """
         渲染 /subscribes 当前页面。
@@ -2502,7 +2501,7 @@ class SubscribeChain(ChainBase):
         )
 
     def _format_subscribe_list(
-        self, subscribes: List[Subscribe], channel: Optional[MessageChannel]
+            self, subscribes: List[Subscribe], channel: Optional[MessageChannel]
     ) -> str:
         """
         根据渠道能力格式化订阅列表。
@@ -2590,11 +2589,11 @@ class SubscribeChain(ChainBase):
         )
 
     def _run_refresh_action(
-        self,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
+            self,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
     ) -> None:
         """
         执行订阅刷新。
@@ -2620,11 +2619,11 @@ class SubscribeChain(ChainBase):
         )
 
     def _run_metadata_refresh_action(
-        self,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
+            self,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
     ) -> None:
         """
         执行订阅元数据刷新。
@@ -2657,12 +2656,12 @@ class SubscribeChain(ChainBase):
         return [int(item) for item in re.findall(r"\d+", arg_str or "")]
 
     def _run_search_action(
-        self,
-        arg_str: str,
-        channel: MessageChannel,
-        source: str,
-        userid: Union[str, int],
-        username: str,
+            self,
+            arg_str: str,
+            channel: MessageChannel,
+            source: str,
+            userid: Union[str, int],
+            username: str,
     ) -> Tuple[bool, str]:
         """
         手动执行订阅搜索。
@@ -2756,9 +2755,13 @@ class SubscribeChain(ChainBase):
         删除订阅
         """
         if not arg_str:
-            self.post_message(schemas.Notification(channel=channel, source=source,
-                                                   title="请输入正确的命令格式：/subscribe_delete [id]，"
-                                                         "[id]为订阅编号", userid=userid))
+            self.post_message(schemas.Notification(
+                channel=channel,
+                source=source,
+                title="请输入正确的命令格式：/subscribe_delete [id]，"
+                      "[id]为订阅编号",
+                userid=userid,
+                save_history=False))
             return
         arg_strs = str(arg_str).split()
         subscribeoper = SubscribeOper()
@@ -2769,8 +2772,11 @@ class SubscribeChain(ChainBase):
             subscribe_id = int(arg_str)
             subscribe = subscribeoper.get(subscribe_id)
             if not subscribe:
-                self.post_message(schemas.Notification(channel=channel, source=source,
-                                                       title=f"订阅编号 {subscribe_id} 不存在！", userid=userid))
+                self.post_message(schemas.Notification(
+                    channel=channel, source=source,
+                    title=f"订阅编号 {subscribe_id} 不存在！",
+                    userid=userid,
+                    save_history=False))
                 return
             # 删除订阅
             subscribeoper.delete(subscribe_id)

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -76,16 +76,17 @@ class SubscribeChain(ChainBase):
         return normalized
 
     @classmethod
-    def __get_episode_priority(cls, subscribe: Subscribe) -> Dict[str, int]:
+    def __get_episode_priority(cls, subscribe: Subscribe,
+                               total_episode: Optional[int] = None) -> Dict[str, int]:
         """
         获取订阅按集洗版优先级状态。
         """
-        episode_priority = cls.__normalize_episode_priority(getattr(subscribe, "episode_priority", None))
+        episode_priority = cls.__normalize_episode_priority(subscribe.episode_priority)
         if episode_priority:
             return episode_priority
 
         if subscribe.best_version and subscribe.type == MediaType.TV.value and subscribe.current_priority is not None:
-            target_episodes = cls.__get_best_version_target_episodes(subscribe)
+            target_episodes = cls.__get_best_version_target_episodes(subscribe, total_episode=total_episode)
             return {
                 str(episode): int(subscribe.current_priority)
                 for episode in target_episodes
@@ -100,7 +101,8 @@ class SubscribeChain(ChainBase):
         return cls.__get_episode_priority(subscribe)
 
     @classmethod
-    def __get_best_version_target_episodes(cls, subscribe: Subscribe) -> List[int]:
+    def __get_best_version_target_episodes(cls, subscribe: Subscribe,
+                                           total_episode: Optional[int] = None) -> List[int]:
         """
         获取洗版订阅目标剧集范围。
         """
@@ -108,36 +110,75 @@ class SubscribeChain(ChainBase):
             return []
 
         start_episode = subscribe.start_episode or 1
-        total_episode = subscribe.total_episode or 0
+        total_episode = total_episode or subscribe.total_episode or 0
         if total_episode < start_episode:
             return []
         return list(range(start_episode, total_episode + 1))
+
+    @classmethod
+    def __get_downloaded_best_version_episodes(cls, subscribe: Subscribe,
+                                               total_episode: Optional[int] = None) -> List[int]:
+        """
+        获取洗版订阅目标范围内已下载到任意版本的剧集。
+
+        分集洗版的完成态要求 priority==100，但订阅目标满足查询有时只需要确认
+        目标集是否已下载过任意版本，因此这里按 note 与 episode_priority>0 统计。
+        """
+        if subscribe.type != MediaType.TV.value:
+            return []
+
+        start_episode = subscribe.start_episode or 1
+        total_episode = total_episode or subscribe.total_episode or 0
+        if total_episode < start_episode:
+            return []
+        target_episodes = set(range(start_episode, total_episode + 1))
+        downloaded = set()
+        for episode in subscribe.note or []:
+            try:
+                episode_number = int(episode)
+            except (TypeError, ValueError):
+                continue
+            if episode_number in target_episodes:
+                downloaded.add(episode_number)
+        for episode, priority in (subscribe.episode_priority or {}).items():
+            if not str(episode).isdigit():
+                continue
+            try:
+                if float(priority) > 0:
+                    episode_number = int(episode)
+                    if episode_number in target_episodes:
+                        downloaded.add(episode_number)
+            except (TypeError, ValueError):
+                continue
+        return sorted(downloaded)
 
     @classmethod
     def __get_pending_best_version_episodes_with_priority(
             cls,
             subscribe: Subscribe,
             episode_priority: Optional[dict] = None,
+            total_episode: Optional[int] = None,
     ) -> List[int]:
         """
         使用指定按集优先级状态获取当前仍需继续洗版的剧集。
         """
-        target_episodes = cls.__get_best_version_target_episodes(subscribe)
+        target_episodes = cls.__get_best_version_target_episodes(subscribe, total_episode=total_episode)
         if not target_episodes:
             return []
 
         if episode_priority is None:
-            normalized = cls.__get_episode_priority(subscribe)
+            normalized = cls.__get_episode_priority(subscribe, total_episode=total_episode)
         else:
             normalized = cls.__normalize_episode_priority(episode_priority)
         return [episode for episode in target_episodes if normalized.get(str(episode)) != 100]
 
     @classmethod
-    def _get_pending_best_version_episodes(cls, subscribe: Subscribe) -> List[int]:
+    def _get_pending_best_version_episodes(cls, subscribe: Subscribe,
+                                           total_episode: Optional[int] = None) -> List[int]:
         """
         获取当前仍需继续洗版的剧集。
         """
-        return cls.__get_pending_best_version_episodes_with_priority(subscribe)
+        return cls.__get_pending_best_version_episodes_with_priority(subscribe, total_episode=total_episode)
 
     @classmethod
     def compute_completed_episode(cls, subscribe: Subscribe) -> Optional[int]:
@@ -324,7 +365,7 @@ class SubscribeChain(ChainBase):
         判断当前订阅是否启用了电视剧全集洗版。
         """
         return (
-            bool(getattr(subscribe, "best_version_full", 0))
+            bool(subscribe.best_version_full)
             and bool(subscribe.best_version)
             and subscribe.type == MediaType.TV.value
         )
@@ -2813,7 +2854,8 @@ class SubscribeChain(ChainBase):
                     season=begin_season,
                     episodes=episodes,
                     total_episode=total_episode,
-                    start_episode=start_episode
+                    start_episode=start_episode,
+                    require_complete_coverage=no_exist_season.require_complete_coverage
                 )
         # 根据订阅已下载集数更新缺失集数
         if downloaded_episodes:
@@ -2841,6 +2883,7 @@ class SubscribeChain(ChainBase):
                     episodes=episodes,
                     total_episode=total,
                     start_episode=start,
+                    require_complete_coverage=no_exist_season.require_complete_coverage
                 )
             else:
                 # 开始集数
@@ -2855,6 +2898,7 @@ class SubscribeChain(ChainBase):
                     episodes=episodes,
                     total_episode=total_episode,
                     start_episode=start,
+                    require_complete_coverage=False,
                 )
         logger.info(f'订阅 {subscribe_name} 缺失剧集数更新为：{no_exists}')
         return False, no_exists
@@ -3070,72 +3114,12 @@ class SubscribeChain(ChainBase):
         """
         self.__refresh_total_episode_before_completion(subscribe=subscribe, mediainfo=mediainfo)
 
-        # 非洗版
-        if not subscribe.best_version:
-            # 每季总集数
-            totals = {}
-            if subscribe.season and subscribe.total_episode:
-                totals = {
-                    subscribe.season: subscribe.total_episode
-                }
-            # 查询媒体库缺失的媒体信息
-            exist_flag, no_exists = DownloadChain().get_no_exists_info(
-                meta=meta,
-                mediainfo=mediainfo,
-                totals=totals
-            )
-        else:
-            # 洗版，如果已经满足了优先级，则认为已经洗版完成
-            if self.__is_best_version_complete(subscribe):
-                exist_flag = True
-                no_exists = {}
-            else:
-                exist_flag = False
-                if meta.type == MediaType.TV:
-                    pending_episodes = [] if self.__is_full_best_version_enabled(
-                        subscribe
-                    ) else self._get_pending_best_version_episodes(subscribe)
-                    # 对于电视剧，构造缺失的媒体信息
-                    no_exists = {
-                        mediakey: {
-                            subscribe.season: schemas.NotExistMediaInfo(
-                                season=subscribe.season,
-                                episodes=pending_episodes,
-                                total_episode=subscribe.total_episode,
-                                start_episode=subscribe.start_episode or 1,
-                                # 完整覆盖约束会影响整季文件探测、显式集列表匹配和多集拆包降级。
-                                require_complete_coverage=self.__is_full_best_version_enabled(subscribe))
-                        }
-                    }
-                else:
-                    no_exists = {}
-
-        # 如果媒体已存在，执行订阅完成操作
-        if exist_flag:
-            if not subscribe.best_version:
-                logger.info(f'{mediainfo.title_year} 媒体库中已存在')
-            self.finish_subscribe_or_not(subscribe=subscribe, meta=meta, mediainfo=mediainfo, force=True)
-            return True, no_exists
-
-        # 获取已下载的集数或电影
-        downloaded = self.__get_downloaded(subscribe)
-        if self.__is_full_best_version_enabled(subscribe):
-            # 全集洗版必须保留整季缺失范围，避免下载链路从整包中拆选单集。
-            downloaded = []
-        if meta.type == MediaType.TV:
-            # 对于电视剧类型，整合缺失集数并剔除已下载的集数
-            exist_flag, no_exists = self.__get_subscribe_no_exits(
-                subscribe_name=f'{subscribe.name} {meta.season}',
-                no_exists=no_exists,
-                mediakey=mediakey,
-                begin_season=meta.begin_season,
-                total_episode=subscribe.total_episode,
-                start_episode=subscribe.start_episode,
-                downloaded_episodes=downloaded
-            )
-        elif meta.type == MediaType.MOVIE:
-            # 对于电影类型，直接根据是否已下载判断
-            exist_flag = bool(downloaded)
+        exist_flag, no_exists = self.resolve_subscribe_missing(
+            subscribe=subscribe,
+            meta=meta,
+            mediainfo=mediainfo,
+            mediakey=mediakey,
+        )
 
         # 如果已下载完毕，执行订阅完成操作
         if exist_flag:
@@ -3145,6 +3129,113 @@ class SubscribeChain(ChainBase):
 
         # 返回结果，表示媒体未完全下载或存在
         return False, no_exists
+
+    def resolve_subscribe_missing(self, subscribe: Subscribe, meta: MetaBase,
+                                  mediainfo: MediaInfo,
+                                  mediakey: Optional[Union[str, int]] = None,
+                                  best_version_accept_downloaded: bool = False):
+        """
+        按主程序订阅口径查询当前目标是否仍有缺失，不推进订阅状态。
+
+        该方法只组合媒体库缺集、订阅范围、下载历史和洗版优先级，用于外部策略在
+        完成前复用主程序"还要不要搜索/下载"的判断口径。它不得完成订阅、写入
+        lack_episode、发送事件或修改数据库。
+
+        best_version_accept_downloaded 仅用于分集洗版的外部完成守卫：为 True 时，
+        priority>0 的目标集视为已满足；默认 False 保持主程序洗版完成需 priority==100
+        的搜索/完成口径。
+        """
+        mediakey = mediakey or subscribe.tmdbid or subscribe.doubanid
+        effective_total_episode = self.__resolve_effective_total_episode(subscribe, mediainfo)
+
+        if not subscribe.best_version:
+            totals = {}
+            if subscribe.season and effective_total_episode:
+                totals = {
+                    subscribe.season: effective_total_episode
+                }
+            exist_flag, no_exists = DownloadChain().get_no_exists_info(
+                meta=meta,
+                mediainfo=mediainfo,
+                totals=totals
+            )
+        elif meta.type != MediaType.TV and self.__is_best_version_complete(subscribe):
+            return True, {}
+        else:
+            exist_flag = False
+            if meta.type == MediaType.TV:
+                if self.__is_full_best_version_enabled(subscribe):
+                    pending_episodes = []
+                elif best_version_accept_downloaded:
+                    downloaded = set(self.__get_downloaded_best_version_episodes(
+                        subscribe, total_episode=effective_total_episode
+                    ))
+                    start_episode = subscribe.start_episode or 1
+                    pending_episodes = [
+                        episode for episode in range(start_episode, effective_total_episode + 1)
+                        if episode not in downloaded
+                    ]
+                    if not pending_episodes:
+                        return True, {}
+                else:
+                    pending_episodes = self._get_pending_best_version_episodes(
+                        subscribe, total_episode=effective_total_episode
+                    )
+                    if not pending_episodes:
+                        return True, {}
+                no_exists = {
+                    mediakey: {
+                        subscribe.season: schemas.NotExistMediaInfo(
+                            season=subscribe.season,
+                            episodes=pending_episodes,
+                            total_episode=effective_total_episode,
+                            start_episode=subscribe.start_episode or 1,
+                            require_complete_coverage=self.__is_full_best_version_enabled(subscribe))
+                    }
+                }
+            else:
+                no_exists = {}
+
+        if exist_flag:
+            return True, no_exists
+
+        downloaded = self.__get_downloaded(subscribe)
+        if self.__is_full_best_version_enabled(subscribe):
+            downloaded = []
+        if meta.type == MediaType.TV:
+            return self.__get_subscribe_no_exits(
+                subscribe_name=f'{subscribe.name} {meta.season}',
+                no_exists=no_exists,
+                mediakey=mediakey,
+                begin_season=meta.begin_season,
+                total_episode=effective_total_episode,
+                start_episode=subscribe.start_episode,
+                downloaded_episodes=downloaded
+            )
+        if meta.type == MediaType.MOVIE:
+            return bool(downloaded), no_exists
+        return False, no_exists
+
+    @staticmethod
+    def __resolve_effective_total_episode(subscribe: Subscribe, mediainfo: MediaInfo) -> int:
+        """
+        只读计算完成前有效总集数，不触发事件、不写回订阅。
+
+        主流程会通过 ``__refresh_total_episode_before_completion`` 持久化增长后的总集数；
+        该查询接口只需要同样避免旧 total 造成误判，因此仅使用当前 mediainfo 中更大的
+        季集数作为临时目标范围。
+        """
+        current_total = subscribe.total_episode or 0
+        if subscribe.type != MediaType.TV.value:
+            return current_total
+        if subscribe.manual_total_episode:
+            return current_total
+        if subscribe.season is None:
+            return current_total
+        media_total = len((mediainfo.seasons or {}).get(subscribe.season) or [])
+        if media_total > current_total:
+            return media_total
+        return current_total
 
     @staticmethod
     def __apply_episodes_refresh(current_total: int, season: Optional[int], *,

--- a/app/chain/system.py
+++ b/app/chain/system.py
@@ -27,8 +27,12 @@ class SystemChain(ChainBase):
         清理系统缓存
         """
         self.clear_cache()
-        self.post_message(Notification(channel=channel, source=source,
-                                       title=f"缓存清理完成！", userid=userid))
+        self.post_message(Notification(
+            channel=channel,
+            source=source,
+            title=f"缓存清理完成！",
+            userid=userid,
+            save_history=False))
 
     def restart(self, channel: MessageChannel, userid: Union[int, str], source: Optional[str] = None):
         """
@@ -37,8 +41,12 @@ class SystemChain(ChainBase):
         from app.core.config import global_vars
 
         if channel and userid:
-            self.post_message(Notification(channel=channel, source=source,
-                                           title="系统正在重启，请耐心等候！", userid=userid))
+            self.post_message(Notification(
+                channel=channel,
+                source=source,
+                title="系统正在重启，请耐心等候！",
+                userid=userid,
+                save_history=False))
             # 保存重启信息
             self.save_cache({
                 "channel": channel.value,
@@ -180,9 +188,12 @@ class SystemChain(ChainBase):
         """
         查看当前版本、远程版本
         """
-        self.post_message(Notification(channel=channel, source=source,
-                                       title=self.__get_version_message(),
-                                       userid=userid))
+        self.post_message(Notification(
+            channel=channel,
+            source=source,
+            title=self.__get_version_message(),
+            userid=userid,
+            save_history=False))
 
     def restart_finish(self):
         """
@@ -202,9 +213,11 @@ class SystemChain(ChainBase):
 
             # 版本号
             title = self.__get_version_message()
-            self.post_message(Notification(channel=channel,
-                                           title=f"系统已重启完成！\n{title}",
-                                           userid=userid))
+            self.post_message(Notification(
+                channel=channel,
+                title=f"系统已重启完成！\n{title}",
+                userid=userid,
+                save_history=False))
             self.remove_cache(self._restart_file)
 
     @staticmethod

--- a/app/chain/torrents.py
+++ b/app/chain/torrents.py
@@ -2,6 +2,8 @@ import re
 import traceback
 from typing import Dict, List, Union, Optional
 
+from app.helper.sites import SitesHelper  # noqa
+
 from app.chain import ChainBase
 from app.chain.media import MediaChain
 from app.core.config import settings, global_vars
@@ -10,7 +12,6 @@ from app.core.metainfo import MetaInfo
 from app.db.site_oper import SiteOper
 from app.db.systemconfig_oper import SystemConfigOper
 from app.helper.rss import RssHelper
-from app.helper.sites import SitesHelper  # noqa
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.schemas import Notification
@@ -39,11 +40,17 @@ class TorrentsChain(ChainBase):
         """
         远程刷新订阅，发送消息
         """
-        self.post_message(Notification(channel=channel,
-                                       title=f"开始刷新种子 ...", userid=userid))
+        self.post_message(Notification(
+            channel=channel,
+            title=f"开始刷新种子 ...",
+            userid=userid,
+            save_history=False))
         self.refresh()
-        self.post_message(Notification(channel=channel,
-                                       title=f"种子刷新完成！", userid=userid))
+        self.post_message(Notification(
+            channel=channel,
+            title=f"种子刷新完成！",
+            userid=userid,
+            save_history=False))
 
     def get_torrents(self, stype: Optional[str] = None) -> Dict[str, List[Context]]:
         """
@@ -150,7 +157,8 @@ class TorrentsChain(ChainBase):
             return []
         # 解析RSS
         rss_items = RssHelper().parse(site.get("rss"), True if site.get("proxy") else False,
-                                      timeout=int(site.get("timeout") or 30), ua=site.get("ua") if site.get("ua") else None)
+                                      timeout=int(site.get("timeout") or 30),
+                                      ua=site.get("ua") if site.get("ua") else None)
         if rss_items is None:
             # rss过期，尝试保留原配置生成新的rss
             self.__renew_rss_url(domain=domain, site=site)

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -3110,6 +3110,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     title="请输入正确的命令格式：/redo [id] 或 /redo [id] [tmdbid/豆瓣id]|[类型]，"
                           "[id] 为整理记录编号",
                     userid=userid,
+                    save_history=False,
                 )
             )
 
@@ -3136,6 +3137,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                         text=errmsg,
                         userid=userid,
                         link=settings.MP_DOMAIN("#/history"),
+                        save_history=False,
                     )
                 )
             return
@@ -3162,6 +3164,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     text=errmsg,
                     userid=userid,
                     link=settings.MP_DOMAIN("#/history"),
+                    save_history=False,
                 )
             )
             return

--- a/app/chain/workflow.py
+++ b/app/chain/workflow.py
@@ -661,18 +661,39 @@ class WorkflowExecutor:
         declared_outputs = self.get_action_output_declarations(action)
         if isinstance(declared_outputs, list):
             normalized_outputs = {}
+            missing = object()
             for item in declared_outputs:
                 key = item.get("name") if isinstance(item, dict) else item
-                if key and outputs.get(key) not in (None, "", [], {}):
-                    normalized_outputs[key] = outputs.get(key)
+                if not key:
+                    continue
+                value = outputs.get(key, missing)
+                if value is missing and key in result_context.__class__.model_fields:
+                    value = getattr(result_context, key, missing)
+                if value is not missing and self.should_keep_output_value(action, key, value):
+                    normalized_outputs[key] = value
             return normalized_outputs or outputs
         if isinstance(declared_outputs, dict):
-            return {
-                key: outputs.get(key)
-                for key in declared_outputs
-                if outputs.get(key) not in (None, "", [], {})
-            } or outputs
+            normalized_outputs = {}
+            missing = object()
+            for key in declared_outputs:
+                value = outputs.get(key, missing)
+                if value is missing and key in result_context.__class__.model_fields:
+                    value = getattr(result_context, key, missing)
+                if value is not missing and self.should_keep_output_value(action, key, value):
+                    normalized_outputs[key] = value
+            return normalized_outputs or outputs
         return outputs
+
+    def should_keep_output_value(self, action: Action, key: str, value: Any) -> bool:
+        """
+        判断输出值是否应参与后续合并。
+        """
+        if value not in (None, "", [], {}):
+            return True
+        output_config = self.get_action_output_config(action, key)
+        target_key = output_config.get("target") or key
+        merge_policy = output_config.get("merge") or self.get_default_merge_policy(action, target_key, value)
+        return merge_policy == "replace"
 
     def record_node_outputs(self, action_id: str, outputs: dict) -> None:
         """
@@ -699,11 +720,11 @@ class WorkflowExecutor:
         按声明式合并策略写入全局上下文和 artifacts 分区。
         """
         for key, value in outputs.items():
-            if value in (None, "", [], {}):
-                continue
             output_config = self.get_action_output_config(action, key)
             target_key = output_config.get("target") or key
             merge_policy = output_config.get("merge") or self.get_default_merge_policy(action, target_key, value)
+            if value in (None, "", [], {}) and merge_policy != "replace":
+                continue
             identity = output_config.get("identity")
             self.merge_output_value(target_key, value, merge_policy, identity)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -552,6 +552,8 @@ class ConfigModel(BaseModel):
     AI_AGENT_ENABLE: bool = False
     # 合局AI智能体
     AI_AGENT_GLOBAL: bool = False
+    # 是否隐藏前端全局智能体入口
+    AI_AGENT_HIDE_ENTRY: bool = False
     # LLM提供商（支持内置 provider，以及从 models.dev 动态补充的平台）
     LLM_PROVIDER: str = "deepseek"
     # LLM模型名称

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -575,7 +575,7 @@ class ConfigModel(BaseModel):
     # LLM Base URL 预设标识，用于区分同一 Base URL 下的不同模型目录
     LLM_BASE_URL_PRESET: Optional[str] = None
     # LLM最大上下文Token数量（K）
-    LLM_MAX_CONTEXT_TOKENS: int = 64
+    LLM_MAX_CONTEXT_TOKENS: int = 128
     # LLM OpenAI兼容接口请求User-Agent
     LLM_USER_AGENT: Optional[str] = None
     # LLM温度参数

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -160,6 +160,10 @@ class ConfigModel(BaseModel):
     CACHE_BACKEND_URL: Optional[str] = "redis://localhost:6379"
     # Redis 缓存最大内存限制，未配置时，如开启大内存模式时为 "1024mb"，未开启时为 "256mb"
     CACHE_REDIS_MAXMEMORY: Optional[str] = None
+    # Redis 连接池最大连接数
+    CACHE_REDIS_MAX_CONNECTIONS: int = 256
+    # Redis 连接池耗尽时等待可用连接的时间（秒）
+    CACHE_REDIS_POOL_TIMEOUT: int = 3
     # 全局图片缓存，将媒体图片缓存到本地
     GLOBAL_IMAGE_CACHE: bool = False
     # 全局图片缓存保留天数

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -596,7 +596,7 @@ class ConfigModel(BaseModel):
     # AI推荐条目数量限制
     AI_RECOMMEND_MAX_ITEMS: int = 50
     # LLM工具选择中间件最大工具数量，0为不启用工具选择中间件
-    LLM_MAX_TOOLS: int = 0
+    LLM_MAX_TOOLS: int = 20
     # AI智能体定时任务检查间隔（小时），0为不启用，默认24小时
     AI_AGENT_JOB_INTERVAL: int = 0
     # AI智能体啰嗦模式，开启后会回复工具调用过程

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -1,10 +1,12 @@
 import asyncio
 import json
 import pickle
+import threading
 from typing import Any, Optional, Generator, Tuple, AsyncGenerator, Union
 from urllib.parse import quote, unquote
 
 import redis
+from redis.asyncio import BlockingConnectionPool as AsyncBlockingConnectionPool
 from redis.asyncio import Redis
 
 from app.core.config import settings
@@ -83,7 +85,13 @@ class RedisHelper(ConfigReloadMixin, metaclass=Singleton):
     - 支持内存限制和淘汰策略设置
     - 提供键名生成和区域管理功能
     """
-    CONFIG_WATCH = {"CACHE_BACKEND_TYPE", "CACHE_BACKEND_URL", "CACHE_REDIS_MAXMEMORY"}
+    CONFIG_WATCH = {
+        "CACHE_BACKEND_TYPE",
+        "CACHE_BACKEND_URL",
+        "CACHE_REDIS_MAXMEMORY",
+        "CACHE_REDIS_MAX_CONNECTIONS",
+        "CACHE_REDIS_POOL_TIMEOUT",
+    }
 
     def __init__(self):
         """
@@ -91,31 +99,46 @@ class RedisHelper(ConfigReloadMixin, metaclass=Singleton):
         """
         self.redis_url = settings.CACHE_BACKEND_URL
         self.client = None
+        self._connect_lock = threading.RLock()
 
     def _connect(self):
         """
         建立Redis连接
         """
+        if self.client is not None:
+            return
+        client = None
         try:
-            if self.client is None:
-                self.client = redis.Redis.from_url(
+            with self._connect_lock:
+                if self.client is not None:
+                    return
+                self.redis_url = settings.CACHE_BACKEND_URL
+                connection_pool = redis.BlockingConnectionPool.from_url(
                     self.redis_url,
                     decode_responses=False,
                     socket_timeout=_socket_timeout,
                     socket_connect_timeout=_socket_connect_timeout,
                     health_check_interval=_health_check_interval,
+                    max_connections=settings.CACHE_REDIS_MAX_CONNECTIONS,
+                    timeout=settings.CACHE_REDIS_POOL_TIMEOUT,
                 )
+                client = redis.Redis(connection_pool=connection_pool)
                 # 测试连接，确保Redis可用
-                self.client.ping()
+                client.ping()
+                self.client = client
                 logger.info(f"Successfully connected to Redis：{self.redis_url}")
                 self.set_memory_limit()
         except Exception as e:
+            if client:
+                client.close()
             logger.error(f"Failed to connect to Redis: {e}")
             self.client = None
             raise RuntimeError("Redis connection failed") from e
 
     def on_config_changed(self):
-        self.close()
+        with self._connect_lock:
+            self.redis_url = settings.CACHE_BACKEND_URL
+            self.close()
         self._connect()
 
     def get_reload_name(self):
@@ -296,10 +319,11 @@ class RedisHelper(ConfigReloadMixin, metaclass=Singleton):
         """
         关闭Redis客户端的连接池
         """
-        if self.client:
-            self.client.close()
-            self.client = None
-            logger.debug("Redis connection closed")
+        with self._connect_lock:
+            if self.client:
+                self.client.close()
+                self.client = None
+                logger.debug("Redis connection closed")
 
 
 class AsyncRedisHelper(ConfigReloadMixin, metaclass=Singleton):
@@ -313,7 +337,13 @@ class AsyncRedisHelper(ConfigReloadMixin, metaclass=Singleton):
     - 提供键名生成和区域管理功能
     - 所有操作都是异步的
     """
-    CONFIG_WATCH = {"CACHE_BACKEND_TYPE", "CACHE_BACKEND_URL", "CACHE_REDIS_MAXMEMORY"}
+    CONFIG_WATCH = {
+        "CACHE_BACKEND_TYPE",
+        "CACHE_BACKEND_URL",
+        "CACHE_REDIS_MAXMEMORY",
+        "CACHE_REDIS_MAX_CONNECTIONS",
+        "CACHE_REDIS_POOL_TIMEOUT",
+    }
 
     def __init__(self):
         """
@@ -322,31 +352,53 @@ class AsyncRedisHelper(ConfigReloadMixin, metaclass=Singleton):
         self.redis_url = settings.CACHE_BACKEND_URL
         self.client: Optional[Redis] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._connect_lock: Optional[asyncio.Lock] = None
+        self._connect_lock_loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def _get_connect_lock(self, current_loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
+        """
+        获取当前事件循环对应的异步连接锁
+        """
+        if self._connect_lock is None or self._connect_lock_loop is not current_loop:
+            self._connect_lock = asyncio.Lock()
+            self._connect_lock_loop = current_loop
+        return self._connect_lock
 
     async def _connect(self):
         """
         建立异步Redis连接
         """
+        current_loop = asyncio.get_running_loop()
+        connect_lock = self._get_connect_lock(current_loop)
+        client = None
         try:
-            current_loop = asyncio.get_running_loop()
-            # 检测事件循环是否发生变化，如果变化则重新连接
-            if self.client is not None and self._loop is not current_loop:
-                logger.debug("Event loop changed, reconnecting Redis (async)")
-                await self._close_client()
-            if self.client is None:
-                self.client = Redis.from_url(
+            async with connect_lock:
+                # 检测事件循环是否发生变化，如果变化则重新连接
+                if self.client is not None and self._loop is not current_loop:
+                    logger.debug("Event loop changed, reconnecting Redis (async)")
+                    await self._close_client()
+                if self.client is not None:
+                    return
+                self.redis_url = settings.CACHE_BACKEND_URL
+                connection_pool = AsyncBlockingConnectionPool.from_url(
                     self.redis_url,
                     decode_responses=False,
                     socket_timeout=_socket_timeout,
                     socket_connect_timeout=_socket_connect_timeout,
                     health_check_interval=_health_check_interval,
+                    max_connections=settings.CACHE_REDIS_MAX_CONNECTIONS,
+                    timeout=settings.CACHE_REDIS_POOL_TIMEOUT,
                 )
+                client = Redis(connection_pool=connection_pool)
                 self._loop = current_loop
                 # 测试连接，确保Redis可用
-                await self.client.ping()
+                await client.ping()
+                self.client = client
                 logger.info(f"Successfully connected to Redis (async)：{self.redis_url}")
                 await self.set_memory_limit()
         except Exception as e:
+            if client:
+                await client.close()
             logger.error(f"Failed to connect to Redis (async): {e}")
             self.client = None
             self._loop = None
@@ -365,6 +417,7 @@ class AsyncRedisHelper(ConfigReloadMixin, metaclass=Singleton):
             self._loop = None
 
     async def on_config_changed(self):
+        self.redis_url = settings.CACHE_BACKEND_URL
         await self._close_client()
         await self._connect()
 

--- a/app/db/agentchat_oper.py
+++ b/app/db/agentchat_oper.py
@@ -1,0 +1,336 @@
+import time
+from typing import Any, Optional, Union
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.db import DbOper
+from app.db.models.agentchat import AgentChat
+from app.schemas.types import MessageChannel
+
+DEFAULT_AGENT_CHAT_TITLE = "未命名会话"
+
+
+class AgentChatOper(DbOper):
+    """
+    Agent 会话历史数据管理。
+    """
+
+    def __init__(self, db: Union[Session, AsyncSession] = None):
+        super().__init__(db)
+
+    @staticmethod
+    def _now() -> str:
+        """返回数据库统一使用的当前时间字符串。"""
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+
+    @staticmethod
+    def _channel_value(channel: Optional[Union[MessageChannel, str]]) -> Optional[str]:
+        """获取渠道枚举的字符串值。"""
+        if isinstance(channel, MessageChannel):
+            return channel.value
+        return channel
+
+    @staticmethod
+    def _normalize_messages(messages: Optional[list[dict]]) -> list[dict]:
+        """规范化展示消息列表，避免 JSON 字段存入 None。"""
+        return messages if isinstance(messages, list) else []
+
+    @staticmethod
+    def _normalize_title(value: Optional[str], messages: list[dict]) -> str:
+        """生成会话标题。"""
+        if value and value.strip():
+            return value.strip()[:120]
+        for message in messages:
+            if message.get("role") != "user":
+                continue
+            content = str(message.get("content") or "").strip()
+            if content:
+                return content.replace("\n", " ")[:120]
+            attachments = message.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                name = attachments[0].get("name") or "附件消息"
+                return str(name)[:120]
+        return DEFAULT_AGENT_CHAT_TITLE
+
+    @staticmethod
+    def has_custom_title(value: Optional[str]) -> bool:
+        """判断会话是否已有真实标题。"""
+        return bool(value and value.strip() and value.strip() != DEFAULT_AGENT_CHAT_TITLE)
+
+    @staticmethod
+    def _normalize_preview(messages: list[dict]) -> str:
+        """生成会话预览文本。"""
+        for message in reversed(messages):
+            content = str(message.get("content") or "").strip()
+            if content:
+                return content.replace("\n", " ")[:240]
+            attachments = message.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                name = attachments[0].get("name") or "附件消息"
+                return str(name)[:240]
+        return ""
+
+    def get(
+        self, session_id: str, user_id: Optional[str] = None
+    ) -> Optional[AgentChat]:
+        """
+        获取 Agent 会话。
+        """
+        return AgentChat.get_by_session(self._db, session_id, user_id)
+
+    async def async_get(
+        self, session_id: str, user_id: Optional[str] = None
+    ) -> Optional[AgentChat]:
+        """
+        异步获取 Agent 会话。
+        """
+        return await AgentChat.async_get_by_session(self._db, session_id, user_id)
+
+    def ensure_session(
+        self,
+        session_id: str,
+        user_id: Optional[str] = None,
+        username: Optional[str] = None,
+        channel: Optional[Union[MessageChannel, str]] = None,
+        source: Optional[str] = None,
+        original_chat_id: Optional[str] = None,
+        client_session_id: Optional[str] = None,
+    ) -> AgentChat:
+        """
+        确保 Agent 会话记录存在，并刷新基础渠道信息。
+        """
+        now = self._now()
+        chat = self.get(session_id=session_id, user_id=user_id)
+        if not chat:
+            chat = self.get(session_id=session_id)
+        payload = {
+            "user_id": user_id,
+            "username": username,
+            "channel": self._channel_value(channel),
+            "source": source,
+            "original_chat_id": original_chat_id,
+            "client_session_id": client_session_id,
+            "updated_at": now,
+        }
+        payload = {key: value for key, value in payload.items() if value is not None}
+        if chat:
+            chat.update(self._db, payload)
+            return self.get(session_id=session_id, user_id=user_id) or self.get(session_id=session_id)
+
+        chat = AgentChat(
+            session_id=session_id,
+            user_id=user_id,
+            username=username,
+            channel=self._channel_value(channel),
+            source=source,
+            original_chat_id=original_chat_id,
+            client_session_id=client_session_id,
+            title=DEFAULT_AGENT_CHAT_TITLE,
+            preview="",
+            agent_messages=[],
+            display_messages=[],
+            message_count=0,
+            created_at=now,
+            updated_at=now,
+        )
+        chat.create(self._db)
+        return self.get(session_id=session_id, user_id=user_id) or self.get(session_id=session_id)
+
+    def save_agent_messages(
+        self,
+        session_id: str,
+        user_id: Optional[str],
+        messages: list[dict],
+    ) -> None:
+        """
+        保存可恢复 Agent 上下文的原始消息。
+        """
+        chat = self.get(session_id=session_id, user_id=user_id)
+        if not chat:
+            chat = self.get(session_id=session_id)
+        if not chat:
+            chat = self.ensure_session(session_id=session_id, user_id=user_id)
+        chat.update(
+            self._db,
+            {
+                "agent_messages": messages or [],
+                "updated_at": self._now(),
+            },
+        )
+
+    def update_title_if_empty(
+        self,
+        session_id: str,
+        user_id: Optional[str],
+        title: Optional[str],
+        username: Optional[str] = None,
+        channel: Optional[Union[MessageChannel, str]] = None,
+        source: Optional[str] = None,
+        original_chat_id: Optional[str] = None,
+        client_session_id: Optional[str] = None,
+    ) -> None:
+        """
+        在会话尚未生成标题时写入标题。
+        """
+        normalized_title = self._normalize_title(title, [])
+        if normalized_title == DEFAULT_AGENT_CHAT_TITLE:
+            return
+
+        chat = self.ensure_session(
+            session_id=session_id,
+            user_id=user_id,
+            username=username,
+            channel=channel,
+            source=source,
+            original_chat_id=original_chat_id,
+            client_session_id=client_session_id,
+        )
+        if self.has_custom_title(chat.title):
+            return
+        chat.update(
+            self._db,
+            {
+                "title": normalized_title,
+                "updated_at": self._now(),
+            },
+        )
+
+    def save_display_messages(
+        self,
+        session_id: str,
+        user_id: Optional[str] = None,
+        messages: Optional[list[dict]] = None,
+        username: Optional[str] = None,
+        channel: Optional[Union[MessageChannel, str]] = None,
+        source: Optional[str] = None,
+        original_chat_id: Optional[str] = None,
+        client_session_id: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> AgentChat:
+        """
+        保存用户可见的 Agent 会话消息。
+        """
+        normalized_messages = self._normalize_messages(messages)
+        chat = self.ensure_session(
+            session_id=session_id,
+            user_id=user_id,
+            username=username,
+            channel=channel,
+            source=source,
+            original_chat_id=original_chat_id,
+            client_session_id=client_session_id,
+        )
+        normalized_title = (
+            chat.title
+            if self.has_custom_title(chat.title)
+            else self._normalize_title(title, normalized_messages)
+        )
+        chat.update(
+            self._db,
+            {
+                "title": normalized_title,
+                "preview": self._normalize_preview(normalized_messages),
+                "display_messages": normalized_messages,
+                "message_count": len(normalized_messages),
+                "updated_at": self._now(),
+            },
+        )
+        return self.get(session_id=session_id, user_id=user_id) or self.get(session_id=session_id)
+
+    def append_display_messages(
+        self,
+        session_id: str,
+        user_id: Optional[str] = None,
+        messages: Optional[list[dict]] = None,
+        username: Optional[str] = None,
+        channel: Optional[Union[MessageChannel, str]] = None,
+        source: Optional[str] = None,
+        original_chat_id: Optional[str] = None,
+        client_session_id: Optional[str] = None,
+    ) -> AgentChat:
+        """
+        追加一组用户可见的 Agent 会话消息。
+        """
+        chat = self.ensure_session(
+            session_id=session_id,
+            user_id=user_id,
+            username=username,
+            channel=channel,
+            source=source,
+            original_chat_id=original_chat_id,
+            client_session_id=client_session_id,
+        )
+        display_messages = self._normalize_messages(chat.display_messages)
+        display_messages.extend(self._normalize_messages(messages))
+        title = chat.title if self.has_custom_title(chat.title) else None
+        return self.save_display_messages(
+            session_id=session_id,
+            user_id=user_id,
+            messages=display_messages,
+            username=username or chat.username,
+            channel=channel or chat.channel,
+            source=source or chat.source,
+            original_chat_id=original_chat_id or chat.original_chat_id,
+            client_session_id=client_session_id or chat.client_session_id,
+            title=title,
+        )
+
+    async def async_list_by_page(
+        self,
+        page: Optional[int] = 1,
+        count: Optional[int] = 30,
+        user_id: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> list[AgentChat]:
+        """
+        异步分页获取 Agent 会话历史。
+        """
+        return await AgentChat.async_list_by_page(
+            self._db,
+            page=page,
+            count=count,
+            user_id=user_id,
+            username=username,
+        )
+
+    async def async_delete(
+        self, session_id: str, user_id: Optional[str] = None
+    ) -> bool:
+        """
+        异步删除 Agent 会话历史。
+        """
+        chat = await self.async_get(session_id=session_id, user_id=user_id)
+        if not chat:
+            return False
+        await AgentChat.async_delete(self._db, chat.id)
+        return True
+
+    @staticmethod
+    def to_summary(chat: AgentChat) -> dict[str, Any]:
+        """
+        转换为历史会话摘要。
+        """
+        return {
+            "id": chat.id,
+            "session_id": chat.session_id,
+            "client_session_id": chat.client_session_id,
+            "title": chat.title,
+            "channel": chat.channel,
+            "source": chat.source,
+            "user_id": chat.user_id,
+            "username": chat.username,
+            "original_chat_id": chat.original_chat_id,
+            "message_count": chat.message_count or 0,
+            "created_at": chat.created_at,
+            "updated_at": chat.updated_at,
+        }
+
+    @classmethod
+    def to_detail(cls, chat: AgentChat) -> dict[str, Any]:
+        """
+        转换为历史会话详情。
+        """
+        data = cls.to_summary(chat)
+        data["messages"] = chat.display_messages or []
+        return data

--- a/app/db/message_oper.py
+++ b/app/db/message_oper.py
@@ -1,6 +1,7 @@
 import time
 from typing import Optional, Union
 
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.db import DbOper
@@ -13,7 +14,7 @@ class MessageOper(DbOper):
     消息数据管理
     """
 
-    def __init__(self, db: Session = None):
+    def __init__(self, db: Union[Session, AsyncSession] = None):
         super().__init__(db)
 
     def add(self,
@@ -27,7 +28,7 @@ class MessageOper(DbOper):
             userid: Optional[str] = None,
             action: Optional[int] = 1,
             note: Union[list, dict] = None,
-            **kwargs):
+            **kwargs) -> dict:
         """
         新增消息
         :param channel: 消息渠道
@@ -60,7 +61,7 @@ class MessageOper(DbOper):
             if k not in Message.__table__.columns.keys():  # noqa
                 kwargs.pop(k)
 
-        Message(**kwargs).create(self._db)
+        return Message(**kwargs).create_and_to_dict(self._db)
 
     async def async_add(self,
                         channel: MessageChannel = None,
@@ -73,7 +74,7 @@ class MessageOper(DbOper):
                         userid: Optional[str] = None,
                         action: Optional[int] = 1,
                         note: Union[list, dict] = None,
-                        **kwargs):
+                        **kwargs) -> Message:
         """
         异步新增消息
         """
@@ -96,10 +97,26 @@ class MessageOper(DbOper):
             if k not in Message.__table__.columns.keys():  # noqa
                 kwargs.pop(k)
 
-        await Message(**kwargs).async_create(self._db)
+        return await Message(**kwargs).async_create(self._db)
 
-    def list_by_page(self, page: Optional[int] = 1, count: Optional[int] = 30) -> Optional[str]:
+    def list_by_page(self, page: Optional[int] = 1, count: Optional[int] = 30) -> list[Message]:
         """
-        获取媒体服务器数据ID
+        分页获取消息记录。
         """
         return Message.list_by_page(self._db, page, count)
+
+    async def async_list_by_page(
+            self, page: Optional[int] = 1, count: Optional[int] = 30
+    ) -> list[Message]:
+        """
+        分页获取消息记录。
+        """
+        return await Message.async_list_by_page(self._db, page, count)
+
+    async def async_list_sent_by_page(
+            self, page: Optional[int] = 1, count: Optional[int] = 30
+    ) -> list[Message]:
+        """
+        分页获取系统发送的通知消息。
+        """
+        return await Message.async_list_sent_by_page(self._db, page, count)

--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -1,3 +1,4 @@
+from .agentchat import AgentChat
 from .downloadhistory import DownloadHistory, DownloadFiles
 from .mediaserver import MediaServerItem
 from .message import Message

--- a/app/db/models/agentchat.py
+++ b/app/db/models/agentchat.py
@@ -1,0 +1,130 @@
+from typing import Optional
+
+from sqlalchemy import Column, Integer, String, JSON, Index, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.db import Base, async_db_query, db_query, get_id_column
+
+
+class AgentChat(Base):
+    """
+    Agent 会话历史表。
+    """
+
+    id = get_id_column()
+    # Agent 内部会话 ID，用于恢复 LangGraph 对话上下文
+    session_id = Column(String, nullable=False)
+    # 前端或渠道侧传入的原始会话标识
+    client_session_id = Column(String)
+    # 用户 ID
+    user_id = Column(String)
+    # 用户名称
+    username = Column(String)
+    # 消息渠道
+    channel = Column(String)
+    # 渠道来源配置名
+    source = Column(String)
+    # 原聊天 ID，用于区分群聊、频道或私聊
+    original_chat_id = Column(String)
+    # 会话标题
+    title = Column(String)
+    # 会话预览文本
+    preview = Column(String)
+    # 原始 LangChain messages，用于继续会话
+    agent_messages = Column(JSON)
+    # 展示给用户的消息记录，包含文字、工具提示、附件与选择卡片
+    display_messages = Column(JSON)
+    # 展示消息数量
+    message_count = Column(Integer, default=0)
+    # 创建时间
+    created_at = Column(String)
+    # 更新时间
+    updated_at = Column(String)
+
+    __table_args__ = (
+        Index("ix_agentchat_session_user", "session_id", "user_id"),
+        Index("ix_agentchat_user_updated", "user_id", "updated_at", "id"),
+        Index("ix_agentchat_channel_updated", "channel", "updated_at", "id"),
+    )
+
+    @classmethod
+    @db_query
+    def get_by_session(
+        cls, db: Session, session_id: str, user_id: Optional[str] = None
+    ) -> Optional["AgentChat"]:
+        """
+        根据会话 ID 获取 Agent 会话。
+        """
+        query = db.query(cls).filter(cls.session_id == session_id)
+        if user_id is not None:
+            query = query.filter(cls.user_id == user_id)
+        return query.order_by(cls.id.desc()).first()
+
+    @classmethod
+    @async_db_query
+    async def async_get_by_session(
+        cls, db: AsyncSession, session_id: str, user_id: Optional[str] = None
+    ) -> Optional["AgentChat"]:
+        """
+        异步根据会话 ID 获取 Agent 会话。
+        """
+        statement = select(cls).where(cls.session_id == session_id)
+        if user_id is not None:
+            statement = statement.where(cls.user_id == user_id)
+        result = await db.execute(statement.order_by(cls.id.desc()))
+        return result.scalars().first()
+
+    @classmethod
+    @db_query
+    def list_by_page(
+        cls,
+        db: Session,
+        page: Optional[int] = 1,
+        count: Optional[int] = 30,
+        user_id: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> list["AgentChat"]:
+        """
+        分页获取 Agent 会话历史。
+        """
+        query = db.query(cls)
+        if user_id is not None and username is not None:
+            query = query.filter((cls.user_id == user_id) | (cls.username == username))
+        elif user_id is not None:
+            query = query.filter(cls.user_id == user_id)
+        elif username is not None:
+            query = query.filter(cls.username == username)
+        return (
+            query.order_by(cls.updated_at.desc(), cls.id.desc())
+            .offset((page - 1) * count)
+            .limit(count)
+            .all()
+        )
+
+    @classmethod
+    @async_db_query
+    async def async_list_by_page(
+        cls,
+        db: AsyncSession,
+        page: Optional[int] = 1,
+        count: Optional[int] = 30,
+        user_id: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> list["AgentChat"]:
+        """
+        异步分页获取 Agent 会话历史。
+        """
+        statement = select(cls)
+        if user_id is not None and username is not None:
+            statement = statement.where((cls.user_id == user_id) | (cls.username == username))
+        elif user_id is not None:
+            statement = statement.where(cls.user_id == user_id)
+        elif username is not None:
+            statement = statement.where(cls.username == username)
+        result = await db.execute(
+            statement.order_by(cls.updated_at.desc(), cls.id.desc())
+            .offset((page - 1) * count)
+            .limit(count)
+        )
+        return result.scalars().all()

--- a/app/db/models/message.py
+++ b/app/db/models/message.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from sqlalchemy import Column, Integer, String, JSON, Index, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,16 +39,59 @@ class Message(Base):
         Index('ix_message_reg_time_id', 'reg_time', 'id'),
     )
 
+    @db_update
+    def create_and_to_dict(self, db: Session) -> dict:
+        """
+        创建消息记录并返回写入后的字段字典。
+        """
+        db.add(self)
+        db.flush()
+        return self.to_dict()
+
     @classmethod
     @db_query
-    def list_by_page(cls, db: Session, page: Optional[int] = 1, count: Optional[int] = 30):
-        return db.query(cls).order_by(cls.reg_time.desc()).offset((page - 1) * count).limit(count).all()
+    def list_by_page(cls, db: Session, page: Optional[int] = 1, count: Optional[int] = 30) -> List["Message"]:
+        """
+        分页获取消息记录。
+        """
+        return (
+            db.query(cls)
+            .order_by(cls.reg_time.desc(), cls.id.desc())
+            .offset((page - 1) * count)
+            .limit(count)
+            .all()
+        )
 
     @classmethod
     @async_db_query
-    async def async_list_by_page(cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30):
+    async def async_list_by_page(
+            cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30
+    ) -> List["Message"]:
+        """
+        异步分页获取消息记录。
+        """
         result = await db.execute(
-            select(cls).order_by(cls.reg_time.desc()).offset((page - 1) * count).limit(count)
+            select(cls)
+            .order_by(cls.reg_time.desc(), cls.id.desc())
+            .offset((page - 1) * count)
+            .limit(count)
+        )
+        return result.scalars().all()
+
+    @classmethod
+    @async_db_query
+    async def async_list_sent_by_page(
+            cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30
+    ) -> List["Message"]:
+        """
+        分页获取系统发送的通知消息。
+        """
+        result = await db.execute(
+            select(cls)
+            .where(cls.action == 1)
+            .order_by(cls.reg_time.desc(), cls.id.desc())
+            .offset((page - 1) * count)
+            .limit(count)
         )
         return result.scalars().all()
 

--- a/app/helper/interaction.py
+++ b/app/helper/interaction.py
@@ -271,6 +271,11 @@ class PendingMediaInteraction:
     meta: Optional[MetaBase] = None
     current_media: Optional[MediaInfo] = None
     items: List[Any] = field(default_factory=list)
+    download_dirs: List[Any] = field(default_factory=list)
+    pending_download_mode: Optional[str] = None
+    pending_download_context: Optional[Any] = None
+    pending_no_exists: Optional[Dict[Any, Any]] = None
+    pending_torrent_page: int = 0
     created_at: datetime = field(default_factory=datetime.now)
 
 

--- a/app/helper/interaction.py
+++ b/app/helper/interaction.py
@@ -218,6 +218,7 @@ def update_or_post_message(
             title=title,
             text=text,
             buttons=buttons,
+            save_history=False,
         )
     )
 

--- a/app/helper/message.py
+++ b/app/helper/message.py
@@ -764,61 +764,74 @@ class MessageQueueManager(metaclass=SingletonClass):
 
 class MessageHelper(metaclass=Singleton):
     """
-    消息队列管理器，包括系统消息和用户消息
+    消息队列管理器，负责系统和插件实时消息的 SSE 推送
     """
 
     def __init__(self):
         self.sys_queue = queue.Queue()
-        self.user_queue = queue.Queue()
+        self._recent_notification_keys = TTLCache(region="message:notification", maxsize=500, ttl=60)
+
+    @staticmethod
+    def _build_system_notification_key(
+            message: Any, role: str, title: str = None, note: Union[list, dict] = None
+    ) -> str:
+        """
+        构建系统通知短期去重键。
+        """
+        return json.dumps(
+            {
+                "role": role,
+                "title": title or "",
+                "text": str(message),
+                "note": note or {},
+                "time": time.strftime("%Y-%m-%d %H:%M", time.localtime()),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    def _is_recent_system_notification(
+            self, message: Any, role: str, title: str = None, note: Union[list, dict] = None
+    ) -> bool:
+        """
+        判断系统通知是否在短时间内重复。
+        """
+        key = self._build_system_notification_key(message, role, title=title, note=note)
+        if self._recent_notification_keys.get(key):
+            return True
+        self._recent_notification_keys.set(key, True)
+        return False
 
     def put(self, message: Any, role: str = "plugin", title: str = None, note: Union[list, dict] = None):
         """
         存消息
         :param message: 消息
-        :param role: 消息通道 systm：系统消息，plugin：插件消息，user：用户消息
+        :param role: 消息通道 system：系统消息，plugin：插件消息
         :param title: 标题
         :param note: 附件json
         """
-        if role in ["system", "plugin"]:
-            # 没有标题时获取插件名称
-            if role == "plugin" and not title:
-                title = "插件通知"
-            # 系统通知，默认
-            self.sys_queue.put(json.dumps({
-                "type": role,
-                "title": title,
-                "text": message,
-                "date": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
-                "note": note
-            }))
-        else:
-            if isinstance(message, str):
-                # 非系统的文本通知
-                self.user_queue.put(json.dumps({
-                    "title": title,
-                    "text": message,
-                    "date": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
-                    "note": note
-                }))
-            elif hasattr(message, "to_dict"):
-                # 非系统的复杂结构通知，如媒体信息/种子列表等。
-                content = message.to_dict()
-                content['title'] = title
-                content['date'] = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-                content['note'] = note
-                self.user_queue.put(json.dumps(content))
+        if role not in ["system", "plugin"]:
+            return
+        # 没有标题时获取插件名称
+        if role == "plugin" and not title:
+            title = "插件通知"
+        if self._is_recent_system_notification(message, role, title=title, note=note):
+            return
+        self.sys_queue.put(json.dumps({
+            "type": role,
+            "title": title,
+            "text": message,
+            "date": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
+            "note": note
+        }))
 
     def get(self, role: str = "system") -> Optional[str]:
         """
         取消息
-        :param role: 消息通道 systm：系统消息，plugin：插件消息，user：用户消息
+        :param role: 兼容旧参数，当前所有 SSE 消息共用一个队列
         """
-        if role == "system":
-            if not self.sys_queue.empty():
-                return self.sys_queue.get(block=False)
-        else:
-            if not self.user_queue.empty():
-                return self.user_queue.get(block=False)
+        if not self.sys_queue.empty():
+            return self.sys_queue.get(block=False)
         return None
 
 

--- a/app/helper/ocr.py
+++ b/app/helper/ocr.py
@@ -31,7 +31,7 @@ class OcrHelper:
         if image_url:
             data_url_b64 = self._extract_data_url_base64(image_url)
             if data_url_b64:
-                image_b64 = data_url_b64
+                image_b64 = self._normalize_image_base64(data_url_b64)
             else:
                 ret = RequestUtils(ua=ua,
                                    cookies=cookie).get_res(image_url)
@@ -54,7 +54,14 @@ class OcrHelper:
         """规范化外部传入的图片 base64 内容。"""
         if not image_b64:
             return ""
-        return OcrHelper._extract_data_url_base64(image_b64) or image_b64.strip()
+        clean_image_b64 = OcrHelper._extract_data_url_base64(image_b64) or image_b64
+        clean_image_b64 = "".join(clean_image_b64.split())
+        if not clean_image_b64:
+            return ""
+        padding_size = len(clean_image_b64) % 4
+        if padding_size:
+            clean_image_b64 = f"{clean_image_b64}{'=' * (4 - padding_size)}"
+        return clean_image_b64
 
     @staticmethod
     def _extract_data_url_base64(image_url: Optional[str]) -> str:

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -299,9 +299,11 @@ class PluginHelper(metaclass=WeakSingleton):
 
     def get_local_plugin_candidate(self, pid: str, package_version: Optional[str] = None,
                                    repo_path: Optional[Path] = None,
-                                   strict_compat: bool = True) -> Optional[dict]:
+                                   strict_compat: bool = True,
+                                   strict_system_version: bool = True) -> Optional[dict]:
         """
         获取指定插件ID的本地插件候选
+        :param strict_system_version: 是否将主系统版本范围不匹配视为不可用候选
         """
         if not pid:
             return None
@@ -344,7 +346,7 @@ class PluginHelper(metaclass=WeakSingleton):
                             candidate["compatible"] = False
                             candidate["skip_reason"] = f"package.json 未声明 {settings.VERSION_FLAG} 兼容"
                         self.annotate_plugin_system_version(candidate)
-                        if candidate.get("system_version_compatible") is False:
+                        if strict_system_version and candidate.get("system_version_compatible") is False:
                             candidate["compatible"] = False
                             candidate["skip_reason"] = candidate.get("system_version_message")
                         if package_version is not None:
@@ -361,6 +363,10 @@ class PluginHelper(metaclass=WeakSingleton):
         candidates = self.get_local_plugin_candidates()
         for candidate_pid, candidate in candidates.items():
             if candidate_pid.lower() == pid.lower():
+                if strict_system_version and candidate.get("system_version_compatible") is False:
+                    candidate = candidate.copy()
+                    candidate["compatible"] = False
+                    candidate["skip_reason"] = candidate.get("system_version_message")
                 return candidate
         return None
 

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -401,6 +401,55 @@ class PluginHelper(metaclass=WeakSingleton):
 
         return payload
 
+    @staticmethod
+    def __build_plugin_release_item(pid: str, release_info: dict) -> Optional[dict]:
+        """
+        从 GitHub release 响应中提取可安装版本，仅接受规范 tag 与同名 zip 资产。
+        """
+        if not isinstance(release_info, dict):
+            return None
+
+        tag_name = release_info.get("tag_name")
+        if not isinstance(tag_name, str):
+            return None
+
+        tag_prefix = f"{pid}_v"
+        if not tag_name.startswith(tag_prefix):
+            return None
+
+        version = tag_name[len(tag_prefix):]
+        if not version:
+            return None
+
+        asset_name = f"{tag_name.lower()}.zip"
+        assets = release_info.get("assets") or []
+        if not any(isinstance(asset, dict) and asset.get("name") == asset_name for asset in assets):
+            return None
+
+        return {
+            "version": version,
+            "tag_name": tag_name,
+            "name": release_info.get("name") or tag_name,
+            "published_at": release_info.get("published_at"),
+            "body": release_info.get("body") or "",
+            "asset_name": asset_name,
+        }
+
+    @staticmethod
+    def __parse_plugin_release_response(pid: str, payload) -> List[dict]:
+        """
+        解析 GitHub release 列表，过滤出当前插件可直接安装的 release 资产。
+        """
+        if not isinstance(payload, list):
+            return []
+
+        releases = []
+        for release_info in payload:
+            item = PluginHelper.__build_plugin_release_item(pid, release_info)
+            if item:
+                releases.append(item)
+        return releases
+
     @cached(maxsize=128, ttl=1800)
     def get_plugins(self, repo_url: str,
                     package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
@@ -428,6 +477,51 @@ class PluginHelper(metaclass=WeakSingleton):
         if res.status_code != 200:
             return None
         return self.__parse_plugin_index_response(res.text)
+
+    @cached(maxsize=128, ttl=1800)
+    def get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+        """
+        获取插件可安装的 GitHub Release 版本列表。
+        """
+        if not pid or not repo_url:
+            return []
+
+        user, repo = self.get_repo_info(repo_url)
+        if not user or not repo:
+            return []
+
+        user_repo = f"{user}/{repo}"
+        releases = []
+        for page in range(1, 11):
+            release_api = f"https://api.github.com/repos/{user_repo}/releases?per_page=100&page={page}"
+            release_api = self.__append_cache_buster(release_api)
+            res = self.__request_with_fallback(
+                release_api,
+                headers=settings.REPO_GITHUB_HEADERS(repo=user_repo),
+                timeout=30,
+                is_api=True,
+            )
+            if res is None or res.status_code != 200:
+                break
+
+            try:
+                payload = res.json()
+                if not payload:
+                    break
+                releases.extend(self.__parse_plugin_release_response(pid, payload))
+                if len(payload) < 100:
+                    break
+            except Exception as e:
+                logger.error(f"解析插件 {pid} Release 列表失败：{e}")
+                break
+        return releases
+
+    @staticmethod
+    def __has_installable_release_version(release_items: List[dict], release_version: str) -> bool:
+        """
+        指定版本必须来自已解析出的可安装 Release 列表，避免直接拼接任意 tag。
+        """
+        return any(item.get("version") == release_version for item in release_items)
 
     def get_plugin_package_version(self, pid: str, repo_url: str,
                                    package_version: Optional[str] = None) -> Optional[str]:
@@ -477,7 +571,8 @@ class PluginHelper(metaclass=WeakSingleton):
             return None, None
         return user, repo
 
-    def install(self, pid: str, repo_url: str, package_version: Optional[str] = None, force_install: bool = False) \
+    def install(self, pid: str, repo_url: str, package_version: Optional[str] = None,
+                release_version: Optional[str] = None, force_install: bool = False) \
             -> Tuple[bool, str]:
         """
         安装插件，包括依赖安装和文件下载，相关资源支持自动降级策略
@@ -490,6 +585,7 @@ class PluginHelper(metaclass=WeakSingleton):
         :param pid: 插件 ID
         :param repo_url: 插件仓库地址
         :param package_version: 首选插件版本 (如 "v2", "v3")，如不指定则默认使用系统配置的版本
+        :param release_version: 指定安装的 release 资产版本；未指定时安装当前索引版本
         :param force_install: 是否强制安装插件，默认不启用，启用时不进行备份和恢复操作
         :return: (是否成功, 错误信息)
         """
@@ -533,6 +629,25 @@ class PluginHelper(metaclass=WeakSingleton):
         is_release = meta.get("release")
         # 插件版本号
         plugin_version = meta.get("version")
+        if release_version:
+            if not is_release:
+                return False, f"{pid} 未声明 Release 安装，无法安装指定版本"
+            if not self.__has_installable_release_version(
+                    self.get_plugin_release_versions(pid, repo_url), release_version
+            ):
+                return False, f"{pid} 未找到可安装的 Release 版本：{release_version}"
+            if release_version == plugin_version:
+                compatible, message = self.check_plugin_system_version(meta)
+                if not compatible:
+                    logger.debug(f"{pid} 插件系统版本兼容性检查失败：{message}")
+                    return False, message
+            release_tag = f"{pid}_v{release_version}"
+
+            def prepare_selected_release() -> Tuple[bool, str]:
+                return self.__install_from_release(pid, user_repo, release_tag)
+
+            return self.__install_flow_sync(pid, force_install, prepare_selected_release, repo_url)
+
         compatible, message = self.check_plugin_system_version(meta)
         if not compatible:
             logger.debug(f"{pid} 插件系统版本兼容性检查失败：{message}")
@@ -1877,6 +1992,44 @@ class PluginHelper(metaclass=WeakSingleton):
             return None
         return self.__parse_plugin_index_response(res.text)
 
+    @cached(maxsize=128, ttl=1800)
+    async def async_get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+        """
+        异步获取插件可安装的 GitHub Release 版本列表。
+        """
+        if not pid or not repo_url:
+            return []
+
+        user, repo = self.get_repo_info(repo_url)
+        if not user or not repo:
+            return []
+
+        user_repo = f"{user}/{repo}"
+        releases = []
+        for page in range(1, 11):
+            release_api = f"https://api.github.com/repos/{user_repo}/releases?per_page=100&page={page}"
+            release_api = self.__append_cache_buster(release_api)
+            res = await self.__async_request_with_fallback(
+                release_api,
+                headers=settings.REPO_GITHUB_HEADERS(repo=user_repo),
+                timeout=30,
+                is_api=True,
+            )
+            if res is None or res.status_code != 200:
+                break
+
+            try:
+                payload = res.json()
+                if not payload:
+                    break
+                releases.extend(self.__parse_plugin_release_response(pid, payload))
+                if len(payload) < 100:
+                    break
+            except Exception as e:
+                logger.error(f"解析插件 {pid} Release 列表失败：{e}")
+                break
+        return releases
+
     async def __async_get_file_list(self, pid: str, user_repo: str, package_version: Optional[str] = None) -> \
             Tuple[Optional[list], Optional[str]]:
         """
@@ -2235,6 +2388,7 @@ class PluginHelper(metaclass=WeakSingleton):
             return []
 
     async def async_install(self, pid: str, repo_url: str, package_version: Optional[str] = None,
+                            release_version: Optional[str] = None,
                             force_install: bool = False) -> Tuple[bool, str]:
         """
         异步安装插件，包括依赖安装和文件下载，相关资源支持自动降级策略
@@ -2247,6 +2401,7 @@ class PluginHelper(metaclass=WeakSingleton):
         :param pid: 插件 ID
         :param repo_url: 插件仓库地址
         :param package_version: 首选插件版本 (如 "v2", "v3")，如不指定则默认使用系统配置的版本
+        :param release_version: 指定安装的 release 资产版本；未指定时安装当前索引版本
         :param force_install: 是否强制安装插件，默认不启用，启用时不进行备份和恢复操作
         :return: (是否成功, 错误信息)
         """
@@ -2289,6 +2444,24 @@ class PluginHelper(metaclass=WeakSingleton):
         is_release = meta.get("release")
         # 插件版本号
         plugin_version = meta.get("version")
+        if release_version:
+            if not is_release:
+                return False, f"{pid} 未声明 Release 安装，无法安装指定版本"
+            release_items = await self.async_get_plugin_release_versions(pid, repo_url)
+            if not self.__has_installable_release_version(release_items, release_version):
+                return False, f"{pid} 未找到可安装的 Release 版本：{release_version}"
+            if release_version == plugin_version:
+                compatible, message = self.check_plugin_system_version(meta)
+                if not compatible:
+                    logger.debug(f"{pid} 插件系统版本兼容性检查失败：{message}")
+                    return False, message
+            release_tag = f"{pid}_v{release_version}"
+
+            async def prepare_selected_release() -> Tuple[bool, str]:
+                return await self.__async_install_from_release(pid, user_repo, release_tag)
+
+            return await self.__install_flow_async(pid, force_install, prepare_selected_release, repo_url)
+
         compatible, message = self.check_plugin_system_version(meta)
         if not compatible:
             logger.debug(f"{pid} 插件系统版本兼容性检查失败：{message}")

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -51,6 +51,9 @@ class PluginHelper(metaclass=WeakSingleton):
     _base_url = "https://raw.githubusercontent.com/{user}/{repo}/main/"
     # 串行化运行期依赖安装，避免多个 pip 子进程和导入缓存刷新互相踩踏。
     _pip_install_lock = threading.Lock()
+    # 同仓库的并发 Release 请求共享任务；事件循环参与键控，避免热重载或测试循环切换后复用失效任务。
+    _release_task_lock = threading.Lock()
+    _release_tasks: Dict[Tuple[asyncio.AbstractEventLoop, str, bool], asyncio.Task] = {}
     # 这些包一旦被插件覆盖，最容易直接拖垮主程序启动，因此冲突提示需要单独高亮。
     _protected_runtime_packages = frozenset({
         "alembic",
@@ -450,6 +453,27 @@ class PluginHelper(metaclass=WeakSingleton):
                 releases.append(item)
         return releases
 
+    @staticmethod
+    def __normalize_plugin_release_response(payload) -> List[dict]:
+        """仅保留版本展示和资产匹配所需字段，控制仓库级缓存体积。"""
+        if not isinstance(payload, list):
+            return []
+        return [
+            {
+                "tag_name": release_info.get("tag_name"),
+                "name": release_info.get("name"),
+                "published_at": release_info.get("published_at"),
+                "body": release_info.get("body"),
+                "assets": [
+                    {"name": asset.get("name")}
+                    for asset in release_info.get("assets") or []
+                    if isinstance(asset, dict)
+                ],
+            }
+            for release_info in payload
+            if isinstance(release_info, dict)
+        ]
+
     @cached(maxsize=128, ttl=1800)
     def get_plugins(self, repo_url: str,
                     package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
@@ -478,12 +502,12 @@ class PluginHelper(metaclass=WeakSingleton):
             return None
         return self.__parse_plugin_index_response(res.text)
 
-    @cached(maxsize=128, ttl=1800)
-    def get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+    @cached(maxsize=32, ttl=1800, shared_key="get_plugin_repo_releases")
+    def _get_plugin_repo_releases(self, repo_url: str) -> Optional[List[dict]]:
         """
-        获取插件可安装的 GitHub Release 版本列表。
+        按仓库获取 GitHub Release 原始分页数据，供仓库内所有插件共享。
         """
-        if not pid or not repo_url:
+        if not repo_url:
             return []
 
         user, repo = self.get_repo_info(repo_url)
@@ -502,19 +526,31 @@ class PluginHelper(metaclass=WeakSingleton):
                 is_api=True,
             )
             if res is None or res.status_code != 200:
-                break
+                return None
 
             try:
                 payload = res.json()
                 if not payload:
                     break
-                releases.extend(self.__parse_plugin_release_response(pid, payload))
+                if not isinstance(payload, list):
+                    return None
+                releases.extend(self.__normalize_plugin_release_response(payload))
                 if len(payload) < 100:
                     break
             except Exception as e:
-                logger.error(f"解析插件 {pid} Release 列表失败：{e}")
-                break
+                logger.error(f"解析插件仓库 {repo_url} Release 列表失败：{e}")
+                return None
         return releases
+
+    def get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+        """
+        获取插件可安装的 GitHub Release 版本列表。
+
+        GitHub 分页结果按仓库缓存，插件 ID 只参与本地过滤，避免同仓库重复分页。
+        """
+        if not pid or not repo_url:
+            return []
+        return self.__parse_plugin_release_response(pid, self._get_plugin_repo_releases(repo_url.rstrip("/")))
 
     @staticmethod
     def __has_installable_release_version(release_items: List[dict], release_version: str) -> bool:
@@ -1992,12 +2028,12 @@ class PluginHelper(metaclass=WeakSingleton):
             return None
         return self.__parse_plugin_index_response(res.text)
 
-    @cached(maxsize=128, ttl=1800)
-    async def async_get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+    @cached(maxsize=32, ttl=1800, shared_key="get_plugin_repo_releases")
+    async def _async_get_plugin_repo_releases(self, repo_url: str) -> Optional[List[dict]]:
         """
-        异步获取插件可安装的 GitHub Release 版本列表。
+        异步按仓库获取 GitHub Release 原始分页数据。
         """
-        if not pid or not repo_url:
+        if not repo_url:
             return []
 
         user, repo = self.get_repo_info(repo_url)
@@ -2016,19 +2052,84 @@ class PluginHelper(metaclass=WeakSingleton):
                 is_api=True,
             )
             if res is None or res.status_code != 200:
-                break
+                return None
 
             try:
                 payload = res.json()
                 if not payload:
                     break
-                releases.extend(self.__parse_plugin_release_response(pid, payload))
+                if not isinstance(payload, list):
+                    return None
+                releases.extend(self.__normalize_plugin_release_response(payload))
                 if len(payload) < 100:
                     break
             except Exception as e:
-                logger.error(f"解析插件 {pid} Release 列表失败：{e}")
-                break
+                logger.error(f"解析插件仓库 {repo_url} Release 列表失败：{e}")
+                return None
         return releases
+
+    async def async_get_plugin_release_versions(self, pid: str, repo_url: str) -> List[dict]:
+        """
+        异步获取插件可安装的 GitHub Release 版本列表。
+
+        同一事件循环内，同仓库的并发读取和强制刷新共享一个请求任务。
+        """
+        if not pid or not repo_url:
+            return []
+
+        loop = asyncio.get_running_loop()
+        normalized_repo_url = repo_url.rstrip("/")
+        normal_task_key = (loop, normalized_repo_url, False)
+        force_task_key = (loop, normalized_repo_url, True)
+        with self._release_task_lock:
+            force_task = self._release_tasks.get(force_task_key)
+            if force_task and not force_task.done():
+                task_key = force_task_key
+                task = force_task
+            elif is_fresh():
+                pending_normal_task = self._release_tasks.get(normal_task_key)
+                if pending_normal_task and pending_normal_task.done():
+                    pending_normal_task = None
+                task_key = force_task_key
+                task = loop.create_task(
+                    self._async_refresh_plugin_repo_releases(normalized_repo_url, pending_normal_task)
+                )
+                self._release_tasks[task_key] = task
+                task.add_done_callback(
+                    lambda completed_task: self._remove_release_task(task_key, completed_task)
+                )
+            else:
+                task_key = normal_task_key
+                task = self._release_tasks.get(task_key)
+                if task is None or task.done():
+                    task = loop.create_task(self._async_get_plugin_repo_releases(normalized_repo_url))
+                    self._release_tasks[task_key] = task
+                    task.add_done_callback(
+                        lambda completed_task: self._remove_release_task(task_key, completed_task)
+                    )
+
+        payload = await asyncio.shield(task)
+        return self.__parse_plugin_release_response(pid, payload)
+
+    async def _async_refresh_plugin_repo_releases(
+        self,
+        repo_url: str,
+        pending_normal_task: Optional[asyncio.Task],
+    ) -> Optional[List[dict]]:
+        """等待在途普通读取落盘后执行强刷，确保旧结果不会覆盖强刷缓存。"""
+        if pending_normal_task:
+            try:
+                await asyncio.shield(pending_normal_task)
+            except (Exception, asyncio.CancelledError):
+                pass
+        return await self._async_get_plugin_repo_releases(repo_url)
+
+    @classmethod
+    def _remove_release_task(cls, task_key: Tuple[asyncio.AbstractEventLoop, str, bool], task: asyncio.Task) -> None:
+        """请求任务完成后释放事件循环和仓库引用。"""
+        with cls._release_task_lock:
+            if cls._release_tasks.get(task_key) is task:
+                cls._release_tasks.pop(task_key, None)
 
     async def __async_get_file_list(self, pid: str, user_repo: str, package_version: Optional[str] = None) -> \
             Tuple[Optional[list], Optional[str]]:
@@ -2657,3 +2758,10 @@ class PluginHelper(metaclass=WeakSingleton):
         except Exception as e:
             logger.error(f"解压 Release 压缩包失败：{e}")
             return False, f"解压 Release 压缩包失败：{e}"
+
+
+# 公开 Release 查询的缓存管理统一指向仓库级分页缓存。
+PluginHelper.get_plugin_release_versions.cache_clear = PluginHelper._get_plugin_repo_releases.cache_clear
+PluginHelper.get_plugin_release_versions.cache_region = PluginHelper._get_plugin_repo_releases.cache_region
+PluginHelper.async_get_plugin_release_versions.cache_clear = PluginHelper._async_get_plugin_repo_releases.cache_clear
+PluginHelper.async_get_plugin_release_versions.cache_region = PluginHelper._async_get_plugin_repo_releases.cache_region

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -826,6 +826,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         if not settings.PLUGIN_MARKET:
             return []
+        if force:
+            from app.helper.plugin import PluginHelper
+            PluginHelper().get_plugin_release_versions.cache_clear()
 
         # 用于存储高于 v1 版本的插件（如 v2, v3 等）
         higher_version_plugins = []
@@ -1133,6 +1136,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 更新历史
         if plugin_info.get("history"):
             plugin.history = plugin_info.get("history")
+        # Release 能力位来自插件市场索引，用于前端展示和后端安装入口双重校验。
+        plugin.release = bool(plugin_info.get("release"))
         # 仓库链接
         plugin.repo_url = market
         # 本地标志
@@ -1149,6 +1154,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         if not settings.PLUGIN_MARKET:
             return []
+        if force:
+            from app.helper.plugin import PluginHelper
+            await PluginHelper().async_get_plugin_release_versions.cache_clear()
 
         # 用于存储高于 v1 版本的插件（如 v2, v3 等）
         higher_version_plugins = []

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -57,6 +57,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         self._stop_monitor_event = threading.Event()
         # 本地插件同步写入运行目录后的短时忽略窗口
         self._recent_local_sync: Dict[str, float] = {}
+        # 插件智能体工具注册表缓存，插件启停或配置生效时主动失效。
+        self._plugin_agent_tools_cache: Dict[str, List[Dict[str, Any]]] = {}
+        self._plugin_agent_tools_cache_lock = threading.Lock()
         # 开发者模式监测插件修改
         if settings.DEV or settings.PLUGIN_AUTO_RELOAD:
             self.__start_monitor()
@@ -114,6 +117,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     eventmanager.disable_event_handler(plugin)
             except Exception as err:
                 logger.error(f"加载插件 {plugin_id} 出错：{str(err)} - {traceback.format_exc()}")
+        self.clear_plugin_agent_tools_cache()
 
     def init_plugin(self, plugin_id: str, conf: dict):
         """
@@ -133,6 +137,14 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         else:
             # 禁用插件类的事件处理器
             eventmanager.disable_event_handler(type(plugin))
+        self.clear_plugin_agent_tools_cache()
+
+    def clear_plugin_agent_tools_cache(self) -> None:
+        """
+        清空插件智能体工具注册表缓存。
+        """
+        with self._plugin_agent_tools_cache_lock:
+            self._plugin_agent_tools_cache.clear()
 
     def stop(self, pid: Optional[str] = None):
         """
@@ -169,6 +181,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             self._running_plugins = {}
             # 清除所有插件模块缓存
             self._clear_plugin_modules()
+        self.clear_plugin_agent_tools_cache()
         logger.info("插件停止完成")
 
     @staticmethod
@@ -739,8 +752,41 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     def get_plugin_actions(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
         return plugin_metadata.get_plugin_actions(self._running_plugins, pid)
 
+    @staticmethod
+    def _copy_plugin_agent_tools(
+        tools_info: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        复制插件智能体工具注册信息，避免调用方修改缓存内容。
+        """
+        return [
+            {
+                **plugin_info,
+                "tools": list(plugin_info.get("tools", [])),
+            }
+            for plugin_info in tools_info
+        ]
+
     def get_plugin_agent_tools(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
-        return plugin_metadata.get_plugin_agent_tools(self._running_plugins, pid)
+        """
+        获取插件智能体工具
+        [{
+            "plugin_id": "插件ID",
+            "plugin_name": "插件名称",
+            "tools": [ToolClass1, ToolClass2, ...]
+        }]
+        """
+        cache_key = pid or "__all__"
+        with self._plugin_agent_tools_cache_lock:
+            cached_tools = self._plugin_agent_tools_cache.get(cache_key)
+        if cached_tools is not None:
+            return self._copy_plugin_agent_tools(cached_tools)
+
+        # 工具收集逻辑（S9）已下沉至 app.helper.plugin_metadata，此处仅在其上叠加注册表缓存层
+        ret_tools = plugin_metadata.get_plugin_agent_tools(self._running_plugins, pid)
+        with self._plugin_agent_tools_cache_lock:
+            self._plugin_agent_tools_cache[cache_key] = self._copy_plugin_agent_tools(ret_tools)
+        return ret_tools
 
     @staticmethod
     def get_plugin_remote_entry(plugin_id: str, dist_path: str) -> str:

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -1139,8 +1139,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         if plugin_info.get("icon"):
             plugin.plugin_icon = plugin_info.get("icon")
         # 标签
-        if plugin_info.get("labels"):
-            plugin.plugin_label = plugin_info.get("labels")
+        plugin.plugin_label = self._normalize_plugin_label(plugin_info.get("labels"))
         # 作者
         if plugin_info.get("author"):
             plugin.plugin_author = plugin_info.get("author")
@@ -1157,6 +1156,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugin.add_time = add_time
 
         return plugin
+
+    @staticmethod
+    def _normalize_plugin_label(labels: Any) -> Optional[str]:
+        """
+        规整插件市场标签字段，兼容旧字符串和新列表格式。
+
+        :param labels: 插件市场 package 中的 labels 字段
+        :return: 用空格拼接后的标签字符串，无法识别或为空时返回 None
+        """
+        if isinstance(labels, str):
+            label = labels.strip()
+            return label or None
+        if isinstance(labels, list):
+            normalized_labels = [str(item).strip() for item in labels if str(item).strip()]
+            return " ".join(normalized_labels) or None
+        return None
 
     async def async_get_online_plugins(self, force: bool = False) -> List[schemas.Plugin]:
         """

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -826,9 +826,6 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         if not settings.PLUGIN_MARKET:
             return []
-        if force:
-            from app.helper.plugin import PluginHelper
-            PluginHelper().get_plugin_release_versions.cache_clear()
 
         # 用于存储高于 v1 版本的插件（如 v2, v3 等）
         higher_version_plugins = []
@@ -938,6 +935,20 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 根据加载排序重新排序
         plugins.sort(key=lambda x: x.plugin_order if hasattr(x, "plugin_order") else 0)
         return plugins
+
+    def get_local_plugin_version(self, pid: str) -> Optional[str]:
+        """
+        获取指定已安装插件的本地版本，不触发全部插件的状态、页面和权限计算。
+
+        插件类由运行期动态加载，旧插件可能未声明版本属性，因此缺失时返回 None。
+        """
+        installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
+        if pid not in installed_apps:
+            return None
+        plugin_class = self._plugins.get(pid)
+        if not plugin_class:
+            return None
+        return getattr(plugin_class, "plugin_version", None)
 
     def get_local_repo_plugins(self) -> List[schemas.Plugin]:
         """
@@ -1154,9 +1165,6 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         if not settings.PLUGIN_MARKET:
             return []
-        if force:
-            from app.helper.plugin import PluginHelper
-            await PluginHelper().async_get_plugin_release_versions.cache_clear()
 
         # 用于存储高于 v1 版本的插件（如 v2, v3 等）
         higher_version_plugins = []

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -468,7 +468,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     pid=plugin_dir_name,
                     package_version=package_version,
                     repo_path=local_repo_path,
-                    strict_compat=False
+                    strict_compat=False,
+                    strict_system_version=not settings.DEV
                 )
                 if candidate:
                     return candidate
@@ -489,6 +490,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
         candidate = candidate or get_plugin_source().get_local_plugin_candidate(pid)
         if not candidate:
+            return False
+        if candidate.get("compatible") is False:
+            logger.info(f"本地插件 {pid} 不满足同步条件，跳过自动同步：{candidate.get('skip_reason')}")
             return False
 
         source_dir = Path(candidate.get("path"))

--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -979,6 +979,13 @@ class Telegram:
         finally:
             self._stop_typing_if_needed(chat_id, stop_typing)
 
+    @staticmethod
+    def __is_no_text_edit_error(err: Exception) -> bool:
+        """
+        判断 Telegram 是否因为原消息没有 text 字段而拒绝文本编辑。
+        """
+        return "there is no text in the message to edit" in str(err).lower()
+
     def __edit_message(
             self,
             chat_id: str,
@@ -1031,7 +1038,18 @@ class Telegram:
                     edit_text_kwargs["disable_web_page_preview"] = (
                         disable_web_page_preview
                     )
-                self._bot.edit_message_text(**edit_text_kwargs)
+                try:
+                    self._bot.edit_message_text(**edit_text_kwargs)
+                except Exception as err:
+                    if not self.__is_no_text_edit_error(err):
+                        raise
+                    self._bot.edit_message_caption(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        caption=standardize(text),
+                        parse_mode="MarkdownV2",
+                        reply_markup=reply_markup,
+                    )
             return True
         except Exception as e:
             logger.error(f"编辑消息失败：{str(e)}")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,3 +1,4 @@
+from .agent import *
 from .context import *
 from .dashboard import *
 from .download import *

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,7 +1,7 @@
 """AI智能体相关数据模型"""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from langchain_core.messages import BaseMessage
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
@@ -55,3 +55,95 @@ class ToolResult(BaseModel):
     success: bool = Field(description="是否成功")
     result: Optional[str] = Field(default=None, description="执行结果")
     error: Optional[str] = Field(default=None, description="错误信息")
+
+
+class AgentChatAttachment(BaseModel):
+    """
+    Agent 会话展示附件。
+    """
+
+    kind: str = Field(..., description="附件类型")
+    url: str = Field(..., description="附件访问地址")
+    download_url: Optional[str] = Field(None, description="附件下载地址")
+    name: Optional[str] = Field(None, description="附件名称")
+    mime_type: Optional[str] = Field(None, description="MIME 类型")
+    size: Optional[int] = Field(None, description="附件大小")
+    local_path: Optional[str] = Field(None, description="服务端本地路径")
+
+
+class AgentChatToolCall(BaseModel):
+    """
+    Agent 会话工具调用展示项。
+    """
+
+    id: str = Field(..., description="展示 ID")
+    message: str = Field(..., description="工具提示")
+    status: str = Field(default="done", description="工具状态")
+
+
+class AgentChatChoiceButton(BaseModel):
+    """
+    Agent 会话选择按钮。
+    """
+
+    label: str = Field(..., description="按钮文案")
+    callback_data: str = Field(..., description="回调数据")
+
+
+class AgentChatChoiceCard(BaseModel):
+    """
+    Agent 会话选择卡片。
+    """
+
+    id: str = Field(..., description="选择卡片 ID")
+    title: Optional[str] = Field(None, description="标题")
+    prompt: str = Field(default="", description="提示语")
+    buttons: list[AgentChatChoiceButton] = Field(default_factory=list, description="按钮列表")
+    status: str = Field(default="pending", description="选择状态")
+    selected_label: Optional[str] = Field(None, description="已选择文案")
+    selected_value: Optional[str] = Field(None, description="已选择值")
+
+
+class AgentChatMessage(BaseModel):
+    """
+    Agent 会话展示消息。
+    """
+
+    id: str = Field(..., description="展示消息 ID")
+    role: str = Field(..., description="消息角色")
+    content: str = Field(default="", description="消息文本")
+    createdAt: Union[int, float] = Field(..., description="创建时间戳")
+    status: str = Field(default="done", description="消息状态")
+    tools: list[AgentChatToolCall] = Field(default_factory=list, description="工具提示列表")
+    attachments: list[AgentChatAttachment] = Field(default_factory=list, description="附件列表")
+    choices: list[AgentChatChoiceCard] = Field(default_factory=list, description="选择卡片列表")
+
+
+class AgentChatSession(BaseModel):
+    """
+    Agent 会话历史详情。
+    """
+
+    id: Optional[int] = Field(None, description="数据库 ID")
+    session_id: str = Field(..., description="Agent 内部会话 ID")
+    client_session_id: Optional[str] = Field(None, description="客户端原始会话 ID")
+    title: Optional[str] = Field(None, description="会话标题")
+    preview: Optional[str] = Field(None, description="会话预览")
+    channel: Optional[str] = Field(None, description="消息渠道")
+    source: Optional[str] = Field(None, description="渠道来源")
+    user_id: Optional[str] = Field(None, description="用户 ID")
+    username: Optional[str] = Field(None, description="用户名")
+    original_chat_id: Optional[str] = Field(None, description="原聊天 ID")
+    message_count: int = Field(default=0, description="展示消息数量")
+    created_at: Optional[str] = Field(None, description="创建时间")
+    updated_at: Optional[str] = Field(None, description="更新时间")
+    messages: list[AgentChatMessage] = Field(default_factory=list, description="展示消息列表")
+
+
+class AgentChatDisplaySaveRequest(BaseModel):
+    """
+    Agent 会话展示消息保存请求。
+    """
+
+    messages: list[AgentChatMessage] = Field(default_factory=list, description="展示消息列表")
+    title: Optional[str] = Field(None, description="会话标题")

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -223,6 +223,8 @@ class Notification(BaseModel):
     original_chat_id: Optional[str] = None
     # 是否禁用链接预览（仅Telegram支持）
     disable_web_page_preview: Optional[bool] = None
+    # 是否写入消息历史
+    save_history: bool = True
 
     def to_dict(self):
         """

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -26,6 +26,37 @@ class MessageResponse(BaseModel):
     success: bool = False
 
 
+class NotificationHistoryItem(BaseModel):
+    """
+    通知历史记录。
+    """
+
+    # 消息ID
+    id: Optional[int] = None
+    # 消息渠道
+    channel: Optional[str] = None
+    # 消息来源
+    source: Optional[str] = None
+    # 消息类型
+    mtype: Optional[str] = None
+    # 标题
+    title: Optional[str] = None
+    # 文本内容
+    text: Optional[str] = None
+    # 图片
+    image: Optional[str] = None
+    # 链接
+    link: Optional[str] = None
+    # 用户ID
+    userid: Optional[str] = None
+    # 登记时间
+    reg_time: Optional[str] = None
+    # 消息方向：0-接收消息，1-发送消息
+    action: Optional[int] = None
+    # 附件json
+    note: Optional[Union[list, dict]] = None
+
+
 class CommingMessage(BaseModel):
     """
     外来消息

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -310,6 +310,8 @@ class AgentWebChatRequest(BaseModel):
     audio_refs: Optional[List[str]] = Field(default_factory=list)
     # 文件附件列表
     files: Optional[List[AgentWebChatFile]] = Field(default_factory=list)
+    # 是否在展示历史中记录本轮用户消息
+    echo_user: bool = Field(default=True)
 
 
 class AgentWebChoiceRequest(BaseModel):

--- a/app/schemas/plugin.py
+++ b/app/schemas/plugin.py
@@ -42,6 +42,8 @@ class Plugin(BaseModel):
     system_version_message: Optional[str] = None
     # 主系统版本限定范围
     system_version: Optional[str] = None
+    # 是否声明支持通过 GitHub Release 资产安装
+    release: Optional[bool] = False
     # 是否本地
     is_local: Optional[bool] = False
     # 仓库地址

--- a/database/versions/8ab72c49d1e3_2_2_10.py
+++ b/database/versions/8ab72c49d1e3_2_2_10.py
@@ -1,0 +1,73 @@
+"""2.2.10
+新增 Agent 会话历史表
+
+Revision ID: 8ab72c49d1e3
+Revises: 7c1a2b3d4e5f
+Create Date: 2026-06-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "8ab72c49d1e3"
+down_revision = "7c1a2b3d4e5f"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(inspector: sa.Inspector, table_name: str) -> bool:
+    """检查数据表是否已存在。"""
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """升级数据库结构。"""
+    inspector = sa.inspect(op.get_bind())
+    if _has_table(inspector, "agentchat"):
+        return
+
+    op.create_table(
+        "agentchat",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("client_session_id", sa.String(), nullable=True),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("channel", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("original_chat_id", sa.String(), nullable=True),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("preview", sa.String(), nullable=True),
+        sa.Column("agent_messages", sa.JSON(), nullable=True),
+        sa.Column("display_messages", sa.JSON(), nullable=True),
+        sa.Column("message_count", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.String(), nullable=True),
+        sa.Column("updated_at", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agentchat_session_user",
+        "agentchat",
+        ["session_id", "user_id"],
+    )
+    op.create_index(
+        "ix_agentchat_user_updated",
+        "agentchat",
+        ["user_id", "updated_at", "id"],
+    )
+    op.create_index(
+        "ix_agentchat_channel_updated",
+        "agentchat",
+        ["channel", "updated_at", "id"],
+    )
+
+
+def downgrade() -> None:
+    """回滚数据库结构。"""
+    inspector = sa.inspect(op.get_bind())
+    if not _has_table(inspector, "agentchat"):
+        return
+    op.drop_index("ix_agentchat_channel_updated", table_name="agentchat")
+    op.drop_index("ix_agentchat_user_updated", table_name="agentchat")
+    op.drop_index("ix_agentchat_session_user", table_name="agentchat")
+    op.drop_table("agentchat")

--- a/docker/nginx.common.conf
+++ b/docker/nginx.common.conf
@@ -76,6 +76,20 @@ location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
     add_header Cache-Control "public, immutable";
 }
 
+# Service Worker 和 Web App Manifest 需要稳定 URL 但不能长缓存，否则前端更新时浏览器可能继续注册旧版本。
+location = /service-worker.js {
+    expires off;
+    add_header Cache-Control "no-cache, must-revalidate";
+    try_files $uri =404;
+}
+
+location = /manifest.webmanifest {
+    expires off;
+    default_type application/manifest+json;
+    add_header Cache-Control "no-cache, must-revalidate";
+    try_files $uri =404;
+}
+
 # JS 和 CSS 静态资源缓存（排除 /api/v1 路径）
 location ~* ^/(?!api/v1).*\.(js|css)$ {
     try_files $uri =404;
@@ -86,8 +100,7 @@ location ~* ^/(?!api/v1).*\.(js|css)$ {
 
 # assets目录
 location /assets {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
+    add_header Cache-Control "public, max-age=31536000, immutable";
 }
 
 # 站点图标

--- a/docs/postgresql-setup.md
+++ b/docs/postgresql-setup.md
@@ -75,13 +75,6 @@ DB_POSTGRESQL_USERNAME=your-username
 DB_POSTGRESQL_PASSWORD=your-password
 ```
 
-使用 Redis Unix Socket 时，可直接设置 `CACHE_BACKEND_URL`，例如：
-
-```bash
-CACHE_BACKEND_TYPE=redis
-CACHE_BACKEND_URL=unix:///var/run/redis/redis.sock?db=0
-```
-
 ## 数据迁移
 
 ### 从 SQLite 迁移到 PostgreSQL

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Cython~=3.2.5
-moviepilot-rust~=0.1.9
+moviepilot-rust~=0.1.10
 pydantic>=2.13.4,<3.0.0
 pydantic-settings>=2.14.1,<3.0.0
 SQLAlchemy~=2.0.50

--- a/skills/organize-files/SKILL.md
+++ b/skills/organize-files/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: organize-files
+version: 1
+description: >-
+  Use this skill when the user asks the MoviePilot agent to identify and organize downloaded/local media files that automatic transfer cannot handle. Typical triggers include: manually organize a file or folder, organize unrecognized downloads, fix files stuck in a download directory, identify a messy episode pack, move/copy/link files into the library, or organize files by explicit TMDB/Douban ID. If the user gives failed transfer history IDs, prefer transfer-failed-retry instead.
+allowed-tools: list_directory query_directory_settings query_download_tasks query_transfer_history delete_transfer_history recognize_media search_media query_media_detail query_library_exists transfer_file ask_user_choice send_message
+---
+
+# Organize Files (智能整理文件)
+
+Use this skill to help the user identify media files that MoviePilot could not organize automatically, then call the normal transfer pipeline through `transfer_file`. Do not rename, move, or copy files manually; let MoviePilot's directory, transfer mode, rename template, overwrite, scrape, and notification settings handle the actual organization.
+
+## MoviePilot Transfer Flow
+
+MoviePilot's normal flow is:
+
+1. `DownloadChain.download_single` adds a downloader task, records `DownloadHistory` and `DownloadFiles`, runs downloader-specific `download_added`, then sends `DownloadAdded`.
+2. `TransferChain.process` scans completed downloader tasks in monitored download directories. If a `DownloadHistory` exists for the hash, it reuses the recorded media IDs; otherwise it falls back to path recognition.
+3. Agent/manual organization calls `transfer_file`, which enters `TransferFileTool` -> `TransferChain.manual_transfer` -> `TransferChain.do_transfer`.
+4. `do_transfer` recursively collects eligible media/subtitle/audio files, ignores recycle/hidden paths and configured exclude words, resolves download history when possible, builds `MetaInfoPath`, then either uses explicit media info or calls `MediaChain.recognize_by_meta`.
+5. `TransferChain.__handle_transfer` chooses the target directory through `DirectoryHelper`, delegates file operations to the file manager module, and lets `TransHandler` build the final target path and name.
+6. The callback writes `TransferHistory` success/failure records, emits transfer events, sends notifications, and may trigger `transfer-failed-retry` for failed history records.
+
+Important implication: an existing `TransferHistory` for the same source path can make a later transfer skip. Delete only stale or failed history records, and only after the user has confirmed the record is safe to remove.
+
+## Workflow
+
+### 1. Classify The Request
+
+- If the user provides one or more failed transfer history IDs, stop and use `transfer-failed-retry`.
+- If the user provides a path, start from that path.
+- If the user describes a download task, use `query_download_tasks` to find its save path or hash, then continue with the path.
+- If the user only says "整理一下下载目录", use `query_directory_settings(directory_type="download")` first, then ask which directory or subdirectory to process if more than one candidate exists.
+
+### 2. Inspect Candidate Files
+
+Use `list_directory` for any directory the user provides. Prefer `sort_by="time"` for "recent" or "刚下载的" requests.
+
+For directories with more than 20 items, ask the user to narrow the folder or choose the relevant child directory before running transfers. Avoid organizing a broad shared download root unless the user explicitly confirms the scope.
+
+Treat these as transfer candidates:
+
+- main media files and Blu-ray folders;
+- matching subtitle and external audio files in the same media folder;
+- episode packs where files share the same title/season pattern.
+
+Skip obvious samples, trailers, screenshots, hidden folders, recycle folders, and files that are not media/subtitle/audio.
+
+### 3. Identify The Media
+
+For the best sample file, call:
+
+```text
+recognize_media(path="<source file path>")
+```
+
+If recognition fails or looks wrong:
+
+1. Extract likely title, year, media type, season, and episode range from filenames.
+2. Call `search_media(title="...", year="...", media_type="movie|tv")`.
+3. If several results are plausible, use `ask_user_choice` when available, or ask the user directly to choose the correct title/TMDB ID.
+4. For TV season confusion, use `query_media_detail(tmdb_id=<id>, media_type="tv")` before deciding the season number.
+
+Never invent a TMDB/Douban ID. When unsure, ask for confirmation.
+
+### 4. Check Existing State
+
+Before writing:
+
+- Use `query_library_exists` when a precise `tmdb_id` and `media_type` are known and duplicate risk matters.
+- Use `query_transfer_history(title="<title or path keyword>", status="all")` if the file may already have a success or failure record.
+- If `transfer_file` later returns "已整理过", query transfer history, identify the matching source path, and ask before deleting the stale record.
+
+Only call `delete_transfer_history(history_id=<id>)` for the exact stale/failed record that blocks the requested source path. Do not delete unrelated successful history.
+
+### 5. Transfer Through MoviePilot
+
+Use `transfer_file` with explicit identity whenever possible:
+
+```text
+transfer_file(
+  file_path="<source path>",
+  storage="local",
+  media_type="movie|tv",
+  tmdbid=<tmdb_id>,
+  season=<season_number_if_tv>
+)
+```
+
+Rules:
+
+- For directories, pass a trailing slash in `file_path` so the tool treats it as a directory.
+- Prefer leaving `target_path`, `target_storage`, and `transfer_type` empty so configured directory rules apply.
+- Set `target_path` or `transfer_type` only when the user explicitly asks or the default directory configuration cannot handle the file.
+- For a single movie or a single TV season folder, transfer the folder once with the shared identity.
+- For mixed folders, split by media and transfer each file/subfolder separately.
+- For episode packs, identify the media once, then reuse `tmdbid`, `media_type="tv"`, and the confirmed `season` for each item.
+
+### 6. Report Clearly
+
+After each transfer batch, report:
+
+- source path(s) processed;
+- recognized media title, type, TMDB/Douban ID, season/episode range when relevant;
+- success/failure count;
+- any failed message exactly enough for the user to act, such as missing media library directory, unsupported storage, existing history, or no media recognized.
+
+If the result creates failed history records, tell the user they can retry with the history ID or let the agent continue with `transfer-failed-retry`.
+
+## Common Cases
+
+### User Gives A Single File
+
+1. `recognize_media(path=...)`
+2. If needed, `search_media(...)` and confirm the result.
+3. `transfer_file(file_path=..., media_type=..., tmdbid=..., season=...)`
+
+### User Gives A Season Folder
+
+1. `list_directory(path=...)`
+2. Pick a representative episode and run `recognize_media(path=...)`.
+3. Confirm `tmdbid`, `media_type="tv"`, and season.
+4. `transfer_file(file_path="<folder>/", media_type="tv", tmdbid=<id>, season=<season>)`
+
+### User Gives A Messy Mixed Folder
+
+1. `list_directory(path=...)`
+2. Group candidates by likely title/year/season.
+3. Confirm groups before writing if there is more than one media.
+4. Transfer each group separately; do not run one directory transfer over unrelated media.
+
+### Transfer Says The File Was Already Organized
+
+1. `query_transfer_history(title="<title or source path keyword>", status="all")`
+2. Find the exact record with matching `src`.
+3. Ask the user to confirm deletion if the record is stale or failed.
+4. `delete_transfer_history(history_id=<id>)`
+5. Retry `transfer_file(...)`.
+
+## Guardrails
+
+- Do not use shell commands, raw database edits, or manual filesystem moves for organization.
+- Do not delete transfer history without an exact matching source path and user confirmation.
+- Do not use broad download roots as transfer targets unless the user explicitly confirms the scope.
+- Do not process unrelated media in one directory transfer.
+- Do not override target directories or transfer modes unless necessary.
+- Prefer asking one focused question over guessing media identity, season mapping, or destructive cleanup.

--- a/skills/publish-moviepilot-plugin/SKILL.md
+++ b/skills/publish-moviepilot-plugin/SKILL.md
@@ -8,6 +8,8 @@ description: >-
   repositories, package.json/package.v2.json metadata, plugins/plugins.v2
   layouts, safe file exclusion, diff preview before publishing, incremental
   GitHub Contents API updates, and syncing local plugin changes back from GitHub.
+  Includes asking whether to use an existing repository or create a new public
+  repository when no target repository is available.
   Also use for Chinese requests mentioning 插件发布, 插件维护, 推送插件到 GitHub,
   从 GitHub 拉取插件, 同步本地插件仓库, 增量发布插件, 插件仓库维护.
 allowed-tools: list_directory read_file write_file edit_file execute_command query_system_settings update_system_settings
@@ -25,6 +27,8 @@ through GitHub while protecting local secrets and unrelated plugins.
 - Merge only that plugin's entry into `package.v2.json` or `package.json`.
 - Preview local/remote differences before writing.
 - Pull remote plugin files back to the local plugin source.
+- Create the target GitHub repository when the user explicitly chooses automatic
+  creation; repositories are public by default unless the user asks for private.
 - Reuse MoviePilot settings `GITHUB_TOKEN`, `REPO_GITHUB_TOKEN`,
   and `PLUGIN_LOCAL_REPO_PATHS` when available.
 
@@ -49,7 +53,12 @@ through GitHub while protecting local secrets and unrelated plugins.
 2. Identify the GitHub repository as `owner/repo`.
    - Use the user's explicit repository first.
    - If omitted, infer only when the local source has an obvious Git remote.
-   - If neither is available, ask for the target repository.
+   - If neither is available, ask whether to use an existing repository or
+     automatically create a new public repository.
+   - If the user chooses an existing repository, ask for `owner/repo`.
+   - If the user chooses automatic creation, ask for the target `owner/repo`
+     and state that the repository will be public by default.
+   - Do not create a private repository unless the user explicitly asks for it.
 3. Select the package version layout.
    - Prefer `v2` when `package.v2.json` or `plugins.v2/<plugin_id_lower>/`
      exists.
@@ -83,13 +92,20 @@ python skills/publish-moviepilot-plugin/scripts/publish_plugin.py pull \
   --plugin-id MyPlugin \
   --local-repo /path/to/MoviePilot-Plugins \
   --package-version v2
+
+python skills/publish-moviepilot-plugin/scripts/publish_plugin.py create-repo \
+  --repo owner/repo
 ```
 
 Options:
 
+- `create-repo`: create the target GitHub repository. Default visibility is
+  public; use `--private` only when the user explicitly asked for private.
 - `preview`: compare local filtered files with remote files and print JSON.
 - `push`: upload changed files and merge the plugin package entry.
 - `pull`: write remote plugin files and package entry into local source.
+- `--create-repo-if-missing`: on push, create the target public repository when
+  GitHub reports that it does not exist.
 - `--delete-remote`: on push, delete remote plugin files that no longer exist
   locally after exclusions.
 - `--force`: on pull, allow overwriting local files that differ from remote.
@@ -102,6 +118,10 @@ Options:
 
 - Always run `preview` before `push` unless the user explicitly asks for a
   direct push and already reviewed the diff.
+- When no repository is known, ask the user to choose:
+  `使用已有 GitHub 仓库` or `自动创建 GitHub 仓库（默认 public）`.
+- Only run `create-repo` or `push --create-repo-if-missing` after the user has
+  explicitly chosen automatic creation.
 - Never upload these files unless explicitly included:
   `.env`, `.env.*`, `config/`, `data/`, `cache/`, `logs/`, `tmp/`,
   `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`,
@@ -122,9 +142,16 @@ Options:
 User asks: `把本地 MyPlugin 发布到我的 GitHub 插件仓库`
 
 1. Find `MyPlugin` under configured `PLUGIN_LOCAL_REPO_PATHS`.
-2. Ask for `owner/repo` if it cannot be inferred.
+2. Ask whether to use an existing repository or create a new public repository
+   if `owner/repo` cannot be inferred.
 3. Run `preview` and summarize the diff.
 4. Run `push` only after the user confirms or requested immediate publish.
+
+User asks: `发布插件，没有 GitHub 仓库`
+
+1. Ask for the target `owner/repo` and confirm automatic creation.
+2. Run `create-repo` or use `push --create-repo-if-missing`.
+3. Continue with `preview` and `push` after repository creation succeeds.
 
 User asks: `同步 GitHub 上 MyPlugin 的最新代码到本地`
 

--- a/skills/publish-moviepilot-plugin/SKILL.md
+++ b/skills/publish-moviepilot-plugin/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: publish-moviepilot-plugin
+version: 1
+description: >-
+  Use this skill when the user asks to publish, upload, sync, pull, push, diff,
+  or maintain a MoviePilot local plugin in a GitHub repository. Covers using the
+  configured MoviePilot GitHub token, PLUGIN_LOCAL_REPO_PATHS local plugin
+  repositories, package.json/package.v2.json metadata, plugins/plugins.v2
+  layouts, safe file exclusion, diff preview before publishing, incremental
+  GitHub Contents API updates, and syncing local plugin changes back from GitHub.
+  Also use for Chinese requests mentioning 插件发布, 插件维护, 推送插件到 GitHub,
+  从 GitHub 拉取插件, 同步本地插件仓库, 增量发布插件, 插件仓库维护.
+allowed-tools: list_directory read_file write_file edit_file execute_command query_system_settings update_system_settings
+---
+
+# Publish MoviePilot Plugin
+
+Use this skill to publish and maintain a MoviePilot local plugin repository
+through GitHub while protecting local secrets and unrelated plugins.
+
+## Scope
+
+- Publish one local plugin under `plugins.v2/<plugin_id_lower>/` or
+  `plugins/<plugin_id_lower>/` to a GitHub repository.
+- Merge only that plugin's entry into `package.v2.json` or `package.json`.
+- Preview local/remote differences before writing.
+- Pull remote plugin files back to the local plugin source.
+- Reuse MoviePilot settings `GITHUB_TOKEN`, `REPO_GITHUB_TOKEN`,
+  and `PLUGIN_LOCAL_REPO_PATHS` when available.
+
+## Ground Truth
+
+- Local plugin development rules: `skills/create-moviepilot-plugin/SKILL.md`.
+- Local plugin source discovery: `app/helper/plugin.py`,
+  `PluginHelper.get_local_repo_paths()`.
+- GitHub token settings: `app/core/config.py`, especially `GITHUB_TOKEN` and
+  `REPO_GITHUB_TOKEN`.
+- Plugin package layouts:
+  - V2: `package.v2.json` and `plugins.v2/<plugin_id_lower>/`
+  - Legacy: `package.json` and `plugins/<plugin_id_lower>/`
+
+## Pre-Flight
+
+1. Identify the target plugin ID and local source repository.
+   - If the user gives a path, use it.
+   - Otherwise query `PLUGIN_LOCAL_REPO_PATHS`; if exactly one configured
+     repository contains the plugin, use it.
+   - If several configured repositories contain the plugin, ask which one.
+2. Identify the GitHub repository as `owner/repo`.
+   - Use the user's explicit repository first.
+   - If omitted, infer only when the local source has an obvious Git remote.
+   - If neither is available, ask for the target repository.
+3. Select the package version layout.
+   - Prefer `v2` when `package.v2.json` or `plugins.v2/<plugin_id_lower>/`
+     exists.
+   - Use legacy only when the local plugin is under `plugins/`.
+4. Verify token availability.
+   - Prefer `REPO_GITHUB_TOKEN` for the target repo when configured.
+   - Fall back to `GITHUB_TOKEN`.
+   - If no token is configured, ask the user to configure one before pushing.
+     Read-only preview may still run without a token for public repositories.
+
+## Script
+
+Use `scripts/publish_plugin.py` for deterministic GitHub operations.
+
+```bash
+python skills/publish-moviepilot-plugin/scripts/publish_plugin.py preview \
+  --repo owner/repo \
+  --plugin-id MyPlugin \
+  --local-repo /path/to/MoviePilot-Plugins \
+  --package-version v2
+
+python skills/publish-moviepilot-plugin/scripts/publish_plugin.py push \
+  --repo owner/repo \
+  --plugin-id MyPlugin \
+  --local-repo /path/to/MoviePilot-Plugins \
+  --package-version v2 \
+  --message "Publish MyPlugin v1.0.0"
+
+python skills/publish-moviepilot-plugin/scripts/publish_plugin.py pull \
+  --repo owner/repo \
+  --plugin-id MyPlugin \
+  --local-repo /path/to/MoviePilot-Plugins \
+  --package-version v2
+```
+
+Options:
+
+- `preview`: compare local filtered files with remote files and print JSON.
+- `push`: upload changed files and merge the plugin package entry.
+- `pull`: write remote plugin files and package entry into local source.
+- `--delete-remote`: on push, delete remote plugin files that no longer exist
+  locally after exclusions.
+- `--force`: on pull, allow overwriting local files that differ from remote.
+- `--include PATTERN`: add files otherwise excluded by default.
+- `--exclude PATTERN`: add an extra ignore pattern.
+- `--dry-run`: print planned changes without writing.
+- `--proxy URL`: use an explicit HTTP/HTTPS proxy for GitHub API requests.
+
+## Safety Rules
+
+- Always run `preview` before `push` unless the user explicitly asks for a
+  direct push and already reviewed the diff.
+- Never upload these files unless explicitly included:
+  `.env`, `.env.*`, `config/`, `data/`, `cache/`, `logs/`, `tmp/`,
+  `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`,
+  `.DS_Store`, `*.pyc`, `*.pyo`, `*.db`, `*.sqlite`, `*.sqlite3`, `*.log`,
+  `*.bak`, `*.tmp`, `*.secret`, `*.key`, `*.pem`, `*.crt`, `*.p12`, `*.pfx`,
+  `node_modules/`.
+- For Vue federation plugins, publish built runtime assets under `dist/assets/`
+  when they are present; do not exclude them as generated files.
+- Do not overwrite or remove package entries for other plugins.
+- Do not log or print GitHub token values.
+- For push operations, report created, updated, deleted, skipped, and rejected
+  files separately.
+- For pull operations, preserve local-only ignored files and refuse to overwrite
+  differing local files unless `--force` is used.
+
+## Examples
+
+User asks: `把本地 MyPlugin 发布到我的 GitHub 插件仓库`
+
+1. Find `MyPlugin` under configured `PLUGIN_LOCAL_REPO_PATHS`.
+2. Ask for `owner/repo` if it cannot be inferred.
+3. Run `preview` and summarize the diff.
+4. Run `push` only after the user confirms or requested immediate publish.
+
+User asks: `同步 GitHub 上 MyPlugin 的最新代码到本地`
+
+1. Run `pull` without `--force`.
+2. If local conflicts are reported, show the conflicting paths and ask whether
+   to force overwrite or resolve manually.
+
+## Final Checklist
+
+- The plugin ID matches the package object key.
+- The package file and plugin directory layout match the selected version.
+- Sensitive and runtime-local files were rejected or skipped.
+- The preview was shown before push, unless explicitly bypassed.
+- The final response mentions whether local agent restart is needed only when
+  this built-in skill itself changed.

--- a/skills/publish-moviepilot-plugin/scripts/publish_plugin.py
+++ b/skills/publish-moviepilot-plugin/scripts/publish_plugin.py
@@ -22,6 +22,7 @@ DEFAULT_BRANCH = "main"
 DEFAULT_TIMEOUT = 60
 GITHUB_API_BASE = "https://api.github.com"
 USER_AGENT = "MoviePilot-Plugin-Publisher"
+COMMANDS_REQUIRE_LOCAL_PLUGIN = {"preview", "push", "pull"}
 PACKAGE_BY_VERSION = {
     "legacy": ("package.json", "plugins"),
     "v1": ("package.json", "plugins"),
@@ -330,6 +331,39 @@ class GitHubClient:
             f"/repos/{self.repo}/contents/{quote_path(path)}",
             payload=payload,
         )
+
+    def repo_exists(self) -> bool:
+        """
+        检查目标仓库是否存在或当前 token 是否可访问。
+
+        :return: 仓库存在或可访问时返回 True
+        """
+        try:
+            self.request("GET", f"/repos/{self.repo}")
+            return True
+        except GitHubError as err:
+            if err.status == 404:
+                return False
+            raise
+
+    def create_repo(self, private: bool = False) -> Any:
+        """
+        创建目标 GitHub 仓库。
+
+        :param private: 是否创建私有仓库，默认创建公开仓库
+        :return: GitHub API 响应
+        """
+        owner, repo_name = self.repo.split("/", 1)
+        payload = {
+            "name": repo_name,
+            "private": private,
+            "auto_init": True,
+        }
+        user_data = self.request("GET", "/user")
+        login = user_data.get("login") if isinstance(user_data, dict) else ""
+        if login and str(login).lower() == owner.lower():
+            return self.request("POST", "/user/repos", payload=payload)
+        return self.request("POST", f"/orgs/{quote(owner)}/repos", payload=payload)
 
 
 def normalize_repo(repo: str) -> str:
@@ -872,6 +906,33 @@ def compare_package(
     return remote_package, merged_content, change_type
 
 
+def load_remote_files_for_push(
+    context: dict[str, Any],
+    args: argparse.Namespace,
+) -> tuple[dict[str, FileState], Optional[FileState], bool]:
+    """
+    读取推送所需的远端文件，允许显式自动建仓时把缺失仓库视为空仓库。
+
+    :param context: 运行上下文
+    :param args: 命令行参数
+    :return: 远端插件文件、远端 package 文件、仓库是否已存在
+    """
+    client: GitHubClient = context["client"]
+    repo_exists = client.repo_exists()
+    if not repo_exists and not args.create_repo_if_missing:
+        raise GitHubError(
+            404,
+            "目标仓库不存在。请先创建仓库，或在用户明确同意后使用 --create-repo-if-missing。",
+        )
+    if not repo_exists:
+        return {}, None, False
+    return (
+        client.list_files(context["remote_prefix"]),
+        client.get_file(context["layout"].package_file),
+        True,
+    )
+
+
 def preview(args: argparse.Namespace) -> dict[str, Any]:
     """
     预览本地插件与远端仓库的差异。
@@ -916,20 +977,28 @@ def push(args: argparse.Namespace) -> dict[str, Any]:
         context["excludes"],
         context["includes"],
     )
-    remote_files = client.list_files(context["remote_prefix"])
     entry = read_package_entry(context["local_repo"], context["layout"], context["plugin_id"])
-    remote_package, package_content, package_change = compare_package(
-        client,
-        context["layout"],
+    remote_files, remote_package, repo_existed = load_remote_files_for_push(context, args)
+    package_content = merge_package_content(
+        remote_package.content if remote_package else None,
         context["plugin_id"],
         entry,
     )
+    if remote_package is None:
+        package_change = "create"
+    elif hashlib.sha256(package_content).hexdigest() != remote_package.sha256:
+        package_change = "update"
+    else:
+        package_change = "same"
     changes = build_push_changes(local_files, remote_files, rejected, args.delete_remote)
     payload = result_payload(context, changes, package_change=package_change)
+    payload["repo_existed"] = repo_existed
     if args.dry_run:
         payload["dry_run"] = True
         return payload
 
+    if not repo_existed:
+        client.create_repo(private=args.private)
     message = args.message or f"Publish {context['plugin_id']}"
     applied: dict[str, list[str]] = {"create": [], "update": [], "delete": []}
     if package_change in {"create", "update"}:
@@ -954,6 +1023,43 @@ def push(args: argparse.Namespace) -> dict[str, Any]:
     payload["applied"] = applied
     payload["message"] = "插件已推送到 GitHub 仓库。"
     return payload
+
+
+def create_repo(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    创建 GitHub 仓库，默认创建公开仓库。
+
+    :param args: 命令行参数
+    :return: 创建结果
+    """
+    context = build_context(args, require_token=not args.dry_run)
+    client: GitHubClient = context["client"]
+    if args.dry_run:
+        return {
+            "success": True,
+            "repo": context["repo"],
+            "created": False,
+            "private": args.private,
+            "dry_run": True,
+            "message": "dry-run 未访问 GitHub，未创建仓库。",
+        }
+    if client.repo_exists():
+        return {
+            "success": True,
+            "repo": context["repo"],
+            "created": False,
+            "private": args.private,
+            "message": "目标 GitHub 仓库已存在。",
+        }
+    data = client.create_repo(private=args.private)
+    return {
+        "success": True,
+        "repo": context["repo"],
+        "created": True,
+        "private": bool(data.get("private")) if isinstance(data, dict) else args.private,
+        "url": data.get("html_url") if isinstance(data, dict) else None,
+        "message": "目标 GitHub 仓库已创建。",
+    }
 
 
 def pull(args: argparse.Namespace) -> dict[str, Any]:
@@ -1080,8 +1186,14 @@ def build_context(args: argparse.Namespace, require_token: bool = False) -> dict
     :return: 运行上下文
     """
     repo = normalize_repo(args.repo)
-    local_repo = resolve_local_repo(args.local_repo, args.plugin_id, args.package_version)
-    layout = resolve_layout(args.package_version, local_repo, args.plugin_id)
+    plugin_id = getattr(args, "plugin_id", "") or ""
+    package_version = getattr(args, "package_version", "auto") or "auto"
+    if args.command in COMMANDS_REQUIRE_LOCAL_PLUGIN:
+        local_repo = resolve_local_repo(args.local_repo, plugin_id, package_version)
+        layout = resolve_layout(package_version, local_repo, plugin_id)
+    else:
+        local_repo = Path.cwd()
+        layout = Layout(package_file="package.v2.json", plugin_root="plugins.v2")
     token = resolve_token(repo, args.token)
     if require_token and not token:
         raise ValueError("未配置 GitHub token，无法写入仓库")
@@ -1101,8 +1213,8 @@ def build_context(args: argparse.Namespace, require_token: bool = False) -> dict
         "branch": branch,
         "local_repo": local_repo,
         "layout": layout,
-        "plugin_id": args.plugin_id,
-        "remote_prefix": remote_plugin_prefix(layout, args.plugin_id),
+        "plugin_id": plugin_id,
+        "remote_prefix": remote_plugin_prefix(layout, plugin_id) if plugin_id else "",
         "client": client,
         "excludes": excludes,
         "includes": includes,
@@ -1127,9 +1239,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="发布和同步 MoviePilot 本地插件到 GitHub 仓库",
     )
-    parser.add_argument("command", choices=("preview", "push", "pull"))
+    parser.add_argument("command", choices=("create-repo", "preview", "push", "pull"))
     parser.add_argument("--repo", required=True, help="GitHub 仓库，格式 owner/repo")
-    parser.add_argument("--plugin-id", required=True, help="插件类名 ID")
+    parser.add_argument("--plugin-id", default="", help="插件类名 ID")
     parser.add_argument("--local-repo", default="", help="本地插件仓库目录")
     parser.add_argument("--package-version", default="auto", help="auto、v2 或 legacy")
     parser.add_argument("--branch", default=DEFAULT_BRANCH, help="目标分支")
@@ -1141,6 +1253,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--include", action="append", default=[], help="强制包含 glob")
     parser.add_argument("--exclude", action="append", default=[], help="额外排除 glob")
     parser.add_argument("--delete-remote", action="store_true", help="推送时删除远端多余文件")
+    parser.add_argument(
+        "--create-repo-if-missing",
+        action="store_true",
+        help="推送时在目标仓库不存在的情况下自动创建公开仓库",
+    )
+    parser.add_argument("--private", action="store_true", help="创建仓库时使用私有可见性")
     parser.add_argument("--force", action="store_true", help="拉取时允许覆盖本地冲突")
     parser.add_argument("--dry-run", action="store_true", help="只输出计划，不写入")
     return parser
@@ -1154,8 +1272,13 @@ def main() -> int:
     """
     parser = build_parser()
     args = parser.parse_args()
+    if args.command in COMMANDS_REQUIRE_LOCAL_PLUGIN and not args.plugin_id:
+        print_json({"success": False, "message": "preview、push、pull 必须提供 --plugin-id"})
+        return 1
     try:
-        if args.command == "preview":
+        if args.command == "create-repo":
+            payload = create_repo(args)
+        elif args.command == "preview":
             payload = preview(args)
         elif args.command == "push":
             payload = push(args)
@@ -1164,7 +1287,8 @@ def main() -> int:
     except (GitHubError, OSError, ValueError, json.JSONDecodeError) as err:
         print_json({"success": False, "message": str(err)})
         return 1
-    payload["success"] = not payload.get("changes", {}).get("conflicts")
+    if "success" not in payload:
+        payload["success"] = not payload.get("changes", {}).get("conflicts")
     print_json(payload)
     return 0 if payload["success"] else 1
 

--- a/skills/publish-moviepilot-plugin/scripts/publish_plugin.py
+++ b/skills/publish-moviepilot-plugin/scripts/publish_plugin.py
@@ -1,0 +1,1173 @@
+#!/usr/bin/env python3
+"""发布和同步 MoviePilot 本地插件到 GitHub 仓库。"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional
+
+
+DEFAULT_BRANCH = "main"
+DEFAULT_TIMEOUT = 60
+GITHUB_API_BASE = "https://api.github.com"
+USER_AGENT = "MoviePilot-Plugin-Publisher"
+PACKAGE_BY_VERSION = {
+    "legacy": ("package.json", "plugins"),
+    "v1": ("package.json", "plugins"),
+    "v2": ("package.v2.json", "plugins.v2"),
+}
+TOKEN_ENV_NAMES = ("MOVIEPILOT_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
+DEFAULT_EXCLUDES = (
+    ".git/",
+    ".idea/",
+    ".vscode/",
+    ".env",
+    ".env.*",
+    ".DS_Store",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    "node_modules/",
+    "config/",
+    "data/",
+    "cache/",
+    "logs/",
+    "tmp/",
+    "*.pyc",
+    "*.pyo",
+    "*.db",
+    "*.sqlite",
+    "*.sqlite3",
+    "*.log",
+    "*.bak",
+    "*.tmp",
+    "*.secret",
+    "*.key",
+    "*.pem",
+    "*.crt",
+    "*.p12",
+    "*.pfx",
+)
+
+
+@dataclass
+class FileState:
+    """表示一个本地或远端文件的内容状态。"""
+
+    path: str
+    content: bytes
+    sha: Optional[str] = None
+
+    @property
+    def sha256(self) -> str:
+        """返回文件内容的 SHA256 摘要。"""
+        return hashlib.sha256(self.content).hexdigest()
+
+
+@dataclass
+class ChangeSet:
+    """保存一次插件同步对比得到的差异集合。"""
+
+    create: list[str] = field(default_factory=list)
+    update: list[str] = field(default_factory=list)
+    delete: list[str] = field(default_factory=list)
+    same: list[str] = field(default_factory=list)
+    rejected: dict[str, str] = field(default_factory=dict)
+    conflicts: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """转换为可序列化的字典。"""
+        return {
+            "create": sorted(self.create),
+            "update": sorted(self.update),
+            "delete": sorted(self.delete),
+            "same": sorted(self.same),
+            "rejected": dict(sorted(self.rejected.items())),
+            "conflicts": sorted(self.conflicts),
+            "summary": {
+                "create": len(self.create),
+                "update": len(self.update),
+                "delete": len(self.delete),
+                "same": len(self.same),
+                "rejected": len(self.rejected),
+                "conflicts": len(self.conflicts),
+            },
+        }
+
+
+@dataclass
+class Layout:
+    """描述 MoviePilot 插件仓库的 package 与插件目录布局。"""
+
+    package_file: str
+    plugin_root: str
+
+    @property
+    def version(self) -> str:
+        """返回布局版本标识。"""
+        if self.plugin_root == "plugins.v2":
+            return "v2"
+        return "legacy"
+
+
+class GitHubError(RuntimeError):
+    """GitHub API 调用失败。"""
+
+    def __init__(self, status: int, message: str):
+        """初始化 GitHub 错误。"""
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+class GitHubClient:
+    """基于 GitHub Contents API 的轻量客户端。"""
+
+    def __init__(
+        self,
+        repo: str,
+        token: str = "",
+        branch: str = DEFAULT_BRANCH,
+        api_base: str = GITHUB_API_BASE,
+        timeout: int = DEFAULT_TIMEOUT,
+        proxy: str = "",
+    ) -> None:
+        """初始化客户端配置。"""
+        self.repo = normalize_repo(repo)
+        self.branch = branch
+        self.api_base = api_base.rstrip("/")
+        self.timeout = timeout
+        self.token = token
+        self.proxy = proxy
+        self.request_utils_class = load_request_utils_class()
+        self.proxies = build_proxy_config(proxy)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[dict[str, Any]] = None,
+        accept: str = "application/vnd.github+json",
+    ) -> Any:
+        """
+        发送 GitHub API 请求并返回解析后的 JSON。
+
+        :param method: HTTP 方法
+        :param path: API 路径
+        :param payload: JSON 请求体
+        :param accept: Accept 请求头
+        :return: 解析后的响应 JSON
+        """
+        url = f"{self.api_base}{path}"
+        body = None
+        headers = {
+            "Accept": accept,
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if payload is not None:
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        response = None
+        try:
+            response = self.request_utils_class(
+                proxies=self.proxies,
+                headers=headers,
+                timeout=self.timeout,
+            ).request(
+                method=method.lower(),
+                url=url,
+                data=body,
+                raise_exception=True,
+            )
+            if response is None:
+                raise GitHubError(0, "GitHub API 未返回响应")
+            if response.status_code >= 400:
+                raise GitHubError(response.status_code, parse_github_error(response.text))
+            raw = response.content
+        except Exception as err:
+            if isinstance(err, GitHubError):
+                raise
+            status = getattr(getattr(err, "response", None), "status_code", 0)
+            raw_error = getattr(getattr(err, "response", None), "text", "")
+            message = parse_github_error(raw_error) if raw_error else str(err)
+            raise GitHubError(status, message) from err
+        finally:
+            if response is not None:
+                response.close()
+
+        if not raw:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            return raw.decode("utf-8", errors="replace")
+
+    def get_file(self, path: str) -> Optional[FileState]:
+        """
+        读取远端单个文件，文件不存在时返回 None。
+
+        :param path: 仓库内 POSIX 路径
+        :return: 文件状态或 None
+        """
+        encoded_path = quote_path(path)
+        try:
+            data = self.request(
+                "GET",
+                f"/repos/{self.repo}/contents/{encoded_path}?ref={quote(self.branch)}",
+            )
+        except GitHubError as err:
+            if err.status == 404:
+                return None
+            raise
+        if not isinstance(data, dict) or data.get("type") != "file":
+            return None
+        raw_content = str(data.get("content") or "")
+        content = base64.b64decode(raw_content.encode("utf-8"), validate=False)
+        return FileState(path=path, content=content, sha=data.get("sha"))
+
+    def list_files(self, prefix: str) -> dict[str, FileState]:
+        """
+        递归列出远端路径下的全部文件。
+
+        :param prefix: 仓库内目录路径
+        :return: 以仓库路径为键的远端文件状态
+        """
+        normalized_prefix = normalize_remote_path(prefix)
+        if not normalized_prefix:
+            return {}
+        tree = self.get_tree()
+        files: dict[str, FileState] = {}
+        prefix_with_slash = f"{normalized_prefix}/"
+        for item in tree:
+            path = item.get("path")
+            if item.get("type") != "blob" or not isinstance(path, str):
+                continue
+            if path == normalized_prefix or path.startswith(prefix_with_slash):
+                files[path] = FileState(path=path, content=b"", sha=item.get("sha"))
+        for path in list(files):
+            file_state = self.get_file(path)
+            if file_state is not None:
+                files[path] = file_state
+        return files
+
+    def get_tree(self) -> list[dict[str, Any]]:
+        """
+        读取目标分支的递归 Git tree。
+
+        :return: Git tree 条目列表
+        """
+        branch_data = self.request(
+            "GET",
+            f"/repos/{self.repo}/branches/{quote(self.branch)}",
+        )
+        commit_sha = branch_data.get("commit", {}).get("sha")
+        if not commit_sha:
+            raise GitHubError(0, f"无法读取分支 {self.branch} 的提交 SHA")
+        tree_data = self.request(
+            "GET",
+            f"/repos/{self.repo}/git/trees/{commit_sha}?recursive=1",
+        )
+        tree = tree_data.get("tree") if isinstance(tree_data, dict) else None
+        if not isinstance(tree, list):
+            return []
+        return tree
+
+    def put_file(self, path: str, content: bytes, message: str, sha: Optional[str]) -> Any:
+        """
+        创建或更新远端文件。
+
+        :param path: 仓库内 POSIX 路径
+        :param content: 文件内容
+        :param message: 提交消息
+        :param sha: 远端现有文件 SHA，创建时为 None
+        :return: GitHub API 响应
+        """
+        payload: dict[str, Any] = {
+            "message": message,
+            "content": base64.b64encode(content).decode("ascii"),
+            "branch": self.branch,
+        }
+        if sha:
+            payload["sha"] = sha
+        return self.request(
+            "PUT",
+            f"/repos/{self.repo}/contents/{quote_path(path)}",
+            payload=payload,
+        )
+
+    def delete_file(self, path: str, message: str, sha: str) -> Any:
+        """
+        删除远端文件。
+
+        :param path: 仓库内 POSIX 路径
+        :param message: 提交消息
+        :param sha: 远端文件 SHA
+        :return: GitHub API 响应
+        """
+        payload = {
+            "message": message,
+            "sha": sha,
+            "branch": self.branch,
+        }
+        return self.request(
+            "DELETE",
+            f"/repos/{self.repo}/contents/{quote_path(path)}",
+            payload=payload,
+        )
+
+
+def normalize_repo(repo: str) -> str:
+    """
+    规范化 GitHub 仓库名称。
+
+    :param repo: owner/repo 或 GitHub URL
+    :return: owner/repo
+    """
+    value = repo.strip().removesuffix(".git")
+    if value.startswith("http://") or value.startswith("https://"):
+        parsed = urllib.parse.urlparse(value)
+        parts = [part for part in parsed.path.strip("/").split("/") if part]
+        if len(parts) >= 2:
+            value = f"{parts[0]}/{parts[1]}"
+    if not re.fullmatch(r"[^/\s]+/[^/\s]+", value):
+        raise ValueError("GitHub 仓库必须是 owner/repo 或 https://github.com/owner/repo")
+    return value
+
+
+def quote(value: str) -> str:
+    """
+    编码 URL 查询参数。
+
+    :param value: 待编码文本
+    :return: URL 编码结果
+    """
+    return urllib.parse.quote(value, safe="")
+
+
+def quote_path(path: str) -> str:
+    """
+    编码 GitHub Contents API 路径。
+
+    :param path: 仓库内 POSIX 路径
+    :return: URL 路径编码结果
+    """
+    return "/".join(urllib.parse.quote(part, safe="") for part in path.split("/"))
+
+
+def normalize_remote_path(path: str) -> str:
+    """
+    规范化远端仓库内路径。
+
+    :param path: 原始路径
+    :return: 去掉首尾斜杠后的 POSIX 路径
+    """
+    return str(PurePosixPath(path.strip("/"))) if path.strip("/") else ""
+
+
+def build_proxy_config(proxy: str = "") -> Optional[dict[str, str]]:
+    """
+    构建 RequestUtils 代理配置。
+
+    :param proxy: 代理地址
+    :return: requests 代理配置
+    """
+    if not proxy:
+        return None
+    return {"http": proxy, "https": proxy}
+
+
+def load_request_utils_class() -> type:
+    """
+    加载 MoviePilot RequestUtils，仓库外运行时返回兼容实现。
+
+    :return: RequestUtils 类
+    """
+    try:
+        root = Path(__file__).resolve().parents[3]
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+        from app.utils.http import RequestUtils  # pylint: disable=import-outside-toplevel
+
+        return RequestUtils
+    except Exception:
+        return FallbackRequestUtils
+
+
+class FallbackResponse:
+    """提供与 requests.Response 相近的最小响应接口。"""
+
+    def __init__(self, status_code: int, content: bytes):
+        """初始化响应内容。"""
+        self.status_code = status_code
+        self.content = content
+        self.text = content.decode("utf-8", errors="replace")
+
+    def close(self) -> None:
+        """关闭响应，兼容 requests.Response 接口。"""
+        return None
+
+
+class FallbackRequestUtils:
+    """仓库外运行时使用的最小 HTTP 客户端。"""
+
+    def __init__(
+        self,
+        headers: Optional[dict[str, str]] = None,
+        proxies: Optional[dict[str, str]] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> None:
+        """初始化请求配置。"""
+        self.headers = headers or {}
+        self.proxies = proxies or {}
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        data: Optional[bytes] = None,
+        raise_exception: bool = False,
+        **_: Any,
+    ) -> Optional[FallbackResponse]:
+        """
+        发送 HTTP 请求。
+
+        :param method: HTTP 方法
+        :param url: 请求地址
+        :param data: 请求体
+        :param raise_exception: 是否抛出请求异常
+        :return: 响应对象或 None
+        """
+        import urllib.request  # pylint: disable=import-outside-toplevel
+
+        handlers = []
+        if self.proxies:
+            handlers.append(urllib.request.ProxyHandler(self.proxies))
+        opener = urllib.request.build_opener(*handlers)
+        request = urllib.request.Request(
+            url,
+            data=data,
+            headers=self.headers,
+            method=method.upper(),
+        )
+        try:
+            with opener.open(request, timeout=self.timeout) as response:
+                return FallbackResponse(response.status, response.read())
+        except urllib.error.HTTPError as err:
+            content = err.read()
+            if raise_exception:
+                err.response = FallbackResponse(err.code, content)
+                raise
+            return FallbackResponse(err.code, content)
+        except urllib.error.URLError:
+            if raise_exception:
+                raise
+            return None
+
+
+def parse_github_error(raw: str) -> str:
+    """
+    从 GitHub 错误响应中提取可读消息。
+
+    :param raw: 原始响应体
+    :return: 错误消息
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if isinstance(data, dict):
+        return str(data.get("message") or raw)
+    return raw
+
+
+def resolve_token(repo: str, explicit_token: str = "") -> str:
+    """
+    解析 GitHub token，优先使用显式参数、仓库专属 token、环境变量与 MoviePilot settings。
+
+    :param repo: owner/repo
+    :param explicit_token: 命令行传入的 token
+    :return: token 字符串
+    """
+    if explicit_token:
+        return explicit_token
+    settings = load_moviepilot_settings()
+    repo_token = repo_token_from_settings(settings, repo)
+    if repo_token:
+        return repo_token
+    settings_token = str(getattr(settings, "GITHUB_TOKEN", "") or "").strip() if settings else ""
+    if settings_token:
+        return settings_token
+    for name in TOKEN_ENV_NAMES:
+        token = os.environ.get(name, "").strip()
+        if token:
+            return token
+    return ""
+
+
+def repo_token_from_settings(settings: Any, repo: str) -> str:
+    """
+    从 MoviePilot settings.REPO_GITHUB_TOKEN 中读取仓库专属 token。
+
+    :param settings: MoviePilot settings 对象
+    :param repo: owner/repo
+    :return: token 字符串
+    """
+    if not settings:
+        return ""
+    raw = str(getattr(settings, "REPO_GITHUB_TOKEN", "") or "")
+    repo_lower = repo.lower()
+    for item in raw.split(","):
+        repo_part, sep, token = item.partition(":")
+        if sep and repo_part.strip().lower() == repo_lower and token.strip():
+            return token.strip()
+    return ""
+
+
+def load_moviepilot_settings() -> Any:
+    """
+    尝试加载 MoviePilot settings，脚本脱离项目运行时返回 None。
+
+    :return: settings 对象或 None
+    """
+    try:
+        root = Path(__file__).resolve().parents[3]
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+        from app.core.config import settings  # pylint: disable=import-outside-toplevel
+
+        return settings
+    except Exception:
+        return None
+
+
+def resolve_proxy(explicit_proxy: str = "") -> str:
+    """
+    解析 GitHub 请求代理地址。
+
+    :param explicit_proxy: 命令行传入代理
+    :return: 代理地址
+    """
+    if explicit_proxy:
+        return explicit_proxy
+    settings = load_moviepilot_settings()
+    if settings:
+        proxy_host = str(getattr(settings, "PROXY_HOST", "") or "").strip()
+        if proxy_host:
+            return proxy_host
+    return ""
+
+
+def resolve_local_repo(local_repo: str, plugin_id: str, package_version: str) -> Path:
+    """
+    解析本地插件仓库目录。
+
+    :param local_repo: 显式本地仓库路径
+    :param plugin_id: 插件 ID
+    :param package_version: 插件布局版本
+    :return: 本地仓库目录
+    """
+    if local_repo:
+        return Path(local_repo).expanduser().resolve()
+    settings = load_moviepilot_settings()
+    raw_paths = str(getattr(settings, "PLUGIN_LOCAL_REPO_PATHS", "") or "") if settings else ""
+    layout = resolve_layout(package_version, Path.cwd(), plugin_id)
+    matches: list[Path] = []
+    for item in raw_paths.split(","):
+        if not item.strip():
+            continue
+        path = Path(item.strip()).expanduser()
+        if not path.is_absolute() and settings:
+            path = Path(getattr(settings, "ROOT_PATH")) / path
+        path = path.resolve()
+        if plugin_dir(path, layout, plugin_id).exists():
+            matches.append(path)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        joined = ", ".join(str(path) for path in matches)
+        raise ValueError(f"多个本地插件仓库包含 {plugin_id}：{joined}，请使用 --local-repo 指定")
+    raise ValueError("未找到本地插件仓库，请使用 --local-repo 指定")
+
+
+def resolve_layout(package_version: str, local_repo: Path, plugin_id: str) -> Layout:
+    """
+    根据参数和本地文件推断插件仓库布局。
+
+    :param package_version: v2、legacy 或 auto
+    :param local_repo: 本地仓库目录
+    :param plugin_id: 插件 ID
+    :return: 布局描述
+    """
+    normalized = package_version.strip().lower()
+    if normalized in PACKAGE_BY_VERSION:
+        package_file, plugin_root = PACKAGE_BY_VERSION[normalized]
+        return Layout(package_file=package_file, plugin_root=plugin_root)
+    v2_dir = local_repo / "plugins.v2" / plugin_id.lower()
+    legacy_dir = local_repo / "plugins" / plugin_id.lower()
+    if (local_repo / "package.v2.json").exists() or v2_dir.exists():
+        return Layout(package_file="package.v2.json", plugin_root="plugins.v2")
+    if (local_repo / "package.json").exists() or legacy_dir.exists():
+        return Layout(package_file="package.json", plugin_root="plugins")
+    return Layout(package_file="package.v2.json", plugin_root="plugins.v2")
+
+
+def plugin_dir(local_repo: Path, layout: Layout, plugin_id: str) -> Path:
+    """
+    返回插件本地目录。
+
+    :param local_repo: 本地仓库目录
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :return: 插件目录
+    """
+    return local_repo / layout.plugin_root / plugin_id.lower()
+
+
+def remote_plugin_prefix(layout: Layout, plugin_id: str) -> str:
+    """
+    返回远端插件目录前缀。
+
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :return: 远端目录路径
+    """
+    return f"{layout.plugin_root}/{plugin_id.lower()}"
+
+
+def read_package_entry(local_repo: Path, layout: Layout, plugin_id: str) -> dict[str, Any]:
+    """
+    读取本地 package 中当前插件的元数据条目。
+
+    :param local_repo: 本地仓库目录
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :return: package 条目
+    """
+    package_path = local_repo / layout.package_file
+    if not package_path.exists():
+        raise FileNotFoundError(f"本地 package 文件不存在：{package_path}")
+    package_data = json.loads(package_path.read_text(encoding="utf-8"))
+    if not isinstance(package_data, dict):
+        raise ValueError(f"本地 package 文件不是 JSON 对象：{package_path}")
+    entry = package_data.get(plugin_id)
+    if not isinstance(entry, dict):
+        raise ValueError(f"{layout.package_file} 中未找到插件条目：{plugin_id}")
+    return entry
+
+
+def merge_package_content(
+    remote_content: Optional[bytes],
+    plugin_id: str,
+    entry: dict[str, Any],
+) -> bytes:
+    """
+    合并远端 package 内容，只更新当前插件条目。
+
+    :param remote_content: 远端 package 原始内容
+    :param plugin_id: 插件 ID
+    :param entry: 当前插件 package 条目
+    :return: 合并后的 package JSON 字节
+    """
+    if remote_content:
+        try:
+            package_data = json.loads(remote_content.decode("utf-8"))
+        except json.JSONDecodeError as err:
+            raise ValueError("远端 package 文件不是有效 JSON，拒绝覆盖") from err
+        if not isinstance(package_data, dict):
+            raise ValueError("远端 package 文件不是 JSON 对象，拒绝覆盖")
+    else:
+        package_data = {}
+    package_data[plugin_id] = entry
+    text = json.dumps(package_data, indent=2, ensure_ascii=False)
+    return f"{text}\n".encode("utf-8")
+
+
+def should_exclude(path: str, patterns: list[str], includes: list[str]) -> Optional[str]:
+    """
+    判断仓库相对路径是否应被排除。
+
+    :param path: POSIX 相对路径
+    :param patterns: 排除模式
+    :param includes: 强制包含模式
+    :return: 命中的排除模式，未排除时为 None
+    """
+    normalized = path.strip("/")
+    for pattern in includes:
+        if match_pattern(normalized, pattern):
+            return None
+    for pattern in patterns:
+        if match_pattern(normalized, pattern):
+            return pattern
+    return None
+
+
+def match_pattern(path: str, pattern: str) -> bool:
+    """
+    匹配路径忽略模式。
+
+    :param path: POSIX 相对路径
+    :param pattern: glob 模式
+    :return: 是否命中
+    """
+    normalized = path.strip("/")
+    raw = pattern.strip()
+    if not raw:
+        return False
+    if raw.endswith("/"):
+        prefix = raw.strip("/")
+        return normalized == prefix or normalized.startswith(f"{prefix}/")
+    if "/" not in raw:
+        return any(fnmatch.fnmatch(part, raw) for part in normalized.split("/"))
+    return fnmatch.fnmatch(normalized, raw.strip("/"))
+
+
+def collect_local_files(
+    local_repo: Path,
+    layout: Layout,
+    plugin_id: str,
+    excludes: list[str],
+    includes: list[str],
+    allow_missing: bool = False,
+) -> tuple[dict[str, FileState], dict[str, str]]:
+    """
+    收集准备发布的本地插件文件。
+
+    :param local_repo: 本地仓库目录
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :param excludes: 排除模式
+    :param includes: 强制包含模式
+    :param allow_missing: 插件目录不存在时是否返回空集合
+    :return: 文件状态和被拒绝路径
+    """
+    source_dir = plugin_dir(local_repo, layout, plugin_id)
+    if not source_dir.exists() or not source_dir.is_dir():
+        if allow_missing:
+            return {}, {}
+        raise FileNotFoundError(f"插件目录不存在：{source_dir}")
+
+    files: dict[str, FileState] = {}
+    rejected: dict[str, str] = {}
+    prefix = remote_plugin_prefix(layout, plugin_id)
+    for file_path in sorted(source_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        relative = file_path.relative_to(source_dir).as_posix()
+        reason = should_exclude(relative, excludes, includes)
+        if reason:
+            rejected[f"{prefix}/{relative}"] = reason
+            continue
+        remote_path = f"{prefix}/{relative}"
+        files[remote_path] = FileState(
+            path=remote_path,
+            content=file_path.read_bytes(),
+        )
+    return files, rejected
+
+
+def build_push_changes(
+    local_files: dict[str, FileState],
+    remote_files: dict[str, FileState],
+    rejected: dict[str, str],
+    delete_remote: bool,
+) -> ChangeSet:
+    """
+    生成推送方向的差异。
+
+    :param local_files: 本地文件
+    :param remote_files: 远端文件
+    :param rejected: 被安全规则拒绝的文件
+    :param delete_remote: 是否删除远端多余文件
+    :return: 差异集合
+    """
+    changes = ChangeSet(rejected=rejected)
+    for path, local_state in local_files.items():
+        remote_state = remote_files.get(path)
+        if remote_state is None:
+            changes.create.append(path)
+        elif local_state.sha256 != remote_state.sha256:
+            changes.update.append(path)
+        else:
+            changes.same.append(path)
+    if delete_remote:
+        for path in remote_files:
+            if path not in local_files:
+                changes.delete.append(path)
+    return changes
+
+
+def build_pull_changes(
+    local_files: dict[str, FileState],
+    remote_files: dict[str, FileState],
+    rejected: dict[str, str],
+    force: bool,
+) -> ChangeSet:
+    """
+    生成拉取方向的差异。
+
+    :param local_files: 本地文件
+    :param remote_files: 远端文件
+    :param rejected: 被安全规则保护的本地文件
+    :param force: 是否允许覆盖冲突
+    :return: 差异集合
+    """
+    changes = ChangeSet(rejected=rejected)
+    for path, remote_state in remote_files.items():
+        local_state = local_files.get(path)
+        if local_state is None:
+            changes.create.append(path)
+        elif local_state.sha256 == remote_state.sha256:
+            changes.same.append(path)
+        elif force:
+            changes.update.append(path)
+        else:
+            changes.conflicts.append(path)
+    return changes
+
+
+def compare_package(
+    client: GitHubClient,
+    layout: Layout,
+    plugin_id: str,
+    entry: dict[str, Any],
+) -> tuple[Optional[FileState], bytes, str]:
+    """
+    比较 package 文件并返回远端状态、合并内容与差异类型。
+
+    :param client: GitHub 客户端
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :param entry: 本地 package 条目
+    :return: 远端状态、合并内容、差异类型
+    """
+    remote_package = client.get_file(layout.package_file)
+    merged_content = merge_package_content(
+        remote_package.content if remote_package else None,
+        plugin_id,
+        entry,
+    )
+    if remote_package is None:
+        change_type = "create"
+    elif hashlib.sha256(merged_content).hexdigest() != remote_package.sha256:
+        change_type = "update"
+    else:
+        change_type = "same"
+    return remote_package, merged_content, change_type
+
+
+def preview(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    预览本地插件与远端仓库的差异。
+
+    :param args: 命令行参数
+    :return: 预览结果
+    """
+    context = build_context(args)
+    local_files, rejected = collect_local_files(
+        context["local_repo"],
+        context["layout"],
+        context["plugin_id"],
+        context["excludes"],
+        context["includes"],
+        allow_missing=True,
+    )
+    remote_files = context["client"].list_files(context["remote_prefix"])
+    entry = read_package_entry(context["local_repo"], context["layout"], context["plugin_id"])
+    _, _, package_change = compare_package(
+        context["client"],
+        context["layout"],
+        context["plugin_id"],
+        entry,
+    )
+    changes = build_push_changes(local_files, remote_files, rejected, args.delete_remote)
+    return result_payload(context, changes, package_change=package_change)
+
+
+def push(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    推送本地插件变更到 GitHub。
+
+    :param args: 命令行参数
+    :return: 推送结果
+    """
+    context = build_context(args, require_token=not args.dry_run)
+    client: GitHubClient = context["client"]
+    local_files, rejected = collect_local_files(
+        context["local_repo"],
+        context["layout"],
+        context["plugin_id"],
+        context["excludes"],
+        context["includes"],
+    )
+    remote_files = client.list_files(context["remote_prefix"])
+    entry = read_package_entry(context["local_repo"], context["layout"], context["plugin_id"])
+    remote_package, package_content, package_change = compare_package(
+        client,
+        context["layout"],
+        context["plugin_id"],
+        entry,
+    )
+    changes = build_push_changes(local_files, remote_files, rejected, args.delete_remote)
+    payload = result_payload(context, changes, package_change=package_change)
+    if args.dry_run:
+        payload["dry_run"] = True
+        return payload
+
+    message = args.message or f"Publish {context['plugin_id']}"
+    applied: dict[str, list[str]] = {"create": [], "update": [], "delete": []}
+    if package_change in {"create", "update"}:
+        client.put_file(
+            context["layout"].package_file,
+            package_content,
+            message,
+            remote_package.sha if remote_package else None,
+        )
+        applied[package_change].append(context["layout"].package_file)
+    for path in changes.create:
+        client.put_file(path, local_files[path].content, message, None)
+        applied["create"].append(path)
+    for path in changes.update:
+        client.put_file(path, local_files[path].content, message, remote_files[path].sha)
+        applied["update"].append(path)
+    for path in changes.delete:
+        remote_sha = remote_files[path].sha
+        if remote_sha:
+            client.delete_file(path, message, remote_sha)
+            applied["delete"].append(path)
+    payload["applied"] = applied
+    payload["message"] = "插件已推送到 GitHub 仓库。"
+    return payload
+
+
+def pull(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    从 GitHub 拉取插件文件到本地仓库。
+
+    :param args: 命令行参数
+    :return: 拉取结果
+    """
+    context = build_context(args)
+    client: GitHubClient = context["client"]
+    local_files, rejected = collect_local_files(
+        context["local_repo"],
+        context["layout"],
+        context["plugin_id"],
+        context["excludes"],
+        context["includes"],
+    )
+    remote_files = client.list_files(context["remote_prefix"])
+    changes = build_pull_changes(local_files, remote_files, rejected, args.force)
+    package_file = client.get_file(context["layout"].package_file)
+    package_change = "missing"
+    package_entry = None
+    if package_file:
+        package_data = json.loads(package_file.content.decode("utf-8"))
+        if isinstance(package_data, dict):
+            package_entry = package_data.get(context["plugin_id"])
+            local_entry = None
+            try:
+                local_entry = read_package_entry(
+                    context["local_repo"],
+                    context["layout"],
+                    context["plugin_id"],
+                )
+            except (FileNotFoundError, ValueError, json.JSONDecodeError):
+                local_entry = None
+            package_change = "same" if package_entry == local_entry else "update"
+    payload = result_payload(context, changes, package_change=package_change)
+    if changes.conflicts and not args.force:
+        payload["message"] = "本地存在未发布改动，已拒绝覆盖。确认后可使用 --force。"
+        return payload
+    if args.dry_run:
+        payload["dry_run"] = True
+        return payload
+
+    target_dir = plugin_dir(context["local_repo"], context["layout"], context["plugin_id"])
+    for path in changes.create + changes.update:
+        relative = PurePosixPath(path).relative_to(context["remote_prefix"]).as_posix()
+        target = target_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(remote_files[path].content)
+    if package_entry is not None:
+        write_local_package_entry(
+            context["local_repo"],
+            context["layout"],
+            context["plugin_id"],
+            package_entry,
+        )
+    payload["message"] = "远端插件已同步到本地仓库。"
+    return payload
+
+
+def write_local_package_entry(
+    local_repo: Path,
+    layout: Layout,
+    plugin_id: str,
+    entry: dict[str, Any],
+) -> None:
+    """
+    写入本地 package 中的插件条目。
+
+    :param local_repo: 本地仓库目录
+    :param layout: 仓库布局
+    :param plugin_id: 插件 ID
+    :param entry: 插件 package 条目
+    """
+    package_path = local_repo / layout.package_file
+    if package_path.exists():
+        package_data = json.loads(package_path.read_text(encoding="utf-8"))
+        if not isinstance(package_data, dict):
+            raise ValueError(f"本地 package 文件不是 JSON 对象：{package_path}")
+    else:
+        package_data = {}
+        package_path.parent.mkdir(parents=True, exist_ok=True)
+    package_data[plugin_id] = entry
+    package_path.write_text(
+        f"{json.dumps(package_data, indent=2, ensure_ascii=False)}\n",
+        encoding="utf-8",
+    )
+
+
+def result_payload(
+    context: dict[str, Any],
+    changes: ChangeSet,
+    package_change: str,
+) -> dict[str, Any]:
+    """
+    生成统一 JSON 输出。
+
+    :param context: 运行上下文
+    :param changes: 文件差异
+    :param package_change: package 文件差异类型
+    :return: 结果对象
+    """
+    return {
+        "repo": context["repo"],
+        "branch": context["branch"],
+        "plugin_id": context["plugin_id"],
+        "local_repo": str(context["local_repo"]),
+        "layout": context["layout"].version,
+        "package_file": context["layout"].package_file,
+        "plugin_prefix": context["remote_prefix"],
+        "package_change": package_change,
+        "changes": changes.to_dict(),
+    }
+
+
+def build_context(args: argparse.Namespace, require_token: bool = False) -> dict[str, Any]:
+    """
+    根据命令行参数构建运行上下文。
+
+    :param args: 命令行参数
+    :param require_token: 是否要求可写 token
+    :return: 运行上下文
+    """
+    repo = normalize_repo(args.repo)
+    local_repo = resolve_local_repo(args.local_repo, args.plugin_id, args.package_version)
+    layout = resolve_layout(args.package_version, local_repo, args.plugin_id)
+    token = resolve_token(repo, args.token)
+    if require_token and not token:
+        raise ValueError("未配置 GitHub token，无法写入仓库")
+    branch = args.branch or DEFAULT_BRANCH
+    client = GitHubClient(
+        repo=repo,
+        token=token,
+        branch=branch,
+        api_base=args.api_base,
+        timeout=args.timeout,
+        proxy=resolve_proxy(args.proxy),
+    )
+    excludes = list(DEFAULT_EXCLUDES) + list(args.exclude or [])
+    includes = list(args.include or [])
+    return {
+        "repo": repo,
+        "branch": branch,
+        "local_repo": local_repo,
+        "layout": layout,
+        "plugin_id": args.plugin_id,
+        "remote_prefix": remote_plugin_prefix(layout, args.plugin_id),
+        "client": client,
+        "excludes": excludes,
+        "includes": includes,
+    }
+
+
+def print_json(payload: dict[str, Any]) -> None:
+    """
+    打印 JSON 输出。
+
+    :param payload: 输出对象
+    """
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """
+    构造命令行参数解析器。
+
+    :return: argparse 解析器
+    """
+    parser = argparse.ArgumentParser(
+        description="发布和同步 MoviePilot 本地插件到 GitHub 仓库",
+    )
+    parser.add_argument("command", choices=("preview", "push", "pull"))
+    parser.add_argument("--repo", required=True, help="GitHub 仓库，格式 owner/repo")
+    parser.add_argument("--plugin-id", required=True, help="插件类名 ID")
+    parser.add_argument("--local-repo", default="", help="本地插件仓库目录")
+    parser.add_argument("--package-version", default="auto", help="auto、v2 或 legacy")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH, help="目标分支")
+    parser.add_argument("--token", default="", help="GitHub token，默认读取配置或环境变量")
+    parser.add_argument("--message", default="", help="提交消息")
+    parser.add_argument("--api-base", default=GITHUB_API_BASE, help="GitHub API 地址")
+    parser.add_argument("--proxy", default="", help="HTTP/HTTPS 代理")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="请求超时时间")
+    parser.add_argument("--include", action="append", default=[], help="强制包含 glob")
+    parser.add_argument("--exclude", action="append", default=[], help="额外排除 glob")
+    parser.add_argument("--delete-remote", action="store_true", help="推送时删除远端多余文件")
+    parser.add_argument("--force", action="store_true", help="拉取时允许覆盖本地冲突")
+    parser.add_argument("--dry-run", action="store_true", help="只输出计划，不写入")
+    return parser
+
+
+def main() -> int:
+    """
+    执行命令行入口。
+
+    :return: 进程退出码
+    """
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "preview":
+            payload = preview(args)
+        elif args.command == "push":
+            payload = push(args)
+        else:
+            payload = pull(args)
+    except (GitHubError, OSError, ValueError, json.JSONDecodeError) as err:
+        print_json({"success": False, "message": str(err)})
+        return 1
+    payload["success"] = not payload.get("changes", {}).get("conflicts")
+    print_json(payload)
+    return 0 if payload["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_activity_log.py
+++ b/tests/test_agent_activity_log.py
@@ -1,0 +1,286 @@
+import asyncio
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.agent.middleware.activity_log import (
+    ActivityLogMiddleware,
+    _summarize_with_llm,
+    load_activity_log_index,
+    query_activity_logs,
+)
+from app.agent.tools.factory import MoviePilotToolFactory
+from app.agent.tools.impl.query_activity_log import QueryActivityLogTool
+from app.agent.tools.manager import MoviePilotToolsManager
+
+
+def _write_activity_log(activity_dir, date_str: str, lines: list[str]) -> None:
+    """写入测试用活动日志。"""
+    activity_dir.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(lines)
+    (activity_dir / f"{date_str}.md").write_text(
+        f"# {date_str} 活动日志\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_activity_log_index_counts_entries_without_body(tmp_path):
+    """活动日志索引只应包含条目数量，不暴露完整摘要正文。"""
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    _write_activity_log(
+        tmp_path,
+        date_str,
+        [
+            "- **10:00** 帮用户整理了电影文件",
+            "- **11:00** 查询了下载任务状态",
+        ],
+    )
+
+    index = load_activity_log_index(str(tmp_path), days=1)
+
+    assert index == {date_str: "2 条活动记录"}
+    assert "整理了电影文件" not in json.dumps(index, ensure_ascii=False)
+
+
+def test_activity_log_prompt_injects_index_not_full_log(tmp_path):
+    """ActivityLogMiddleware 注入系统提示词时不应携带完整活动日志正文。"""
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    _write_activity_log(
+        tmp_path,
+        date_str,
+        ["- **10:00** 这是一条不应默认进入上下文的活动正文"],
+    )
+    middleware = ActivityLogMiddleware(activity_dir=str(tmp_path), prompt_load_days=1)
+    state_update = asyncio.run(middleware.abefore_agent({}, runtime=None))
+    request = SimpleNamespace(
+        state=state_update,
+        system_message=SystemMessage(content="SYSTEM"),
+        override=lambda **kwargs: SimpleNamespace(
+            state=state_update,
+            system_message=kwargs.get("system_message", SystemMessage(content="SYSTEM")),
+        ),
+    )
+
+    modified = middleware.modify_request(request)
+    system_text = str(modified.system_message.content)
+
+    assert "1 条活动记录" in system_text
+    assert "这是一条不应默认进入上下文的活动正文" not in system_text
+    assert "query_activity_log" in system_text
+
+
+def test_activity_log_skips_trivial_greeting_without_llm(tmp_path):
+    """无实际任务的寒暄不应调用 LLM，也不应写入活动日志。"""
+    middleware = ActivityLogMiddleware(activity_dir=str(tmp_path))
+    summarize_mock = AsyncMock(return_value="不应写入")
+    append_mock = AsyncMock()
+
+    with (
+        patch(
+            "app.agent.middleware.activity_log._summarize_with_llm",
+            new=summarize_mock,
+        ),
+        patch.object(middleware, "_append_activity", new=append_mock),
+    ):
+        asyncio.run(
+            middleware.aafter_agent(
+                {
+                    "messages": [
+                        HumanMessage(content="你好"),
+                        AIMessage(content="你好，有什么可以帮你？"),
+                    ],
+                },
+                runtime=None,
+            )
+        )
+
+    summarize_mock.assert_not_awaited()
+    append_mock.assert_not_awaited()
+    assert not list(tmp_path.glob("*.md"))
+
+
+def test_summarize_with_llm_ignores_skip_marker():
+    """LLM 返回 SKIP 时应视为无需记录活动日志。"""
+    llm = SimpleNamespace(
+        ainvoke=AsyncMock(return_value=SimpleNamespace(content="SKIP"))
+    )
+
+    with patch(
+        "app.agent.llm.LLMHelper.get_llm",
+        new=AsyncMock(return_value=llm),
+    ):
+        summary = asyncio.run(_summarize_with_llm("用户: 你好"))
+
+    assert summary is None
+    llm.ainvoke.assert_awaited_once()
+
+
+def test_activity_log_records_detailed_summary(tmp_path):
+    """有实际工具动作的交互应写入较完整的活动摘要。"""
+    middleware = ActivityLogMiddleware(activity_dir=str(tmp_path))
+    summary = (
+        "用户要求整理 `/downloads/Show`，助手调用 transfer_file 识别并转移剧集，"
+        "结果成功写入目标媒体库。"
+    )
+
+    with patch(
+        "app.agent.middleware.activity_log._summarize_with_llm",
+        new=AsyncMock(return_value=summary),
+    ):
+        asyncio.run(
+            middleware.aafter_agent(
+                {
+                    "messages": [
+                        HumanMessage(content="帮我整理 /downloads/Show"),
+                        AIMessage(
+                            content="",
+                            tool_calls=[
+                                {
+                                    "name": "transfer_file",
+                                    "args": {"path": "/downloads/Show"},
+                                    "id": "call_1",
+                                }
+                            ],
+                        ),
+                        ToolMessage(
+                            content='{"success": true, "target": "/media/Show"}',
+                            tool_call_id="call_1",
+                        ),
+                    ],
+                },
+                runtime=None,
+            )
+        )
+
+    log_files = list(tmp_path.glob("*.md"))
+    assert len(log_files) == 1
+    content = log_files[0].read_text(encoding="utf-8")
+    assert summary in content
+    assert "- **" in content
+
+
+def test_query_activity_logs_filters_by_keyword_and_date(tmp_path):
+    """活动日志查询应支持日期和关键词过滤。"""
+    _write_activity_log(
+        tmp_path,
+        "2026-06-18",
+        [
+            "- **10:00** 帮用户整理了电影 A",
+            "- **10:30** 查询了站点状态",
+        ],
+    )
+    _write_activity_log(
+        tmp_path,
+        "2026-06-17",
+        ["- **09:00** 帮用户整理了电影 B"],
+    )
+
+    payload = query_activity_logs(
+        str(tmp_path),
+        keyword="整理",
+        date="2026-06-18",
+        limit=10,
+    )
+
+    assert payload["success"] is True
+    assert payload["total_count"] == 1
+    assert payload["entries"][0]["date"] == "2026-06-18"
+    assert payload["entries"][0]["time"] == "10:00"
+    assert payload["entries"][0]["summary"] == "帮用户整理了电影 A"
+
+
+def test_query_activity_logs_supports_optional_regex(tmp_path):
+    """活动日志查询应在显式开启时支持正则匹配。"""
+    _write_activity_log(
+        tmp_path,
+        "2026-06-18",
+        [
+            "- **10:00** 帮用户整理了剧集 A",
+            "- **10:30** 查询了站点状态",
+        ],
+    )
+
+    payload = query_activity_logs(
+        str(tmp_path),
+        keyword="整理|站点",
+        use_regex=True,
+        date="2026-06-18",
+        limit=10,
+    )
+
+    assert payload["success"] is True
+    assert payload["use_regex"] is True
+    assert payload["total_count"] == 2
+
+
+def test_query_activity_logs_reports_invalid_regex(tmp_path):
+    """活动日志查询遇到无效正则时应返回结构化错误。"""
+    payload = query_activity_logs(
+        str(tmp_path),
+        keyword="[",
+        use_regex=True,
+        date="2026-06-18",
+    )
+
+    assert payload["success"] is False
+    assert "无效的活动日志正则表达式" in payload["message"]
+    assert payload["entries"] == []
+
+
+def test_query_activity_log_tool_returns_json_payload(tmp_path):
+    """query_activity_log 工具应返回结构化 JSON 查询结果。"""
+    _write_activity_log(
+        tmp_path,
+        "2026-06-18",
+        ["- **10:00** 帮用户整理了电影 A"],
+    )
+    tool = QueryActivityLogTool(session_id="activity-session", user_id="10001")
+
+    with patch(
+        "app.agent.tools.impl.query_activity_log.agent_runtime_manager.activity_dir",
+        tmp_path,
+    ):
+        result = asyncio.run(
+            tool.run(keyword="整理", date="2026-06-18", limit=5)
+        )
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["returned_count"] == 1
+    assert payload["entries"][0]["summary"] == "帮用户整理了电影 A"
+
+
+def test_factory_registers_activity_log_tool():
+    """工具工厂应注册活动日志查询工具。"""
+    with patch(
+        "app.agent.tools.factory.PluginManager.get_plugin_agent_tools",
+        return_value=[],
+    ):
+        tools = MoviePilotToolFactory.create_tools(
+            session_id="activity-session",
+            user_id="10001",
+        )
+
+    tool_names = {tool.name for tool in tools}
+    assert "query_activity_log" in tool_names
+
+
+def test_mcp_tool_manager_exposes_activity_log_tool():
+    """MCP 工具管理器应暴露活动日志查询工具。"""
+    tool = QueryActivityLogTool(session_id="activity-session", user_id="10001")
+
+    with patch(
+        "app.agent.tools.manager.MoviePilotToolFactory.create_tools",
+        return_value=[tool],
+    ):
+        manager = MoviePilotToolsManager(is_admin=True)
+
+    tool_definitions = manager.list_tools()
+    assert [item.name for item in tool_definitions] == ["query_activity_log"]
+    schema = tool_definitions[0].input_schema
+    assert "keyword" in schema["properties"]
+    assert "use_regex" in schema["properties"]
+    assert "date" in schema["properties"]

--- a/tests/test_agent_background_output.py
+++ b/tests/test_agent_background_output.py
@@ -81,7 +81,7 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             await agent._execute_agent([])
 
         agent.send_agent_message.assert_not_awaited()
-        save_messages.assert_called_once()
+        save_messages.assert_not_called()
         self.assertEqual("后台结果", agent._streamed_output)
 
     async def test_non_streaming_image_unsupported_error_sends_friendly_notice(self):
@@ -213,7 +213,7 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         agent.send_agent_message.assert_awaited_once_with(
             "后台结果", title="MoviePilot助手"
         )
-        save_messages.assert_called_once()
+        save_messages.assert_not_called()
         self.assertEqual("后台结果", agent._streamed_output)
 
     async def test_background_non_streaming_captures_without_sending_when_capture_only(self):
@@ -236,7 +236,7 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             await agent._execute_agent([])
 
         agent.send_agent_message.assert_not_awaited()
-        save_messages.assert_called_once()
+        save_messages.assert_not_called()
         self.assertEqual("后台结果", agent._streamed_output)
 
     async def test_heartbeat_check_jobs_captures_final_reply_and_keeps_message_tools(self):

--- a/tests/test_agent_background_output.py
+++ b/tests/test_agent_background_output.py
@@ -66,7 +66,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         agent.channel = None
         agent.source = None
         agent.reply_mode = ReplyMode.CAPTURE_ONLY
-        agent.persist_output_message = True
         agent._tool_context = {"user_reply_sent": False}
         agent._streamed_output = ""
         agent.stream_handler = SimpleNamespace(
@@ -77,15 +76,11 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             return_value=_FakeAgent([AIMessage(content="后台结果")])
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         with patch.object(memory_manager, "save_agent_messages") as save_messages:
             await agent._execute_agent([])
 
         agent.send_agent_message.assert_not_awaited()
-        agent._save_agent_message_to_db.assert_awaited_once_with(
-            "后台结果", title="MoviePilot助手"
-        )
         save_messages.assert_called_once()
         self.assertEqual("后台结果", agent._streamed_output)
 
@@ -105,7 +100,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             )
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         result, _ = await agent._execute_agent(
             [
@@ -122,7 +116,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         agent.send_agent_message.assert_awaited_once_with(
             UNSUPPORTED_IMAGE_INPUT_MESSAGE, title=""
         )
-        agent._save_agent_message_to_db.assert_not_awaited()
         self.assertEqual(UNSUPPORTED_IMAGE_INPUT_MESSAGE, agent._streamed_output)
 
     async def test_streaming_image_unsupported_error_sends_friendly_notice(self):
@@ -144,7 +137,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             )
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         result, _ = await agent._execute_agent(
             [
@@ -161,7 +153,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         agent.send_agent_message.assert_awaited_once_with(
             UNSUPPORTED_IMAGE_INPUT_MESSAGE, title=""
         )
-        agent._save_agent_message_to_db.assert_not_awaited()
 
     async def test_streaming_model_chunk_timeout_sends_friendly_notice(self):
         """流式模型分块超时时应只把主错误信息发给用户。"""
@@ -186,7 +177,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             return_value=_FakeStreamingFailingAgent(raw_error)
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         result, _ = await agent._execute_agent([HumanMessage(content="测试超时")])
 
@@ -200,14 +190,12 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("No streaming chunk received for 120.0s", sent_message)
         self.assertNotIn("Tune or disable", sent_message)
         self.assertEqual(expected, agent._streamed_output)
-        agent._save_agent_message_to_db.assert_not_awaited()
 
     async def test_background_non_streaming_sends_when_reply_mode_dispatch(self):
         agent = MoviePilotAgent(session_id="bg-test", user_id="system")
         agent.channel = None
         agent.source = None
         agent.reply_mode = ReplyMode.DISPATCH
-        agent.persist_output_message = False
         agent._tool_context = {"user_reply_sent": False}
         agent._streamed_output = ""
         agent.stream_handler = SimpleNamespace(
@@ -218,7 +206,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             return_value=_FakeAgent([AIMessage(content="后台结果")])
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         with patch.object(memory_manager, "save_agent_messages") as save_messages:
             await agent._execute_agent([])
@@ -226,16 +213,14 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         agent.send_agent_message.assert_awaited_once_with(
             "后台结果", title="MoviePilot助手"
         )
-        agent._save_agent_message_to_db.assert_not_awaited()
         save_messages.assert_called_once()
         self.assertEqual("后台结果", agent._streamed_output)
 
-    async def test_background_non_streaming_persists_without_sending_when_capture_only(self):
+    async def test_background_non_streaming_captures_without_sending_when_capture_only(self):
         agent = MoviePilotAgent(session_id="bg-test", user_id="system")
         agent.channel = None
         agent.source = None
         agent.reply_mode = ReplyMode.CAPTURE_ONLY
-        agent.persist_output_message = True
         agent._tool_context = {"user_reply_sent": False}
         agent._streamed_output = ""
         agent.stream_handler = SimpleNamespace(
@@ -246,15 +231,11 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             return_value=_FakeAgent([AIMessage(content="后台结果")])
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         with patch.object(memory_manager, "save_agent_messages") as save_messages:
             await agent._execute_agent([])
 
         agent.send_agent_message.assert_not_awaited()
-        agent._save_agent_message_to_db.assert_awaited_once_with(
-            "后台结果", title="MoviePilot助手"
-        )
         save_messages.assert_called_once()
         self.assertEqual("后台结果", agent._streamed_output)
 
@@ -279,7 +260,6 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         process_message.assert_awaited_once()
         kwargs = process_message.await_args.kwargs
         self.assertEqual(ReplyMode.CAPTURE_ONLY, kwargs["reply_mode"])
-        self.assertFalse(kwargs["persist_output_message"])
         self.assertTrue(kwargs["allow_message_tools"])
 
     async def test_heartbeat_check_jobs_skips_when_no_active_jobs(self):

--- a/tests/test_agent_background_output.py
+++ b/tests/test_agent_background_output.py
@@ -330,14 +330,62 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
             created["middleware"],
         )
 
-    def test_send_message_tool_is_always_included_by_tool_selector(self):
+    async def test_create_agent_excludes_activity_log_without_message_context(self):
+        """无渠道信息的后台捕获任务不应注入活动日志。"""
+        agent = MoviePilotAgent(
+            session_id="background-capture-session",
+            user_id="system",
+            output_callback=lambda _text: None,
+        )
+        agent._initialize_tools = lambda: []
+        agent._initialize_subagent_tools = lambda: []
+
+        with (
+            patch.object(settings, "LLM_MAX_TOOLS", 0),
+            patch.object(agent, "_initialize_llm", new=AsyncMock(return_value=object())),
+            patch("app.agent.prompt_manager.get_agent_prompt", return_value="PROMPT"),
+            patch("app.agent.create_subagent_middlewares", return_value=([], [])),
+            patch(
+                "app.agent.MoviePilotToolFactory.get_tool_selector_always_include_names",
+                return_value=[],
+            ),
+            patch("app.agent.SkillsMiddleware", side_effect=lambda *args, **kwargs: "skills"),
+            patch("app.agent.JobsMiddleware", side_effect=lambda *args, **kwargs: "jobs"),
+            patch("app.agent.RuntimeConfigMiddleware", side_effect=lambda *args, **kwargs: "runtime"),
+            patch("app.agent.MemoryMiddleware", side_effect=lambda *args, **kwargs: "memory"),
+            patch("app.agent.ActivityLogMiddleware", side_effect=lambda *args, **kwargs: "activity"),
+            patch("app.agent.SummarizationMiddleware", side_effect=lambda *args, **kwargs: "summary"),
+            patch("app.agent.PatchToolCallsMiddleware", side_effect=lambda *args, **kwargs: "patch"),
+            patch("app.agent.UsageMiddleware", side_effect=lambda *args, **kwargs: "usage"),
+            patch("app.agent.InMemorySaver", return_value="checkpointer"),
+            patch("app.agent.create_agent", side_effect=lambda **kwargs: kwargs),
+        ):
+            created = await agent._create_agent(streaming=False)
+
+        self.assertEqual(
+            ["skills", "jobs", "runtime", "memory", "summary", "patch", "usage"],
+            created["middleware"],
+        )
+
+    def test_message_tool_is_not_always_included_by_tool_selector(self):
+        """消息发送工具不应绕过工具筛选。"""
         send_message_tool = SimpleNamespace(name="send_message")
 
         always_include = MoviePilotToolFactory.get_tool_selector_always_include_names(
             [send_message_tool]
         )
 
-        self.assertIn("send_message", always_include)
+        self.assertNotIn("send_message", always_include)
+
+    def test_activity_log_tool_is_always_included_by_tool_selector(self):
+        """活动日志查询工具应绕过工具筛选。"""
+        activity_log_tool = SimpleNamespace(name="query_activity_log")
+
+        always_include = MoviePilotToolFactory.get_tool_selector_always_include_names(
+            [activity_log_tool]
+        )
+
+        self.assertIn("query_activity_log", always_include)
 
     async def test_create_agent_always_includes_subagent_tools(self):
         """工具筛选开启时应保留同步和异步子代理入口。"""
@@ -386,7 +434,12 @@ class AgentBackgroundOutputTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn(SUBAGENT_CONTROL_TOOL_NAME, captured["always_include"])
 
     async def test_create_agent_keeps_activity_log_for_normal_session(self):
-        agent = MoviePilotAgent(session_id="normal-session", user_id="system")
+        agent = MoviePilotAgent(
+            session_id="normal-session",
+            user_id="system",
+            channel="Web",
+            source="openai",
+        )
         agent._initialize_tools = lambda: []
         agent._initialize_subagent_tools = lambda: []
 

--- a/tests/test_agent_chat_history.py
+++ b/tests/test_agent_chat_history.py
@@ -111,63 +111,72 @@ def test_agent_prepare_chat_title_generates_title(monkeypatch):
     assert chat.source == "web-agent"
 
 
-def test_agent_prepare_chat_title_skips_internal_background_sessions(monkeypatch):
-    """内部后台任务和心跳会话不应生成标题或创建历史会话。"""
+def test_agent_prepare_chat_title_skips_sessions_without_channel(monkeypatch):
+    """没有渠道来源的 Agent 会话不应生成标题或创建历史会话。"""
 
     async def fake_initialize_llm(self, streaming=False):
-        """后台会话不应初始化标题模型。"""
-        raise AssertionError("background title generation should be skipped")
+        """无渠道会话不应初始化标题模型。"""
+        raise AssertionError("no-channel title generation should be skipped")
 
     monkeypatch.setattr(MoviePilotAgent, "_initialize_llm", fake_initialize_llm)
 
-    for session_id in (
-        "__agent_background_title__",
-        f"{HEARTBEAT_SESSION_PREFIX}title__",
+    for session_id, user_id in (
+        ("__agent_background_title__", SYSTEM_INTERNAL_USER_ID),
+        (f"{HEARTBEAT_SESSION_PREFIX}title__", SYSTEM_INTERNAL_USER_ID),
+        ("mcp-title-session", "mcp"),
+        ("cli-title-session", "cli"),
     ):
         agent = MoviePilotAgent(
             session_id=session_id,
-            user_id=SYSTEM_INTERNAL_USER_ID,
+            user_id=user_id,
             username="admin",
         )
         asyncio.run(agent.prepare_chat_title("后台任务"))
 
         assert AgentChatOper().get(
             session_id=session_id,
-            user_id=SYSTEM_INTERNAL_USER_ID,
+            user_id=user_id,
         ) is None
 
 
-def test_agent_prepare_chat_title_keeps_user_cli_sessions(monkeypatch):
-    """用户显式 CLI 会话即使没有渠道来源也应保留标题生成。"""
+def test_agent_prepare_chat_title_keeps_message_channel_sessions(monkeypatch):
+    """带渠道来源的消息会话应保留标题生成。"""
 
     class FakeTitleModel:
-        """测试用 CLI 标题模型。"""
+        """测试用消息渠道标题模型。"""
 
         async def ainvoke(self, messages):
-            """返回固定 CLI 标题。"""
-            return SimpleNamespace(content="CLI 会话排查")
+            """返回固定消息渠道标题。"""
+            return SimpleNamespace(content="Telegram 会话排查")
 
     async def fake_initialize_llm(self, streaming=False):
-        """返回测试 CLI 标题模型。"""
+        """返回测试消息渠道标题模型。"""
         return FakeTitleModel()
 
     monkeypatch.setattr(MoviePilotAgent, "_initialize_llm", fake_initialize_llm)
     agent = MoviePilotAgent(
-        session_id="cli-title-session",
-        user_id="cli",
+        session_id="telegram-title-session",
+        user_id="telegram-user",
+        channel="Telegram",
+        source="telegram-main",
         username="admin",
     )
 
     asyncio.run(agent.prepare_chat_title("帮我检查配置"))
-    chat = AgentChatOper().get(session_id="cli-title-session", user_id="cli")
+    chat = AgentChatOper().get(
+        session_id="telegram-title-session",
+        user_id="telegram-user",
+    )
 
-    assert chat.title == "CLI 会话排查"
+    assert chat.title == "Telegram 会话排查"
+    assert chat.channel == "Telegram"
+    assert chat.source == "telegram-main"
 
 
-def test_internal_background_agent_execution_does_not_persist_chat_history(monkeypatch):
-    """内部后台任务执行完成后不应写入 Agent 会话历史表。"""
-    session_id = "__agent_background_skip_persist__"
-    user_id = SYSTEM_INTERNAL_USER_ID
+def test_agent_execution_without_channel_does_not_persist_chat_history(monkeypatch):
+    """没有渠道来源的 Agent 执行完成后不应写入会话历史表。"""
+    session_id = "mcp-skip-persist"
+    user_id = "mcp"
     memory_manager.clear_memory(session_id, user_id)
 
     class FakeGraphState:

--- a/tests/test_agent_chat_history.py
+++ b/tests/test_agent_chat_history.py
@@ -1,0 +1,141 @@
+import asyncio
+from types import SimpleNamespace
+
+from langchain_core.messages import HumanMessage
+
+from app.agent import MoviePilotAgent
+from app.agent.memory import memory_manager
+from app.db.agentchat_oper import AgentChatOper
+
+
+def test_agent_chat_oper_saves_display_messages_with_channel():
+    """Agent 会话历史应保存展示消息与渠道标识。"""
+    oper = AgentChatOper()
+    oper.save_display_messages(
+        session_id="session-chat",
+        user_id="1",
+        username="admin",
+        channel="Telegram",
+        source="telegram-main",
+        original_chat_id="chat-1",
+        messages=[
+            {
+                "id": "user-1",
+                "role": "user",
+                "content": "帮我看看下载器",
+                "createdAt": 1,
+                "status": "done",
+                "tools": [],
+                "attachments": [],
+                "choices": [],
+            }
+        ],
+    )
+    chat = AgentChatOper().get(session_id="session-chat", user_id="1")
+
+    assert chat.channel == "Telegram"
+    assert chat.source == "telegram-main"
+    assert chat.original_chat_id == "chat-1"
+    assert chat.message_count == 1
+    assert chat.title == "帮我看看下载器"
+
+
+def test_agent_chat_oper_keeps_generated_title_when_saving_display_messages():
+    """保存展示消息时不应覆盖已生成的模型标题。"""
+    oper = AgentChatOper()
+    oper.update_title_if_empty(
+        session_id="session-title",
+        user_id="1",
+        username="admin",
+        channel="WebAgent",
+        source="web-agent",
+        title="下载器状态排查",
+    )
+    oper.save_display_messages(
+        session_id="session-title",
+        user_id="1",
+        messages=[
+            {
+                "id": "user-1",
+                "role": "user",
+                "content": "帮我看看下载器现在是不是正常",
+                "createdAt": 1,
+                "status": "done",
+                "tools": [],
+                "attachments": [],
+                "choices": [],
+            }
+        ],
+        title="帮我看看下载器现在是不是正常",
+    )
+
+    chat = AgentChatOper().get(session_id="session-title", user_id="1")
+    summary = AgentChatOper.to_summary(chat)
+
+    assert chat.title == "下载器状态排查"
+    assert "preview" not in summary
+    assert "messages" not in summary
+
+
+def test_agent_prepare_chat_title_generates_title(monkeypatch):
+    """首次调用 Agent 时应使用模型生成会话标题并写入渠道信息。"""
+
+    class FakeTitleModel:
+        """测试用标题模型。"""
+
+        async def ainvoke(self, messages):
+            """返回固定标题。"""
+            assert "标题生成器" in messages[0].content
+            assert messages[1].content == "帮我看看下载器现在是不是正常"
+            return SimpleNamespace(content="「下载器状态排查」")
+
+    async def fake_initialize_llm(self, streaming=False):
+        """返回测试标题模型。"""
+        return FakeTitleModel()
+
+    monkeypatch.setattr(MoviePilotAgent, "_initialize_llm", fake_initialize_llm)
+    agent = MoviePilotAgent(
+        session_id="session-ai-title",
+        user_id="3",
+        channel="WebAgent",
+        source="web-agent",
+        username="admin",
+    )
+
+    asyncio.run(agent.prepare_chat_title("帮我看看下载器现在是不是正常"))
+    chat = AgentChatOper().get(session_id="session-ai-title", user_id="3")
+
+    assert chat.title == "下载器状态排查"
+    assert chat.channel == "WebAgent"
+    assert chat.source == "web-agent"
+
+
+def test_memory_manager_restores_agent_messages_from_database():
+    """内存缓存缺失时应从 Agent 会话历史表恢复原始 messages。"""
+    session_id = "session-memory"
+    user_id = "2"
+    memory_manager.clear_memory(session_id, user_id)
+    AgentChatOper().save_agent_messages(
+        session_id=session_id,
+        user_id=user_id,
+        messages=[
+            {
+                "type": "human",
+                "data": {
+                    "content": "继续之前的话题",
+                    "additional_kwargs": {},
+                    "response_metadata": {},
+                    "type": "human",
+                    "name": None,
+                    "id": None,
+                    "example": False,
+                },
+            }
+        ],
+    )
+
+    messages = memory_manager.get_agent_messages(session_id=session_id, user_id=user_id)
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "继续之前的话题"

--- a/tests/test_agent_chat_history.py
+++ b/tests/test_agent_chat_history.py
@@ -1,11 +1,12 @@
 import asyncio
 from types import SimpleNamespace
 
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
-from app.agent import MoviePilotAgent
+from app.agent import HEARTBEAT_SESSION_PREFIX, MoviePilotAgent
 from app.agent.memory import memory_manager
 from app.db.agentchat_oper import AgentChatOper
+from app.utils.identity import SYSTEM_INTERNAL_USER_ID
 
 
 def test_agent_chat_oper_saves_display_messages_with_channel():
@@ -108,6 +109,99 @@ def test_agent_prepare_chat_title_generates_title(monkeypatch):
     assert chat.title == "下载器状态排查"
     assert chat.channel == "WebAgent"
     assert chat.source == "web-agent"
+
+
+def test_agent_prepare_chat_title_skips_internal_background_sessions(monkeypatch):
+    """内部后台任务和心跳会话不应生成标题或创建历史会话。"""
+
+    async def fake_initialize_llm(self, streaming=False):
+        """后台会话不应初始化标题模型。"""
+        raise AssertionError("background title generation should be skipped")
+
+    monkeypatch.setattr(MoviePilotAgent, "_initialize_llm", fake_initialize_llm)
+
+    for session_id in (
+        "__agent_background_title__",
+        f"{HEARTBEAT_SESSION_PREFIX}title__",
+    ):
+        agent = MoviePilotAgent(
+            session_id=session_id,
+            user_id=SYSTEM_INTERNAL_USER_ID,
+            username="admin",
+        )
+        asyncio.run(agent.prepare_chat_title("后台任务"))
+
+        assert AgentChatOper().get(
+            session_id=session_id,
+            user_id=SYSTEM_INTERNAL_USER_ID,
+        ) is None
+
+
+def test_agent_prepare_chat_title_keeps_user_cli_sessions(monkeypatch):
+    """用户显式 CLI 会话即使没有渠道来源也应保留标题生成。"""
+
+    class FakeTitleModel:
+        """测试用 CLI 标题模型。"""
+
+        async def ainvoke(self, messages):
+            """返回固定 CLI 标题。"""
+            return SimpleNamespace(content="CLI 会话排查")
+
+    async def fake_initialize_llm(self, streaming=False):
+        """返回测试 CLI 标题模型。"""
+        return FakeTitleModel()
+
+    monkeypatch.setattr(MoviePilotAgent, "_initialize_llm", fake_initialize_llm)
+    agent = MoviePilotAgent(
+        session_id="cli-title-session",
+        user_id="cli",
+        username="admin",
+    )
+
+    asyncio.run(agent.prepare_chat_title("帮我检查配置"))
+    chat = AgentChatOper().get(session_id="cli-title-session", user_id="cli")
+
+    assert chat.title == "CLI 会话排查"
+
+
+def test_internal_background_agent_execution_does_not_persist_chat_history(monkeypatch):
+    """内部后台任务执行完成后不应写入 Agent 会话历史表。"""
+    session_id = "__agent_background_skip_persist__"
+    user_id = SYSTEM_INTERNAL_USER_ID
+    memory_manager.clear_memory(session_id, user_id)
+
+    class FakeGraphState:
+        """测试用 LangGraph 状态。"""
+
+        def __init__(self, messages):
+            self.values = {"messages": messages}
+
+    class FakeAgent:
+        """测试用 LangGraph Agent。"""
+
+        async def ainvoke(self, _payload, config=None):
+            """模拟非流式 Agent 执行。"""
+            return None
+
+        def get_state(self, _config):
+            """返回包含最终回复的状态。"""
+            return FakeGraphState([AIMessage(content="后台结果")])
+
+    async def fake_create_agent(self, streaming=False):
+        """返回测试 Agent，避免真实初始化模型。"""
+        return FakeAgent()
+
+    monkeypatch.setattr(MoviePilotAgent, "_create_agent", fake_create_agent)
+    agent = MoviePilotAgent(
+        session_id=session_id,
+        user_id=user_id,
+        username="admin",
+    )
+
+    asyncio.run(agent._execute_agent([]))
+
+    assert AgentChatOper().get(session_id=session_id, user_id=user_id) is None
+    assert memory_manager.get_memory(session_id, user_id) is None
 
 
 def test_memory_manager_restores_agent_messages_from_database():

--- a/tests/test_agent_image_support.py
+++ b/tests/test_agent_image_support.py
@@ -569,8 +569,8 @@ class AgentImageSupportTest(unittest.TestCase):
 
         self.assertEqual(payload.image_url, "https://example.com/poster.png")
 
-    def test_send_message_tool_uses_agent_notification_type(self):
-        """发送消息工具应固定使用智能体消息类型。"""
+    def test_send_message_tool_uses_regular_notification_type(self):
+        """发送消息工具应按普通通知消息登记。"""
 
         async def _run():
             tool = SendMessageTool(session_id="session-1", user_id="10001")
@@ -595,7 +595,7 @@ class AgentImageSupportTest(unittest.TestCase):
         notification = async_post_message.await_args.args[0]
 
         self.assertEqual(result, "消息已发送")
-        self.assertEqual(notification.mtype, NotificationType.Agent)
+        self.assertEqual(notification.mtype, NotificationType.Other)
         self.assertEqual(notification.channel, MessageChannel.Telegram)
         self.assertEqual(notification.source, "telegram-test")
         self.assertEqual(notification.title, "智能体通知")

--- a/tests/test_agent_interaction.py
+++ b/tests/test_agent_interaction.py
@@ -204,8 +204,8 @@ class TestAgentInteraction(unittest.TestCase):
         self.assertEqual(kwargs["channel"], MessageChannel.Telegram.value)
         self.assertEqual(kwargs["source"], "telegram-test")
         self.assertNotIn("processing_status", kwargs)
-        message_put.assert_called_once()
-        message_add.assert_called_once()
+        message_put.assert_not_called()
+        message_add.assert_not_called()
 
     def test_legacy_agent_choice_callback_still_supported(self):
         chain = MessageChain()

--- a/tests/test_agent_message_routing.py
+++ b/tests/test_agent_message_routing.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from app.chain.message import MessageChain
-from app.helper.interaction import media_interaction_manager
+from app.core.config import settings
+from app.helper.interaction import AgentInteractionOption, agent_interaction_manager, media_interaction_manager
 from app.schemas.types import MessageChannel
 
 
@@ -38,3 +39,73 @@ def test_explicit_ai_message_bypasses_pending_media_interaction():
 
     handle_ai_message.assert_called_once()
     handle_media_interaction.assert_not_called()
+
+
+def test_explicit_ai_message_is_not_recorded_to_message_history():
+    """显式 /ai 消息不登记到数据库或实时消息队列。"""
+    chain = MessageChain()
+
+    with patch.object(settings, "AI_AGENT_ENABLE", True), patch.object(
+        chain, "_record_user_message"
+    ) as record_user_message, patch(
+        "app.chain.message.agent_manager.process_message",
+        new_callable=AsyncMock,
+    ) as process_message, patch(
+        "app.chain.message.asyncio.run_coroutine_threadsafe",
+        side_effect=lambda coro, _loop: (coro.close(), Mock())[1],
+    ):
+        chain.handle_message(
+            channel=MessageChannel.Telegram,
+            source="telegram-test",
+            userid="10001",
+            username="tester",
+            text="/ai 帮我检查订阅",
+        )
+
+    record_user_message.assert_not_called()
+    process_message.assert_called_once()
+
+
+def test_agent_choice_callback_is_not_recorded_to_message_history():
+    """Agent 按钮选择回传不登记到数据库或实时消息队列。"""
+    chain = MessageChain()
+    request = agent_interaction_manager.create_request(
+        session_id="session-choice",
+        user_id="10001",
+        channel=MessageChannel.Telegram.value,
+        source="telegram-test",
+        username="tester",
+        title="需要你的选择",
+        prompt="请选择",
+        options=[
+            AgentInteractionOption(label="电影", value="我选择电影"),
+            AgentInteractionOption(label="电视剧", value="我选择电视剧"),
+        ],
+    )
+
+    try:
+        with patch.object(settings, "AI_AGENT_ENABLE", True), patch.object(
+            chain, "_record_user_message"
+        ) as record_user_message, patch.object(
+            chain, "edit_message", return_value=True
+        ), patch(
+            "app.chain.message.agent_manager.process_message",
+            new_callable=AsyncMock,
+        ) as process_message, patch(
+            "app.chain.message.asyncio.run_coroutine_threadsafe",
+            side_effect=lambda coro, _loop: (coro.close(), Mock())[1],
+        ):
+            chain._handle_callback(
+                text=f"CALLBACK:agent_interaction:choice:{request.request_id}:1",
+                channel=MessageChannel.Telegram,
+                source="telegram-test",
+                userid="10001",
+                username="tester",
+                original_message_id=123,
+                original_chat_id="456",
+            )
+    finally:
+        agent_interaction_manager.clear()
+
+    record_user_message.assert_not_called()
+    process_message.assert_called_once()

--- a/tests/test_agent_message_routing.py
+++ b/tests/test_agent_message_routing.py
@@ -48,7 +48,7 @@ def test_explicit_ai_message_is_not_recorded_to_message_history():
     with patch.object(settings, "AI_AGENT_ENABLE", True), patch.object(
         chain, "_record_user_message"
     ) as record_user_message, patch(
-        "app.chain.message.agent_manager.process_message",
+        "app.agent.agent_manager.process_message",
         new_callable=AsyncMock,
     ) as process_message, patch(
         "app.chain.message.asyncio.run_coroutine_threadsafe",
@@ -89,7 +89,7 @@ def test_agent_choice_callback_is_not_recorded_to_message_history():
         ) as record_user_message, patch.object(
             chain, "edit_message", return_value=True
         ), patch(
-            "app.chain.message.agent_manager.process_message",
+            "app.agent.agent_manager.process_message",
             new_callable=AsyncMock,
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",

--- a/tests/test_agent_recognize_captcha_tool.py
+++ b/tests/test_agent_recognize_captcha_tool.py
@@ -82,6 +82,35 @@ def test_ocr_helper_extracts_data_url_base64_without_downloading_image():
     }
 
 
+def test_ocr_helper_normalizes_data_url_base64_padding():
+    """data:image 地址缺少 padding 时应补齐后提交给 OCR 服务。"""
+    image_url = "data:image/jpeg;base64,YWJjZA"
+
+    with patch("app.helper.ocr.RequestUtils") as request_utils:
+        request_utils.return_value.post_res.return_value = _FakeResponse(
+            payload={"result": "z9k2"}
+        )
+
+        result = OcrHelper().get_captcha_text(image_url=image_url)
+
+    assert result == "z9k2"
+    request_utils.return_value.get_res.assert_not_called()
+    assert request_utils.return_value.post_res.call_args.kwargs["json"] == {
+        "base64_img": "YWJjZA=="
+    }
+
+
+def test_recognize_captcha_tool_formats_data_url_for_log():
+    """验证码工具日志应隐藏 data:image 的完整图片内容。"""
+    image_b64 = base64.b64encode(b"captcha-image").decode()
+    image_url = f"data:image/jpeg;base64,{image_b64}"
+
+    result = RecognizeCaptchaTool._format_image_url_for_log(image_url)
+
+    assert result == f"data:image/jpeg;base64,<base64:{len(image_b64)} chars>"
+    assert image_b64 not in result
+
+
 def test_recognize_captcha_tool_returns_captcha_text_from_ocr_helper():
     """验证码工具应返回结构化识别结果，便于 Agent 继续填写表单。"""
     tool = RecognizeCaptchaTool(session_id="captcha-session", user_id="10001")

--- a/tests/test_agent_tokens_events.py
+++ b/tests/test_agent_tokens_events.py
@@ -94,7 +94,6 @@ class AgentTokensEventsTest(unittest.IsolatedAsyncioTestCase):
             stop_streaming=AsyncMock(return_value=(False, ""))
         )
         agent.send_agent_message = AsyncMock()
-        agent._save_agent_message_to_db = AsyncMock()
 
         async def create_agent(_streaming=False, streaming=False):
             """模拟创建 Agent 时完成供应商选择和用量统计。"""

--- a/tests/test_agent_tool_factory_cache.py
+++ b/tests/test_agent_tool_factory_cache.py
@@ -1,0 +1,150 @@
+from types import SimpleNamespace
+from typing import Iterator, Optional
+
+import pytest
+
+from app.agent.tools.base import MoviePilotTool
+from app.agent.tools.factory import MoviePilotToolFactory
+from app.core.plugin import PluginManager
+from app.utils.singleton import Singleton
+
+
+class DemoAgentTool(MoviePilotTool):
+    """测试用插件工具。"""
+
+    name: str = "demo_agent_tool"
+    description: str = "Demo agent tool for tests."
+
+    async def run(self, **kwargs) -> str:
+        """返回测试结果。"""
+        return "ok"
+
+
+class DemoMessageAgentTool(DemoAgentTool):
+    """测试用消息发送插件工具。"""
+
+    name: str = "demo_message_agent_tool"
+    sends_message: bool = True
+
+
+@pytest.fixture
+def plugin_manager() -> Iterator[PluginManager]:
+    """构造隔离的插件管理器实例，避免单例缓存污染其它用例。"""
+    Singleton._instances.pop((PluginManager, (), frozenset()), None)
+    manager = PluginManager()
+    yield manager
+    Singleton._instances.pop((PluginManager, (), frozenset()), None)
+
+
+def _build_plugin(
+    tools: list[type[MoviePilotTool]],
+    state: bool = True,
+    calls: Optional[list[int]] = None,
+) -> SimpleNamespace:
+    """构造仅包含 Agent 工具接口的插件实例。"""
+
+    def get_agent_tools() -> list[type[MoviePilotTool]]:
+        """返回测试预设的工具类列表。"""
+        if calls is not None:
+            calls.append(1)
+        return tools
+
+    return SimpleNamespace(
+        plugin_name="Demo Plugin",
+        get_state=lambda: state,
+        get_agent_tools=get_agent_tools,
+    )
+
+
+def test_plugin_agent_tools_are_cached(plugin_manager: PluginManager) -> None:
+    """插件智能体工具注册表应缓存，避免同一轮启动反复询问插件实例。"""
+    calls: list[int] = []
+    plugin_manager.running_plugins["DemoPlugin"] = _build_plugin(
+        [DemoAgentTool], calls=calls
+    )
+
+    first_result = plugin_manager.get_plugin_agent_tools()
+    second_result = plugin_manager.get_plugin_agent_tools()
+
+    assert len(calls) == 1
+    assert first_result == second_result
+    assert first_result[0]["tools"] == [DemoAgentTool]
+
+
+def test_plugin_agent_tools_cache_returns_copy(plugin_manager: PluginManager) -> None:
+    """缓存命中时应返回副本，调用方修改结果不应污染注册表缓存。"""
+    plugin_manager.running_plugins["DemoPlugin"] = _build_plugin([DemoAgentTool])
+
+    first_result = plugin_manager.get_plugin_agent_tools()
+    first_result[0]["tools"].append(DemoMessageAgentTool)
+
+    second_result = plugin_manager.get_plugin_agent_tools()
+
+    assert second_result[0]["tools"] == [DemoAgentTool]
+
+
+def test_plugin_agent_tools_cache_can_be_cleared(
+    plugin_manager: PluginManager,
+) -> None:
+    """清理缓存后应重新读取插件当前声明的智能体工具。"""
+    tools = [DemoAgentTool]
+    calls: list[int] = []
+    plugin_manager.running_plugins["DemoPlugin"] = _build_plugin(tools, calls=calls)
+
+    assert plugin_manager.get_plugin_agent_tools()[0]["tools"] == [DemoAgentTool]
+    tools.append(DemoMessageAgentTool)
+    assert plugin_manager.get_plugin_agent_tools()[0]["tools"] == [DemoAgentTool]
+
+    plugin_manager.clear_plugin_agent_tools_cache()
+
+    assert plugin_manager.get_plugin_agent_tools()[0]["tools"] == [
+        DemoAgentTool,
+        DemoMessageAgentTool,
+    ]
+    assert len(calls) == 2
+
+
+def test_factory_reuses_plugin_registry_but_creates_new_tool_instances(
+    plugin_manager: PluginManager,
+) -> None:
+    """工具工厂可复用插件注册表缓存，但每次请求仍需创建新的工具实例。"""
+    calls: list[int] = []
+    plugin_manager.running_plugins["DemoPlugin"] = _build_plugin(
+        [DemoAgentTool], calls=calls
+    )
+
+    first_tools = MoviePilotToolFactory.create_tools(
+        session_id="session-1",
+        user_id="10001",
+    )
+    second_tools = MoviePilotToolFactory.create_tools(
+        session_id="session-2",
+        user_id="10002",
+    )
+
+    first_demo_tool = next(tool for tool in first_tools if tool.name == "demo_agent_tool")
+    second_demo_tool = next(tool for tool in second_tools if tool.name == "demo_agent_tool")
+
+    assert len(calls) == 1
+    assert first_demo_tool is not second_demo_tool
+    assert first_demo_tool._session_id == "session-1"
+    assert second_demo_tool._session_id == "session-2"
+
+
+def test_factory_suppresses_plugin_message_tools_for_subagents(
+    plugin_manager: PluginManager,
+) -> None:
+    """子代理静默工具列表不应包含会直接向用户发消息的插件工具。"""
+    plugin_manager.running_plugins["DemoPlugin"] = _build_plugin(
+        [DemoAgentTool, DemoMessageAgentTool]
+    )
+
+    tools = MoviePilotToolFactory.create_tools(
+        session_id="session-1",
+        user_id="10001",
+        allow_message_tools=False,
+    )
+    tool_names = {tool.name for tool in tools}
+
+    assert "demo_agent_tool" in tool_names
+    assert "demo_message_agent_tool" not in tool_names

--- a/tests/test_agent_tool_selector_middleware.py
+++ b/tests/test_agent_tool_selector_middleware.py
@@ -3,9 +3,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from app.agent.middleware import tool_selection as tool_selector_module
+from app.agent.tools.tags import ToolTag
 
 
 class _FakeBoundModel:
@@ -58,6 +59,11 @@ class _FakeRequest:
         }
         data.update(kwargs)
         return _FakeRequest(**data)
+
+
+def _tool(name, description, tags=None):
+    """构造测试用工具对象。"""
+    return SimpleNamespace(name=name, description=description, tags=tags or [])
 
 
 class ToolSelectorMiddlewareTest(unittest.TestCase):
@@ -223,14 +229,115 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
 
         self.assertEqual(normalized, {"tools": ["search"]})
 
-    def test_process_selection_response_completes_low_count_tool_chain(self):
-        """筛选结果过少时应按已命中的工具链补齐相邻工具。"""
+    def test_deepseek_selection_uses_recent_conversation_context(self):
+        """多轮追问时工具筛选应看到上一轮用户需求和助手回复。"""
         tools = [
-            SimpleNamespace(name="search_media", description="Search media"),
-            SimpleNamespace(name="search_torrents", description="Search torrents"),
-            SimpleNamespace(name="get_search_results", description="Get results"),
-            SimpleNamespace(name="add_download_tasks", description="Add downloads"),
-            SimpleNamespace(name="query_download_tasks", description="Query downloads"),
+            _tool(
+                "query_plugin_config",
+                "Query plugin config",
+                [ToolTag.Read, ToolTag.Plugin, ToolTag.Settings],
+            ),
+            _tool(
+                "update_plugin_config",
+                "Update plugin config",
+                [ToolTag.Write, ToolTag.Plugin, ToolTag.Settings],
+            ),
+            _tool(
+                "reload_plugin",
+                "Reload plugin",
+                [ToolTag.Write, ToolTag.Plugin],
+            ),
+        ]
+        model = _FakeModel(content='{"tools": ["query_plugin_config"]}')
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=3,
+            selection_tools=tools,
+        )
+        middleware.model = model
+        request = _FakeRequest(
+            tools=tools,
+            messages=[
+                HumanMessage(content="帮我检查插件 DemoPlugin 的配置"),
+                AIMessage(content="我建议先查询插件配置，然后根据结果决定是否重载插件。"),
+                HumanMessage(content="按你说的来"),
+            ],
+            model=model,
+        )
+
+        state_update = asyncio.run(
+            middleware.abefore_agent(request.state, runtime=None, config=None)
+        )
+
+        user_message = model.bound_model.messages[1]
+        self.assertEqual(
+            state_update,
+            {"selected_tool_names": ["query_plugin_config", "update_plugin_config", "reload_plugin"]},
+        )
+        self.assertIsInstance(user_message, HumanMessage)
+        self.assertIn(
+            "Recent conversation context for tool selection",
+            user_message.content,
+        )
+        self.assertIn("帮我检查插件 DemoPlugin 的配置", user_message.content)
+        self.assertIn("我建议先查询插件配置", user_message.content)
+        self.assertIn("按你说的来", user_message.content)
+
+    def test_single_turn_selection_keeps_original_user_message(self):
+        """单轮对话不应额外包裹上下文提示。"""
+        tools = [
+            _tool("search", "Search for information", [ToolTag.Read, ToolTag.Web]),
+            _tool("calendar", "Manage events", [ToolTag.Write]),
+        ]
+        model = _FakeModel(content='{"tools": ["search"]}')
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=2,
+            selection_tools=tools,
+        )
+        middleware.model = model
+        original_message = HumanMessage(content="帮我查一下最近的更新")
+        request = _FakeRequest(
+            tools=tools,
+            messages=[original_message],
+            model=model,
+        )
+
+        asyncio.run(middleware.abefore_agent(request.state, runtime=None, config=None))
+
+        user_message = model.bound_model.messages[1]
+        self.assertIs(user_message, original_message)
+        self.assertNotIn(
+            "Recent conversation context for tool selection",
+            user_message.content,
+        )
+
+    def test_process_selection_response_completes_low_count_tool_group_by_tags(self):
+        """筛选结果过少时应按已命中的工具标签组补齐同组工具。"""
+        tools = [
+            _tool(
+                "search_media",
+                "Search media",
+                [ToolTag.Read, ToolTag.Media],
+            ),
+            _tool(
+                "search_torrents",
+                "Search torrents",
+                [ToolTag.Read, ToolTag.Resource, ToolTag.Site, ToolTag.Media],
+            ),
+            _tool(
+                "get_search_results",
+                "Get results",
+                [ToolTag.Read, ToolTag.Resource],
+            ),
+            _tool(
+                "add_download_tasks",
+                "Add downloads",
+                [ToolTag.Write, ToolTag.Download, ToolTag.Resource],
+            ),
+            _tool(
+                "query_download_tasks",
+                "Query downloads",
+                [ToolTag.Read, ToolTag.Download],
+            ),
         ]
         middleware = tool_selector_module.ToolSelectorMiddleware(
             max_tools=4,
@@ -243,20 +350,21 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
         )
 
         result = middleware._process_selection_response(
-            {"tools": ["search_media"]},
+            {"tools": ["search_torrents"]},
             available_tools=tools,
             valid_tool_names=[tool.name for tool in tools],
             request=request,
         )
 
+        self.assertEqual(len(result.tools), 4)
         self.assertEqual(
-            [tool.name for tool in result.tools],
-            [
+            {tool.name for tool in result.tools},
+            {
                 "search_media",
                 "search_torrents",
                 "get_search_results",
                 "add_download_tasks",
-            ],
+            },
         )
 
     def test_process_selection_response_keeps_high_count_selection(self):
@@ -302,12 +410,28 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
         )
 
     def test_process_selection_response_respects_max_tools_when_completing(self):
-        """工具链补齐不应突破 max_tools 上限。"""
+        """标签组补齐不应突破 max_tools 上限。"""
         tools = [
-            SimpleNamespace(name="list_directory", description="List directory"),
-            SimpleNamespace(name="query_directory_settings", description="Query settings"),
-            SimpleNamespace(name="recognize_media", description="Recognize media"),
-            SimpleNamespace(name="transfer_file", description="Transfer file"),
+            _tool(
+                "list_directory",
+                "List directory",
+                [ToolTag.Read, ToolTag.Directory, ToolTag.File],
+            ),
+            _tool(
+                "query_directory_settings",
+                "Query settings",
+                [ToolTag.Read, ToolTag.Directory, ToolTag.Settings],
+            ),
+            _tool(
+                "recognize_media",
+                "Recognize media",
+                [ToolTag.Read, ToolTag.Media],
+            ),
+            _tool(
+                "transfer_file",
+                "Transfer file",
+                [ToolTag.Write, ToolTag.Transfer, ToolTag.Library, ToolTag.File],
+            ),
         ]
         middleware = tool_selector_module.ToolSelectorMiddleware(
             max_tools=2,
@@ -331,3 +455,29 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
             {tool.name for tool in result.tools},
             {"transfer_file", "list_directory"},
         )
+
+    def test_process_selection_response_ignores_generic_tags_when_completing(self):
+        """通用权限标签不应被当作工具组使用。"""
+        tools = [
+            _tool("read_one", "Read one", [ToolTag.Read]),
+            _tool("read_two", "Read two", [ToolTag.Read]),
+            _tool("write_one", "Write one", [ToolTag.Write, ToolTag.Admin]),
+        ]
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=4,
+            selection_tools=tools,
+        )
+        request = _FakeRequest(
+            tools=tools,
+            messages=[HumanMessage(content="查一下信息")],
+            model=_FakeModel(),
+        )
+
+        result = middleware._process_selection_response(
+            {"tools": ["read_one"]},
+            available_tools=tools,
+            valid_tool_names=[tool.name for tool in tools],
+            request=request,
+        )
+
+        self.assertEqual([tool.name for tool in result.tools], ["read_one"])

--- a/tests/test_agent_tool_selector_middleware.py
+++ b/tests/test_agent_tool_selector_middleware.py
@@ -103,6 +103,7 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
         self.assertIn("Return the answer in JSON only.", prompt)
         self.assertIn('- search: Search for information', prompt)
         self.assertIn('- calendar: Manage events', prompt)
+        self.assertIn("MoviePilot tool-chain hints:", prompt)
         self.assertEqual(len(handled_requests), 1)
 
     def test_awrap_model_call_reuses_first_selection_for_later_model_rounds(self):
@@ -221,3 +222,112 @@ class ToolSelectorMiddlewareTest(unittest.TestCase):
         normalized = middleware._normalize_selection_response(response)
 
         self.assertEqual(normalized, {"tools": ["search"]})
+
+    def test_process_selection_response_completes_low_count_tool_chain(self):
+        """筛选结果过少时应按已命中的工具链补齐相邻工具。"""
+        tools = [
+            SimpleNamespace(name="search_media", description="Search media"),
+            SimpleNamespace(name="search_torrents", description="Search torrents"),
+            SimpleNamespace(name="get_search_results", description="Get results"),
+            SimpleNamespace(name="add_download_tasks", description="Add downloads"),
+            SimpleNamespace(name="query_download_tasks", description="Query downloads"),
+        ]
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=4,
+            selection_tools=tools,
+        )
+        request = _FakeRequest(
+            tools=tools,
+            messages=[HumanMessage(content="帮我下载流浪地球")],
+            model=_FakeModel(),
+        )
+
+        result = middleware._process_selection_response(
+            {"tools": ["search_media"]},
+            available_tools=tools,
+            valid_tool_names=[tool.name for tool in tools],
+            request=request,
+        )
+
+        self.assertEqual(
+            [tool.name for tool in result.tools],
+            [
+                "search_media",
+                "search_torrents",
+                "get_search_results",
+                "add_download_tasks",
+            ],
+        )
+
+    def test_process_selection_response_keeps_high_count_selection(self):
+        """筛选结果数量足够时不应额外补齐工具。"""
+        tools = [
+            SimpleNamespace(name="search_media", description="Search media"),
+            SimpleNamespace(name="search_torrents", description="Search torrents"),
+            SimpleNamespace(name="get_search_results", description="Get results"),
+            SimpleNamespace(name="query_sites", description="Query sites"),
+        ]
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=4,
+            selection_tools=tools,
+        )
+        request = _FakeRequest(
+            tools=tools,
+            messages=[HumanMessage(content="帮我下载流浪地球")],
+            model=_FakeModel(),
+        )
+
+        result = middleware._process_selection_response(
+            {
+                "tools": [
+                    "search_media",
+                    "search_torrents",
+                    "get_search_results",
+                    "query_sites",
+                ]
+            },
+            available_tools=tools,
+            valid_tool_names=[tool.name for tool in tools],
+            request=request,
+        )
+
+        self.assertEqual(
+            [tool.name for tool in result.tools],
+            [
+                "search_media",
+                "search_torrents",
+                "get_search_results",
+                "query_sites",
+            ],
+        )
+
+    def test_process_selection_response_respects_max_tools_when_completing(self):
+        """工具链补齐不应突破 max_tools 上限。"""
+        tools = [
+            SimpleNamespace(name="list_directory", description="List directory"),
+            SimpleNamespace(name="query_directory_settings", description="Query settings"),
+            SimpleNamespace(name="recognize_media", description="Recognize media"),
+            SimpleNamespace(name="transfer_file", description="Transfer file"),
+        ]
+        middleware = tool_selector_module.ToolSelectorMiddleware(
+            max_tools=2,
+            selection_tools=tools,
+        )
+        request = _FakeRequest(
+            tools=tools,
+            messages=[HumanMessage(content="帮我整理这个目录")],
+            model=_FakeModel(),
+        )
+
+        result = middleware._process_selection_response(
+            {"tools": ["transfer_file"]},
+            available_tools=tools,
+            valid_tool_names=[tool.name for tool in tools],
+            request=request,
+        )
+
+        self.assertEqual(len(result.tools), 2)
+        self.assertEqual(
+            {tool.name for tool in result.tools},
+            {"transfer_file", "list_directory"},
+        )

--- a/tests/test_agent_transfer_file_tool.py
+++ b/tests/test_agent_transfer_file_tool.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from app.agent.tools.impl.transfer_file import TransferFileTool
+
+
+def test_transfer_file_local_directory_without_trailing_slash_uses_dir(tmp_path):
+    """本地目录路径即使没有尾斜杠，也应按目录交给整理链路。"""
+    source_dir = tmp_path / "Movie Folder"
+    source_dir.mkdir()
+    captured = {}
+
+    def _manual_transfer(self, **kwargs):
+        """记录工具传给整理链路的参数。"""
+        captured.update(kwargs)
+        return True, None
+
+    with patch(
+        "app.chain.transfer.TransferChain.manual_transfer",
+        new=_manual_transfer,
+    ):
+        result = TransferFileTool._transfer_file_sync(str(source_dir))
+
+    assert result == f"整理成功：{source_dir}"
+    assert captured["fileitem"].type == "dir"
+    assert captured["fileitem"].path == str(source_dir)
+
+
+def test_transfer_file_local_file_uses_file(tmp_path):
+    """本地文件路径应继续按文件交给整理链路。"""
+    source_file = tmp_path / "Movie.mkv"
+    source_file.write_text("fake media", encoding="utf-8")
+    captured = {}
+
+    def _manual_transfer(self, **kwargs):
+        """记录工具传给整理链路的参数。"""
+        captured.update(kwargs)
+        return True, None
+
+    with patch(
+        "app.chain.transfer.TransferChain.manual_transfer",
+        new=_manual_transfer,
+    ):
+        result = TransferFileTool._transfer_file_sync(str(source_file))
+
+    assert result == f"整理成功：{source_file}"
+    assert captured["fileitem"].type == "file"
+    assert captured["fileitem"].path == str(source_file)
+
+
+def test_transfer_file_remote_directory_still_uses_trailing_slash():
+    """远程存储无法用本地 stat 判断时，继续使用尾斜杠识别目录。"""
+    captured = {}
+
+    def _manual_transfer(self, **kwargs):
+        """记录工具传给整理链路的参数。"""
+        captured.update(kwargs)
+        return True, None
+
+    with patch(
+        "app.chain.transfer.TransferChain.manual_transfer",
+        new=_manual_transfer,
+    ):
+        result = TransferFileTool._transfer_file_sync(
+            "downloads/Show/",
+            storage="alist",
+        )
+
+    assert result == "整理成功：/downloads/Show/"
+    assert captured["fileitem"].type == "dir"
+    assert captured["fileitem"].path == "/downloads/Show/"

--- a/tests/test_cache_system.py
+++ b/tests/test_cache_system.py
@@ -1,7 +1,8 @@
 import asyncio
 
 from app.core.cache import AsyncFileBackend, FileBackend, MemoryBackend
-from app.helper.redis import RedisHelper
+from app.core.config import settings
+from app.helper.redis import AsyncRedisHelper, RedisHelper
 
 
 def test_file_backend_items_keep_relative_keys_and_bytes(tmp_path):
@@ -47,6 +48,122 @@ def test_redis_original_key_decodes_quoted_key():
     redis_key = b"region:DEFAULT:key:nested/poster%20one.jpg"
 
     assert RedisHelper._RedisHelper__get_original_key(redis_key) == "nested/poster one.jpg"
+
+
+def test_redis_helper_uses_blocking_pool_settings(monkeypatch):
+    """
+    Redis 同步客户端应使用阻塞连接池，避免并发峰值直接耗尽 Redis 连接数。
+    """
+    calls = {}
+
+    class FakeClient:
+        """模拟同步 Redis 客户端。"""
+
+        def __init__(self, connection_pool):
+            self.connection_pool = connection_pool
+            self.config_calls = []
+            self.closed = False
+
+        def ping(self):
+            """模拟 Redis ping。"""
+            calls["ping"] = True
+
+        def config_set(self, key, value):
+            """记录 Redis 配置写入。"""
+            self.config_calls.append((key, value))
+
+        def close(self):
+            """标记客户端已关闭。"""
+            self.closed = True
+
+    def fake_from_url(url, **kwargs):
+        """记录连接池构造参数。"""
+        calls["pool"] = {"url": url, **kwargs}
+        return "pool"
+
+    monkeypatch.setattr(settings, "CACHE_BACKEND_URL", "redis://cache:6379/2")
+    monkeypatch.setattr(settings, "CACHE_REDIS_MAX_CONNECTIONS", 7)
+    monkeypatch.setattr(settings, "CACHE_REDIS_POOL_TIMEOUT", 3)
+    monkeypatch.setattr("app.core.redis.redis.BlockingConnectionPool.from_url", fake_from_url)
+    monkeypatch.setattr("app.core.redis.redis.Redis", FakeClient)
+
+    helper = RedisHelper()
+    helper.close()
+    helper._connect()
+
+    assert calls["pool"]["url"] == "redis://cache:6379/2"
+    assert calls["pool"]["max_connections"] == 7
+    assert calls["pool"]["timeout"] == 3
+    assert calls["pool"]["decode_responses"] is False
+    assert calls["ping"] is True
+    assert ("maxmemory-policy", "allkeys-lru") in helper.client.config_calls
+
+    helper.close()
+
+
+def test_async_redis_helper_uses_blocking_pool_settings(monkeypatch):
+    """
+    Redis 异步客户端应使用阻塞连接池，避免高并发缓存读取立刻抛出连接耗尽错误。
+    """
+    calls = {}
+
+    class FakeAsyncClient:
+        """模拟异步 Redis 客户端。"""
+
+        def __init__(self, connection_pool):
+            self.connection_pool = connection_pool
+            self.config_calls = []
+            self.closed = False
+
+        async def ping(self):
+            """模拟 Redis ping。"""
+            calls["ping"] = True
+
+        async def config_set(self, key, value):
+            """记录 Redis 配置写入。"""
+            self.config_calls.append((key, value))
+
+        async def close(self):
+            """标记客户端已关闭。"""
+            self.closed = True
+
+    def fake_from_url(url, **kwargs):
+        """记录连接池构造参数。"""
+        calls["pool"] = {"url": url, **kwargs}
+        return "async_pool"
+
+    async def run_connect():
+        helper = AsyncRedisHelper()
+        await helper.close()
+        await helper._connect()
+        config_calls = list(helper.client.config_calls)
+        await helper.close()
+        return config_calls
+
+    monkeypatch.setattr(settings, "CACHE_BACKEND_URL", "redis://cache:6379/3")
+    monkeypatch.setattr(settings, "CACHE_REDIS_MAX_CONNECTIONS", 9)
+    monkeypatch.setattr(settings, "CACHE_REDIS_POOL_TIMEOUT", 4)
+    monkeypatch.setattr("app.core.redis.AsyncBlockingConnectionPool.from_url", fake_from_url)
+    monkeypatch.setattr("app.core.redis.Redis", FakeAsyncClient)
+
+    config_calls = asyncio.run(run_connect())
+
+    assert calls["pool"]["url"] == "redis://cache:6379/3"
+    assert calls["pool"]["max_connections"] == 9
+    assert calls["pool"]["timeout"] == 4
+    assert calls["pool"]["decode_responses"] is False
+    assert calls["ping"] is True
+    assert ("maxmemory-policy", "allkeys-lru") in config_calls
+
+
+def test_redis_helpers_watch_pool_settings():
+    """
+    Redis 连接池配置变化应触发客户端重建。
+    """
+    assert "CACHE_REDIS_MAX_CONNECTIONS" in RedisHelper.CONFIG_WATCH
+    assert "CACHE_REDIS_POOL_TIMEOUT" in RedisHelper.CONFIG_WATCH
+    assert "CACHE_REDIS_MAX_CONNECTIONS" in AsyncRedisHelper.CONFIG_WATCH
+    assert "CACHE_REDIS_POOL_TIMEOUT" in AsyncRedisHelper.CONFIG_WATCH
 
 
 def test_async_file_backend_missing_region_has_no_items(tmp_path):

--- a/tests/test_media_interaction.py
+++ b/tests/test_media_interaction.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 import pytest
 
 from app.chain.message import MediaInteractionChain, MessageChain
-from app.core.context import MediaInfo
+from app.core.context import Context, MediaInfo, TorrentInfo
 from app.core.meta import MetaBase
 from app.helper.interaction import media_interaction_manager
-from app.schemas.types import MessageChannel
+from app.schemas import TransferDirectoryConf
+from app.schemas.types import MediaType, MessageChannel
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +23,43 @@ def _build_meta(name: str) -> MetaBase:
     meta.name = name
     meta.begin_season = 1
     return meta
+
+
+def _build_context(title: str = "星际穿越") -> Context:
+    """构造可用于媒体交互下载测试的资源上下文。"""
+    return Context(
+        meta_info=_build_meta(title),
+        media_info=MediaInfo(
+            type=MediaType.MOVIE,
+            title=title,
+            year="2014",
+            tmdb_id=1,
+        ),
+        torrent_info=TorrentInfo(
+            title=f"{title}.2014.1080p",
+            site_name="TestSite",
+            enclosure="https://example.com/demo.torrent",
+            seeders=10,
+        ),
+    )
+
+
+def _build_download_dirs() -> list[TransferDirectoryConf]:
+    """构造消息交互可选择的下载目录配置。"""
+    return [
+        TransferDirectoryConf(
+            name="电影下载",
+            storage="local",
+            download_path="/downloads/movies",
+            priority=1,
+        ),
+        TransferDirectoryConf(
+            name="动画下载",
+            storage="rclone",
+            download_path="/media/anime",
+            priority=2,
+        ),
+    ]
 
 
 def test_message_routes_text_reply_to_media_interaction_before_ai():
@@ -230,3 +268,164 @@ def test_media_interaction_legacy_page_callback_updates_existing_request():
     notification = post_medias_message.call_args.args[0]
     assert notification.original_message_id == 123
     assert notification.original_chat_id == "456"
+
+
+def test_torrent_selection_prompts_download_dir_buttons_before_download():
+    """支持按钮的渠道选择资源后，应先发送下载目录按钮而不是立即下载。"""
+    chain = MediaInteractionChain()
+    context = _build_context()
+    request = media_interaction_manager.create_or_replace(
+        user_id="10001",
+        channel=MessageChannel.Telegram,
+        source="telegram-test",
+        username="tester",
+        action="Search",
+        keyword="星际穿越",
+        title="星际穿越",
+        meta=_build_meta("星际穿越"),
+        items=[context],
+    )
+    request.phase = "torrent"
+
+    with patch(
+        "app.chain.message.DirectoryHelper.get_download_dirs",
+        return_value=_build_download_dirs(),
+    ), patch.object(chain, "post_message") as post_message, patch(
+        "app.chain.message.DownloadChain.download_single"
+    ) as download_single:
+        handled = chain.handle_text_interaction(
+            channel=MessageChannel.Telegram,
+            source="telegram-test",
+            userid="10001",
+            username="tester",
+            text="1",
+        )
+
+    assert handled
+    download_single.assert_not_called()
+    assert request.phase == "download-dir"
+    post_message.assert_called_once()
+    notification = post_message.call_args.args[0]
+    assert "请选择下载目录" in notification.title
+    assert "电影下载 (/downloads/movies)" in notification.text
+    assert notification.buttons[0][0]["callback_data"] == f"media:{request.request_id}:download-dir:1"
+
+
+def test_torrent_selection_prompts_text_download_dir_for_plain_channel():
+    """不支持按钮的渠道选择资源后，应提示用户回复数字选择下载目录。"""
+    chain = MediaInteractionChain()
+    context = _build_context()
+    request = media_interaction_manager.create_or_replace(
+        user_id="wechat-user",
+        channel=MessageChannel.Wechat,
+        source="wechat-test",
+        username="tester",
+        action="Search",
+        keyword="星际穿越",
+        title="星际穿越",
+        meta=_build_meta("星际穿越"),
+        items=[context],
+    )
+    request.phase = "torrent"
+
+    with patch(
+        "app.chain.message.DirectoryHelper.get_download_dirs",
+        return_value=_build_download_dirs(),
+    ), patch.object(chain, "post_message") as post_message:
+        handled = chain.handle_text_interaction(
+            channel=MessageChannel.Wechat,
+            source="wechat-test",
+            userid="wechat-user",
+            username="tester",
+            text="1",
+        )
+
+    assert handled
+    notification = post_message.call_args.args[0]
+    assert "请回复对应数字" in notification.title
+    assert notification.buttons is None
+    assert "2. 动画下载 (rclone:/media/anime)" in notification.text
+
+
+def test_download_dir_callback_runs_pending_single_download_with_save_path():
+    """下载目录按钮回调应使用所选 save_path 继续执行挂起的单资源下载。"""
+    chain = MediaInteractionChain()
+    context = _build_context()
+    request = media_interaction_manager.create_or_replace(
+        user_id="10001",
+        channel=MessageChannel.Telegram,
+        source="telegram-test",
+        username="tester",
+        action="Search",
+        keyword="星际穿越",
+        title="星际穿越",
+        meta=_build_meta("星际穿越"),
+        items=[context],
+    )
+    request.phase = "download-dir"
+    request.pending_download_mode = "single"
+    request.pending_download_context = context
+
+    with patch(
+        "app.chain.message.DirectoryHelper.get_download_dirs",
+        return_value=_build_download_dirs(),
+    ), patch(
+        "app.chain.message.DownloadChain.download_single",
+        return_value="hash",
+    ) as download_single:
+        request.download_dirs = chain._get_download_dirs()
+        handled = chain.handle_callback_interaction(
+            callback_data=f"media:{request.request_id}:download-dir:2",
+            channel=MessageChannel.Telegram,
+            source="telegram-test",
+            userid="10001",
+            username="tester",
+        )
+
+    assert handled
+    assert request.phase == "torrent"
+    download_single.assert_called_once()
+    assert download_single.call_args.args[0] is context
+    assert download_single.call_args.kwargs["save_path"] == "rclone:/media/anime"
+
+
+def test_download_dir_text_reply_runs_pending_single_download_with_save_path():
+    """下载目录文本回复应使用所选 save_path 继续执行挂起的单资源下载。"""
+    chain = MediaInteractionChain()
+    context = _build_context()
+    request = media_interaction_manager.create_or_replace(
+        user_id="wechat-user",
+        channel=MessageChannel.Wechat,
+        source="wechat-test",
+        username="tester",
+        action="Search",
+        keyword="星际穿越",
+        title="星际穿越",
+        meta=_build_meta("星际穿越"),
+        items=[context],
+    )
+    request.phase = "download-dir"
+    request.pending_download_mode = "single"
+    request.pending_download_context = context
+
+    with patch(
+        "app.chain.message.DirectoryHelper.get_download_dirs",
+        return_value=_build_download_dirs(),
+    ), patch(
+        "app.chain.message.DownloadChain.download_single",
+        return_value="hash",
+    ) as download_single:
+        request.download_dirs = chain._get_download_dirs()
+        handled = chain.handle_text_interaction(
+            channel=MessageChannel.Wechat,
+            source="wechat-test",
+            userid="wechat-user",
+            username="tester",
+            text="1",
+        )
+
+    assert handled
+    assert request.phase == "torrent"
+    download_single.assert_called_once()
+    assert download_single.call_args.args[0] is context
+    assert download_single.call_args.kwargs["save_path"] == "/downloads/movies"

--- a/tests/test_media_interaction.py
+++ b/tests/test_media_interaction.py
@@ -224,6 +224,7 @@ def test_media_interaction_starts_search_and_posts_media_list():
     assert handled
     post_medias_message.assert_called_once()
     notification = post_medias_message.call_args.args[0]
+    assert notification.save_history is False
     assert notification.buttons
     assert notification.buttons[0][0]["callback_data"].startswith("media:")
 
@@ -306,6 +307,7 @@ def test_torrent_selection_prompts_download_dir_buttons_before_download():
     assert request.phase == "download-dir"
     post_message.assert_called_once()
     notification = post_message.call_args.args[0]
+    assert notification.save_history is False
     assert "请选择下载目录" in notification.title
     assert "电影下载 (/downloads/movies)" in notification.text
     assert notification.buttons[0][0]["callback_data"] == f"media:{request.request_id}:download-dir:1"
@@ -342,6 +344,7 @@ def test_torrent_selection_prompts_text_download_dir_for_plain_channel():
 
     assert handled
     notification = post_message.call_args.args[0]
+    assert notification.save_history is False
     assert "请回复对应数字" in notification.title
     assert notification.buttons is None
     assert "2. 动画下载 (rclone:/media/anime)" in notification.text

--- a/tests/test_message_notifications.py
+++ b/tests/test_message_notifications.py
@@ -5,9 +5,11 @@ from app.db import SessionFactory
 from app.db.message_oper import MessageOper
 from app.db.models.message import Message
 from app.chain import ChainBase
+from app.core.context import Context, MediaInfo, TorrentInfo
+from app.core.meta import MetaBase
 from app.helper.message import MessageHelper
 from app.schemas import Notification
-from app.schemas.types import NotificationType
+from app.schemas.types import MediaType, NotificationType
 
 
 def _clear_messages() -> None:
@@ -167,3 +169,59 @@ def test_agent_notification_post_message_is_persisted_without_sse_queue() -> Non
     assert messages[0].mtype == NotificationType.Agent.value
     assert helper.get() is None
     chain.messagequeue.send_message.assert_called_once()
+
+
+def test_transient_notification_post_message_skips_history_but_dispatches() -> None:
+    """
+    标记为不保存历史的过程消息应跳过数据库登记，但仍正常派发。
+    """
+    _clear_messages()
+    chain = ChainBase()
+
+    chain.messagequeue.send_message = Mock()
+    chain.eventmanager.send_event = Mock()
+
+    chain.post_message(
+        Notification(
+            title="请选择下载目录",
+            text="1. 默认目录",
+            save_history=False,
+        )
+    )
+
+    assert MessageOper().list_by_page(page=1, count=10) == []
+    assert "save_history" not in chain.eventmanager.send_event.call_args.kwargs["data"]
+    chain.eventmanager.send_event.assert_called_once()
+    chain.messagequeue.send_message.assert_called_once()
+
+
+def test_transient_media_and_torrent_lists_skip_history_but_dispatch() -> None:
+    """
+    传统交互候选列表标记为不保存历史时，只发送到渠道，不写入消息表。
+    """
+    _clear_messages()
+    chain = ChainBase()
+    media = MediaInfo(type=MediaType.MOVIE, title="星际穿越", year="2014")
+    torrent = Context(
+        meta_info=MetaBase("星际穿越"),
+        media_info=media,
+        torrent_info=TorrentInfo(
+            title="星际穿越.2014.1080p",
+            site_name="TestSite",
+            enclosure="https://example.com/demo.torrent",
+        ),
+    )
+
+    chain.messagequeue.send_message = Mock()
+
+    chain.post_medias_message(
+        Notification(title="请选择媒体", save_history=False),
+        medias=[media],
+    )
+    chain.post_torrents_message(
+        Notification(title="请选择资源", save_history=False),
+        torrents=[torrent],
+    )
+
+    assert MessageOper().list_by_page(page=1, count=10) == []
+    assert chain.messagequeue.send_message.call_count == 2

--- a/tests/test_message_notifications.py
+++ b/tests/test_message_notifications.py
@@ -1,0 +1,169 @@
+import json
+from unittest.mock import Mock
+
+from app.db import SessionFactory
+from app.db.message_oper import MessageOper
+from app.db.models.message import Message
+from app.chain import ChainBase
+from app.helper.message import MessageHelper
+from app.schemas import Notification
+from app.schemas.types import NotificationType
+
+
+def _clear_messages() -> None:
+    """
+    清空消息表，隔离通知测试数据。
+    """
+    with SessionFactory() as db:
+        db.query(Message).delete()
+        db.commit()
+
+
+def _reset_message_helper(helper: MessageHelper) -> None:
+    """
+    清空单例消息队列和去重缓存，避免用例间互相影响。
+    """
+    while helper.get() is not None:
+        pass
+    helper._recent_notification_keys.clear()
+
+
+def test_notification_history_only_lists_sent_messages() -> None:
+    """
+    通知历史应返回已发送消息，包含通过消息链登记的智能体消息。
+    """
+    _clear_messages()
+    oper = MessageOper()
+    oper.add(title="系统通知", text="下载完成", action=1, mtype=NotificationType.Download)
+    oper.add(title="用户消息", text="帮我搜索", action=0)
+    oper.add(title="智能体回复", text="已处理", action=1, mtype=NotificationType.Agent)
+
+    messages = MessageOper().list_by_page(page=1, count=10)
+    assert [message.title for message in messages if message.action == 1] == ["智能体回复", "系统通知"]
+
+
+def test_web_message_history_returns_all_messages() -> None:
+    """
+    Web 消息历史返回消息表中的全部记录。
+    """
+    _clear_messages()
+    oper = MessageOper()
+    oper.add(title="智能体回复", text="已处理", action=1, mtype=NotificationType.Agent)
+    oper.add(title="用户消息", text="/ai 帮我处理", action=0)
+    oper.add(title="普通通知", text="下载完成", action=1, mtype=NotificationType.Download)
+
+    messages = MessageOper().list_by_page(page=1, count=10)
+    assert [message.title for message in messages] == ["普通通知", "用户消息", "智能体回复"]
+
+
+def test_system_helper_message_only_enters_sse_queue() -> None:
+    """
+    系统实时消息只进入前端 SSE 队列，不写入通知历史。
+    """
+    _clear_messages()
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+
+    helper.put("调度任务执行失败", role="system", title="系统错误")
+
+    assert MessageOper().list_by_page(page=1, count=10) == []
+    realtime_message = json.loads(helper.get())
+    assert realtime_message["type"] == "system"
+    assert realtime_message["title"] == "系统错误"
+    assert realtime_message["text"] == "调度任务执行失败"
+
+
+def test_plugin_helper_message_deduplicates_recent_sse_messages() -> None:
+    """
+    短时间内相同插件实时消息只应推送一次，不写入通知历史。
+    """
+    _clear_messages()
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+
+    helper.put("站点刷流任务出错，获取下载器实例失败，请检查配置", role="plugin", title="站点刷流")
+    helper.put("站点刷流任务出错，获取下载器实例失败，请检查配置", role="plugin", title="站点刷流")
+
+    assert MessageOper().list_by_page(page=1, count=10) == []
+    assert json.loads(helper.get())["title"] == "站点刷流"
+    assert helper.get() is None
+
+
+def test_agent_helper_message_does_not_enter_sse_queue() -> None:
+    """
+    智能体消息不进入前端 SSE 队列。
+    """
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+
+    helper.put("智能体回复", role="agent", title="MoviePilot助手")
+
+    assert helper.get() is None
+
+
+def test_user_helper_message_does_not_enter_sse_queue() -> None:
+    """
+    用户消息不进入前端 SSE 队列。
+    """
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+
+    helper.put("用户输入", role="user", title="admin")
+
+    assert helper.get() is None
+
+
+def test_notification_post_message_is_persisted_without_sse_queue() -> None:
+    """
+    业务通知通过消息链发送时只登记数据库，不进入前端 SSE 队列。
+    """
+    _clear_messages()
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+    chain = ChainBase()
+
+    chain.messagequeue.send_message = Mock()
+    chain.eventmanager.send_event = Mock()
+
+    chain.post_message(
+        Notification(
+            mtype=NotificationType.Download,
+            title="下载完成",
+            text="影片已加入下载器",
+        )
+    )
+
+    messages = MessageOper().list_by_page(page=1, count=10)
+    assert len(messages) == 1
+    assert messages[0].title == "下载完成"
+    assert messages[0].mtype == NotificationType.Download.value
+    assert helper.get() is None
+    chain.messagequeue.send_message.assert_called_once()
+
+
+def test_agent_notification_post_message_is_persisted_without_sse_queue() -> None:
+    """
+    智能体消息通过消息链发送时登记数据库，但不进入前端 SSE 队列。
+    """
+    _clear_messages()
+    helper = MessageHelper()
+    _reset_message_helper(helper)
+    chain = ChainBase()
+
+    chain.messagequeue.send_message = Mock()
+    chain.eventmanager.send_event = Mock()
+
+    chain.post_message(
+        Notification(
+            mtype=NotificationType.Agent,
+            title="MoviePilot助手",
+            text="已完成处理",
+        )
+    )
+
+    messages = MessageOper().list_by_page(page=1, count=10)
+    assert len(messages) == 1
+    assert messages[0].title == "MoviePilot助手"
+    assert messages[0].mtype == NotificationType.Agent.value
+    assert helper.get() is None
+    chain.messagequeue.send_message.assert_called_once()

--- a/tests/test_plugin_endpoint.py
+++ b/tests/test_plugin_endpoint.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from app import schemas
 from app.api.endpoints.plugin import plugin_history
+from app.api.endpoints.plugin import plugin_releases
 from app.api.endpoints.plugin import reset_plugin
 from app.api.endpoints.system import sync_plugin_market_from_wiki
 from app.schemas.event import PluginDataResetEventData
@@ -62,6 +63,137 @@ def test_plugin_history_returns_installed_plugin_when_remote_missing():
 
     assert result.id == "DemoPlugin"
     assert result.history == {}
+
+
+def test_plugin_releases_returns_supported_versions_with_latest_and_current(monkeypatch):
+    """
+    release 列表接口返回可安装版本，并标记当前 package 最新版本与本地已安装版本。
+    """
+    market_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.3",
+        repo_url="https://github.com/demo/plugins",
+        release=True,
+    )
+    installed_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.0",
+        installed=True,
+    )
+    plugin_manager = MagicMock()
+    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugins.return_value = [installed_plugin]
+    plugin_helper = MagicMock()
+    plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[
+        {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},
+        {"version": "1.2.0", "tag_name": "DemoPlugin_v1.2.0", "asset_name": "demoplugin_v1.2.0.zip"},
+    ])
+
+    with (
+        patch("app.api.endpoints.plugin.PluginManager", return_value=plugin_manager),
+        patch("app.api.endpoints.plugin.PluginHelper", return_value=plugin_helper),
+    ):
+        result = asyncio.run(plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", False))
+
+    assert result["release_supported"] is True
+    assert result["latest_version"] == "1.2.3"
+    assert result["current_version"] == "1.2.0"
+    assert result["items"][0]["is_latest"] is True
+    assert result["items"][0]["is_current"] is False
+    assert result["items"][1]["is_latest"] is False
+    assert result["items"][1]["is_current"] is True
+    plugin_manager.async_get_online_plugins.assert_awaited_once_with(force=False)
+
+
+def test_plugin_releases_does_not_mutate_cached_release_items(monkeypatch):
+    """
+    接口标记当前/最新版本时不能修改 helper 返回对象，避免污染缓存中的 release 列表。
+    """
+    market_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.3",
+        repo_url="https://github.com/demo/plugins",
+        release=True,
+    )
+    installed_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.0",
+        installed=True,
+    )
+    release_items = [
+        {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},
+    ]
+    plugin_manager = MagicMock()
+    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugins.return_value = [installed_plugin]
+    plugin_helper = MagicMock()
+    plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=release_items)
+
+    with (
+        patch("app.api.endpoints.plugin.PluginManager", return_value=plugin_manager),
+        patch("app.api.endpoints.plugin.PluginHelper", return_value=plugin_helper),
+    ):
+        result = asyncio.run(plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", False))
+
+    assert result["items"][0]["is_latest"] is True
+    assert "is_latest" not in release_items[0]
+    assert "is_current" not in release_items[0]
+
+
+def test_plugin_releases_uses_force_refresh_for_market_metadata(monkeypatch):
+    """
+    release 列表接口沿用插件市场的 force 语义，供前端手动刷新时绕过缓存。
+    """
+    market_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.3",
+        repo_url="https://github.com/demo/plugins",
+        release=True,
+    )
+    plugin_manager = MagicMock()
+    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugins.return_value = []
+    plugin_helper = MagicMock()
+    plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[])
+
+    with (
+        patch("app.api.endpoints.plugin.PluginManager", return_value=plugin_manager),
+        patch("app.api.endpoints.plugin.PluginHelper", return_value=plugin_helper),
+    ):
+        result = asyncio.run(plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", True))
+
+    assert result["release_supported"] is False
+    plugin_manager.async_get_online_plugins.assert_awaited_once_with(force=True)
+    assert plugin_helper.async_get_plugin_release_versions.await_args.args == ("DemoPlugin", "https://github.com/demo/plugins")
+
+
+def test_plugin_releases_hides_items_when_market_plugin_does_not_enable_release(monkeypatch):
+    """
+    接口是否支持 Release 安装要与当前 package 的 release 声明保持一致。
+    """
+    market_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.3",
+        repo_url="https://github.com/demo/plugins",
+        release=False,
+    )
+    plugin_manager = MagicMock()
+    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugins.return_value = []
+    plugin_helper = MagicMock()
+    plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[
+        {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},
+    ])
+
+    with (
+        patch("app.api.endpoints.plugin.PluginManager", return_value=plugin_manager),
+        patch("app.api.endpoints.plugin.PluginHelper", return_value=plugin_helper),
+    ):
+        result = asyncio.run(plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", False))
+
+    assert result["release_supported"] is False
+    assert result["items"] == []
+    plugin_helper.async_get_plugin_release_versions.assert_not_awaited()
 
 
 def test_sync_plugin_market_from_wiki_merges_and_deduplicates_repos():

--- a/tests/test_plugin_endpoint.py
+++ b/tests/test_plugin_endpoint.py
@@ -6,6 +6,7 @@ from app.api.endpoints.plugin import plugin_history
 from app.api.endpoints.plugin import plugin_releases
 from app.api.endpoints.plugin import reset_plugin
 from app.api.endpoints.system import sync_plugin_market_from_wiki
+from app.core.config import settings
 from app.schemas.event import PluginDataResetEventData
 from app.schemas.types import ChainEventType
 
@@ -75,14 +76,10 @@ def test_plugin_releases_returns_supported_versions_with_latest_and_current(monk
         repo_url="https://github.com/demo/plugins",
         release=True,
     )
-    installed_plugin = schemas.Plugin(
-        id="DemoPlugin",
-        plugin_version="1.2.0",
-        installed=True,
-    )
     plugin_manager = MagicMock()
     plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
-    plugin_manager.get_local_plugins.return_value = [installed_plugin]
+    plugin_manager.async_get_plugins_from_market = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugin_version.return_value = "1.2.0"
     plugin_helper = MagicMock()
     plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[
         {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},
@@ -102,7 +99,11 @@ def test_plugin_releases_returns_supported_versions_with_latest_and_current(monk
     assert result["items"][0]["is_current"] is False
     assert result["items"][1]["is_latest"] is False
     assert result["items"][1]["is_current"] is True
-    plugin_manager.async_get_online_plugins.assert_awaited_once_with(force=False)
+    plugin_manager.async_get_plugins_from_market.assert_awaited_once_with(
+        "https://github.com/demo/plugins", settings.VERSION_FLAG, False
+    )
+    plugin_manager.async_get_online_plugins.assert_not_awaited()
+    plugin_manager.get_local_plugins.assert_not_called()
 
 
 def test_plugin_releases_does_not_mutate_cached_release_items(monkeypatch):
@@ -115,17 +116,12 @@ def test_plugin_releases_does_not_mutate_cached_release_items(monkeypatch):
         repo_url="https://github.com/demo/plugins",
         release=True,
     )
-    installed_plugin = schemas.Plugin(
-        id="DemoPlugin",
-        plugin_version="1.2.0",
-        installed=True,
-    )
     release_items = [
         {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},
     ]
     plugin_manager = MagicMock()
-    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
-    plugin_manager.get_local_plugins.return_value = [installed_plugin]
+    plugin_manager.async_get_plugins_from_market = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugin_version.return_value = "1.2.0"
     plugin_helper = MagicMock()
     plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=release_items)
 
@@ -140,6 +136,39 @@ def test_plugin_releases_does_not_mutate_cached_release_items(monkeypatch):
     assert "is_current" not in release_items[0]
 
 
+def test_plugin_releases_falls_back_to_compatible_base_package(monkeypatch):
+    """
+    当前版本 package 未包含插件时，再读取基础 package 兼容项，不扫描其他市场。
+    """
+    market_plugin = schemas.Plugin(
+        id="DemoPlugin",
+        plugin_version="1.2.3",
+        repo_url="https://github.com/demo/plugins",
+        release=True,
+    )
+    plugin_manager = MagicMock()
+    plugin_manager.async_get_plugins_from_market = AsyncMock(
+        side_effect=[[], [market_plugin]]
+    )
+    plugin_manager.get_local_plugin_version.return_value = None
+    plugin_helper = MagicMock()
+    plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[])
+
+    with (
+        patch("app.api.endpoints.plugin.PluginManager", return_value=plugin_manager),
+        patch("app.api.endpoints.plugin.PluginHelper", return_value=plugin_helper),
+    ):
+        result = asyncio.run(
+            plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", False)
+        )
+
+    assert result["latest_version"] == "1.2.3"
+    assert plugin_manager.async_get_plugins_from_market.await_args_list == [
+        (("https://github.com/demo/plugins", settings.VERSION_FLAG, False), {}),
+        (("https://github.com/demo/plugins", None, False), {}),
+    ]
+
+
 def test_plugin_releases_uses_force_refresh_for_market_metadata(monkeypatch):
     """
     release 列表接口沿用插件市场的 force 语义，供前端手动刷新时绕过缓存。
@@ -151,8 +180,8 @@ def test_plugin_releases_uses_force_refresh_for_market_metadata(monkeypatch):
         release=True,
     )
     plugin_manager = MagicMock()
-    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
-    plugin_manager.get_local_plugins.return_value = []
+    plugin_manager.async_get_plugins_from_market = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugin_version.return_value = None
     plugin_helper = MagicMock()
     plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[])
 
@@ -163,8 +192,13 @@ def test_plugin_releases_uses_force_refresh_for_market_metadata(monkeypatch):
         result = asyncio.run(plugin_releases("DemoPlugin", None, "https://github.com/demo/plugins", True))
 
     assert result["release_supported"] is False
-    plugin_manager.async_get_online_plugins.assert_awaited_once_with(force=True)
-    assert plugin_helper.async_get_plugin_release_versions.await_args.args == ("DemoPlugin", "https://github.com/demo/plugins")
+    plugin_manager.async_get_plugins_from_market.assert_awaited_once_with(
+        "https://github.com/demo/plugins", settings.VERSION_FLAG, True
+    )
+    assert plugin_helper.async_get_plugin_release_versions.await_args.args == (
+        "DemoPlugin",
+        "https://github.com/demo/plugins",
+    )
 
 
 def test_plugin_releases_hides_items_when_market_plugin_does_not_enable_release(monkeypatch):
@@ -178,8 +212,8 @@ def test_plugin_releases_hides_items_when_market_plugin_does_not_enable_release(
         release=False,
     )
     plugin_manager = MagicMock()
-    plugin_manager.async_get_online_plugins = AsyncMock(return_value=[market_plugin])
-    plugin_manager.get_local_plugins.return_value = []
+    plugin_manager.async_get_plugins_from_market = AsyncMock(return_value=[market_plugin])
+    plugin_manager.get_local_plugin_version.return_value = None
     plugin_helper = MagicMock()
     plugin_helper.async_get_plugin_release_versions = AsyncMock(return_value=[
         {"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3", "asset_name": "demoplugin_v1.2.3.zip"},

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -39,6 +39,18 @@ class _FakeContentResponse(_FakeResponse):
         self.content = content
 
 
+class _FakeTextResponse(_FakeResponse):
+    """带文本正文的响应对象，用于模拟 GitHub release 列表响应。"""
+
+    def __init__(self, status_code: int, payload: list[dict] | dict):
+        super().__init__(status_code, payload if isinstance(payload, dict) else {})
+        self._payload = payload
+
+    def json(self):
+        """返回构造时注入的 JSON payload。"""
+        return self._payload
+
+
 def _build_zip(entries: dict[str, bytes]) -> bytes:
     """构造内存 zip 包，键为包内路径、值为文件内容。"""
     buffer = io.BytesIO()
@@ -203,6 +215,134 @@ class TestPluginHelper:
 
         assert success
         assert "" == message
+
+    def test_get_plugin_release_versions_keeps_only_matching_zip_assets(self, monkeypatch):
+        """
+        release 版本列表只暴露符合插件 tag 规范且存在同名 zip 资产的版本。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        payload = [
+            {
+                "tag_name": "DemoPlugin_v1.2.3",
+                "name": "DemoPlugin v1.2.3",
+                "published_at": "2026-06-01T00:00:00Z",
+                "body": "稳定版本",
+                "assets": [{"name": "demoplugin_v1.2.3.zip", "id": 1}],
+            },
+            {
+                "tag_name": "DemoPlugin_v1.2.2",
+                "name": "missing asset",
+                "assets": [{"name": "other.zip", "id": 2}],
+            },
+            {
+                "tag_name": "OtherPlugin_v9.9.9",
+                "name": "other plugin",
+                "assets": [{"name": "otherplugin_v9.9.9.zip", "id": 3}],
+            },
+        ]
+        helper = PluginHelper()
+        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", lambda *_args, **_kwargs: _FakeTextResponse(200, payload))
+
+        releases = helper.get_plugin_release_versions(PLUGIN_ID, REPO_URL)
+
+        assert releases == [
+            {
+                "version": "1.2.3",
+                "tag_name": "DemoPlugin_v1.2.3",
+                "name": "DemoPlugin v1.2.3",
+                "published_at": "2026-06-01T00:00:00Z",
+                "body": "稳定版本",
+                "asset_name": "demoplugin_v1.2.3.zip",
+            }
+        ]
+
+    def test_get_plugin_release_versions_uses_cache_buster_during_fresh_context(self, monkeypatch):
+        """
+        插件市场强制刷新时 Release 列表请求也要绕过 GitHub 镜像或代理缓存。
+        """
+        try:
+            from app.core.cache import fresh
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        requested_urls = []
+
+        def fake_request(url, **_kwargs):
+            requested_urls.append(url)
+            return _FakeTextResponse(200, [])
+
+        helper = PluginHelper()
+        helper.get_plugin_release_versions.cache_clear()
+        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", fake_request)
+
+        with patch("app.helper.plugin.time.time_ns", return_value=1234567890):
+            with fresh(True):
+                helper.get_plugin_release_versions(PLUGIN_ID, REPO_URL)
+
+        assert requested_urls == [
+            "https://api.github.com/repos/demo/MoviePilot-Plugins/releases?per_page=100&page=1&_refresh=1234567890"
+        ]
+
+    def test_get_plugin_release_versions_fetches_multiple_pages(self, monkeypatch):
+        """
+        多插件共用 Release 列表时需要分页，避免目标插件历史发行版被第一页之外的数据遮蔽。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        payload_by_page = {
+            "1": [
+                {
+                    "tag_name": f"OtherPlugin_v9.9.{index}",
+                    "assets": [{"name": f"otherplugin_v9.9.{index}.zip", "id": index}],
+                }
+                for index in range(100)
+            ],
+            "2": [{"tag_name": "DemoPlugin_v1.2.0", "assets": [{"name": "demoplugin_v1.2.0.zip", "id": 2}]}],
+        }
+        requested_pages = []
+
+        def fake_request(url, **_kwargs):
+            page = url.rsplit("page=", 1)[1].split("&", 1)[0]
+            requested_pages.append(page)
+            return _FakeTextResponse(200, payload_by_page[page])
+
+        helper = PluginHelper()
+        helper.get_plugin_release_versions.cache_clear()
+        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", fake_request)
+
+        releases = helper.get_plugin_release_versions(PLUGIN_ID, REPO_URL)
+
+        assert requested_pages == ["1", "2"]
+        assert [item["version"] for item in releases] == ["1.2.0"]
+
+    def test_get_online_plugins_force_clears_release_cache(self, monkeypatch):
+        """
+        插件市场缓存刷新会一并清理 Release 列表缓存，覆盖定时刷新服务入口。
+        """
+        try:
+            from app.core.plugin import PluginManager
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        clear_calls = []
+        fake_release_method = SimpleNamespace(cache_clear=lambda: clear_calls.append("clear"))
+        fake_helper = SimpleNamespace(get_plugin_release_versions=fake_release_method)
+        monkeypatch.setattr("app.core.plugin.settings.PLUGIN_MARKET", "https://github.com/demo/plugins")
+        monkeypatch.setattr("app.core.plugin.PluginHelper", lambda: fake_helper)
+        monkeypatch.setattr(PluginManager, "get_plugins_from_market", lambda *_args, **_kwargs: [])
+
+        PluginManager().get_online_plugins(force=True)
+
+        assert clear_calls == ["clear"]
 
     def test_annotate_plugin_system_version_marks_incompatible(self):
         """
@@ -660,6 +800,99 @@ class TestPluginHelper:
         assert "MoviePilot 版本 >=9.0.0" in message
         assert [] == calls
 
+    def test_install_rejects_latest_release_version_when_system_version_is_incompatible(self, monkeypatch):
+        """
+        指定安装当前最新 release 时仍按当前 package 元数据校验主程序版本。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        helper = PluginHelper()
+        calls = _patch_sync_remote_install(
+            helper,
+            monkeypatch,
+            {"release": True, "version": "1.2.3", "system_version": ">=9.0.0"},
+            (True, ""),
+        )
+        monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.0.0"))
+        monkeypatch.setattr(
+            helper,
+            "get_plugin_release_versions",
+            lambda *_args: [{"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3"}],
+        )
+
+        success, message = helper.install(
+            PLUGIN_ID, REPO_URL, package_version="v2", release_version="1.2.3", force_install=True
+        )
+
+        assert not success
+        assert "MoviePilot 版本 >=9.0.0" in message
+        assert [] == calls
+
+    def test_install_old_release_version_uses_release_asset_without_filelist_fallback(self, monkeypatch):
+        """
+        指定旧 release 版本时直接安装对应资产，失败也不回退当前分支文件列表。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        helper = PluginHelper()
+        calls = _patch_sync_remote_install(
+            helper,
+            monkeypatch,
+            {"release": True, "version": "1.2.3", "system_version": ">=9.0.0"},
+            (False, "未找到资产文件：demoplugin_v1.2.0.zip"),
+            (True, ""),
+        )
+        monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.0.0"))
+        monkeypatch.setattr(
+            helper,
+            "get_plugin_release_versions",
+            lambda *_args: [{"version": "1.2.0", "tag_name": "DemoPlugin_v1.2.0"}],
+        )
+
+        success, message = helper.install(
+            PLUGIN_ID, REPO_URL, package_version="v2", release_version="1.2.0", force_install=True
+        )
+
+        assert not success
+        assert "未找到资产文件：demoplugin_v1.2.0.zip" == message
+        assert ["remove", "release", "remove"] == calls
+
+    def test_install_rejects_release_version_missing_from_release_list(self, monkeypatch):
+        """
+        指定版本必须来自可安装 Release 列表，避免客户端绕过前端约束拼接任意 tag。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        helper = PluginHelper()
+        calls = _patch_sync_remote_install(
+            helper,
+            monkeypatch,
+            {"release": True, "version": "1.2.3"},
+            (True, ""),
+        )
+        monkeypatch.setattr(
+            helper,
+            "get_plugin_release_versions",
+            lambda *_args: [{"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3"}],
+        )
+
+        success, message = helper.install(
+            PLUGIN_ID, REPO_URL, package_version="v2", release_version="1.2.0", force_install=True
+        )
+
+        assert not success
+        assert f"{PLUGIN_ID} 未找到可安装的 Release 版本：1.2.0" == message
+        assert [] == calls
+
     def test_install_rejects_invalid_parameters_before_remote_lookup(self):
         """
         远端安装缺少插件 ID 或仓库地址时直接拒绝。
@@ -823,6 +1056,72 @@ class TestPluginHelper:
         assert "" == message
         assert calls[:4] == ["remove", "release", "remove", "filelist"]
         assert calls[4][0] == "to_thread"
+
+    def test_async_install_old_release_version_uses_release_asset_without_filelist_fallback(self, monkeypatch):
+        """
+        异步路径指定旧 release 版本时直接安装对应资产，失败也不回退当前分支文件列表。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        helper = PluginHelper()
+        calls = _patch_async_remote_install(
+            helper,
+            monkeypatch,
+            {"release": True, "version": "1.2.3", "system_version": ">=9.0.0"},
+            (False, "未找到资产文件：demoplugin_v1.2.0.zip"),
+            (True, ""),
+        )
+        monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.0.0"))
+
+        async def fake_releases(*_args):
+            return [{"version": "1.2.0", "tag_name": "DemoPlugin_v1.2.0"}]
+
+        monkeypatch.setattr(helper, "async_get_plugin_release_versions", fake_releases)
+
+        success, message = asyncio.run(
+            helper.async_install(
+                PLUGIN_ID, REPO_URL, package_version="v2", release_version="1.2.0", force_install=True
+            )
+        )
+
+        assert not success
+        assert "未找到资产文件：demoplugin_v1.2.0.zip" == message
+        assert calls[:3] == ["remove", "release", "remove"]
+
+    def test_async_install_rejects_release_version_missing_from_release_list(self, monkeypatch):
+        """
+        异步安装同样只接受 Release 列表中存在的指定版本。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        helper = PluginHelper()
+        calls = _patch_async_remote_install(
+            helper,
+            monkeypatch,
+            {"release": True, "version": "1.2.3"},
+            (True, ""),
+        )
+
+        async def fake_releases(*_args):
+            return [{"version": "1.2.3", "tag_name": "DemoPlugin_v1.2.3"}]
+
+        monkeypatch.setattr(helper, "async_get_plugin_release_versions", fake_releases)
+
+        success, message = asyncio.run(
+            helper.async_install(
+                PLUGIN_ID, REPO_URL, package_version="v2", release_version="1.2.0", force_install=True
+            )
+        )
+
+        assert not success
+        assert f"{PLUGIN_ID} 未找到可安装的 Release 版本：1.2.0" == message
+        assert [] == calls
 
     def test_async_install_reports_filelist_error_after_release_fallback_fails(self, monkeypatch):
         """

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -495,6 +495,39 @@ class TestPluginHelper:
         assert [item["version"] for item in cached] == ["1.2.3"]
         assert responses == []
 
+    def test_get_plugins_from_market_normalizes_list_labels(self, monkeypatch) -> None:
+        """
+        插件市场 labels 为列表时应转换为字符串，避免响应模型序列化异常。
+        """
+        try:
+            from app.core.plugin import PluginManager
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        market_plugins = {
+            "DemoPlugin": {
+                "name": "Demo Plugin",
+                "description": "Demo",
+                "version": "1.0.0",
+                "labels": ["站点", "通知", ""],
+                "v2": True,
+            }
+        }
+        plugin_manager = PluginManager()
+        monkeypatch.setattr(plugin_manager, "_plugins", {})
+        monkeypatch.setattr(plugin_manager, "_running_plugins", {})
+        monkeypatch.setattr("app.helper.plugin_manager.settings", SimpleNamespace(VERSION_FLAG="v2"))
+        monkeypatch.setattr("app.helper.plugin_manager.SystemConfigOper", lambda: SimpleNamespace(get=lambda _key: []))
+        monkeypatch.setattr("app.helper.plugin_manager.get_auth_level", lambda: 999)
+        monkeypatch.setattr(PluginHelper, "get_plugins", lambda _self, *_args: market_plugins)
+
+        plugins = plugin_manager.get_plugins_from_market(REPO_URL)
+
+        assert len(plugins) == 1
+        assert plugins[0].plugin_label == "站点 通知"
+        assert plugins[0].model_dump()["plugin_label"] == "站点 通知"
+
     def test_get_online_plugins_force_keeps_release_cache_scoped(self, monkeypatch):
         """
         全市场刷新不清理 Release 缓存，Release 接口按请求仓库协调刷新两类数据。

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -336,8 +336,8 @@ class TestPluginHelper:
         clear_calls = []
         fake_release_method = SimpleNamespace(cache_clear=lambda: clear_calls.append("clear"))
         fake_helper = SimpleNamespace(get_plugin_release_versions=fake_release_method)
-        monkeypatch.setattr("app.core.plugin.settings.PLUGIN_MARKET", "https://github.com/demo/plugins")
-        monkeypatch.setattr("app.core.plugin.PluginHelper", lambda: fake_helper)
+        monkeypatch.setattr("app.helper.plugin_manager.settings.PLUGIN_MARKET", "https://github.com/demo/plugins")
+        monkeypatch.setattr("app.helper.plugin.PluginHelper", lambda: fake_helper)
         monkeypatch.setattr(PluginManager, "get_plugins_from_market", lambda *_args, **_kwargs: [])
 
         PluginManager().get_online_plugins(force=True)

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -245,7 +245,11 @@ class TestPluginHelper:
             },
         ]
         helper = PluginHelper()
-        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", lambda *_args, **_kwargs: _FakeTextResponse(200, payload))
+        monkeypatch.setattr(
+            helper,
+            "_PluginHelper__request_with_fallback",
+            lambda *_args, **_kwargs: _FakeTextResponse(200, payload),
+        )
 
         releases = helper.get_plugin_release_versions(PLUGIN_ID, REPO_URL)
 
@@ -323,9 +327,177 @@ class TestPluginHelper:
         assert requested_pages == ["1", "2"]
         assert [item["version"] for item in releases] == ["1.2.0"]
 
-    def test_get_online_plugins_force_clears_release_cache(self, monkeypatch):
+    def test_get_plugin_release_versions_reuses_repository_pages_across_plugins(self, monkeypatch):
         """
-        插件市场缓存刷新会一并清理 Release 列表缓存，覆盖定时刷新服务入口。
+        同一仓库的不同插件共享 GitHub Release 分页结果，避免按插件 ID 重复请求。
+        """
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        payload = [
+            {
+                "tag_name": "DemoPlugin_v1.2.3",
+                "assets": [{"name": "demoplugin_v1.2.3.zip", "id": 1}],
+            },
+            {
+                "tag_name": "OtherPlugin_v2.0.0",
+                "assets": [{"name": "otherplugin_v2.0.0.zip", "id": 2}],
+            },
+        ]
+        request_count = 0
+
+        def fake_request(*_args, **_kwargs):
+            nonlocal request_count
+            request_count += 1
+            return _FakeTextResponse(200, payload)
+
+        helper = PluginHelper()
+        helper.get_plugin_release_versions.cache_clear()
+        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", fake_request)
+
+        demo_releases = helper.get_plugin_release_versions("DemoPlugin", REPO_URL)
+        other_releases = helper.get_plugin_release_versions("OtherPlugin", REPO_URL)
+
+        assert request_count == 1
+        assert [item["version"] for item in demo_releases] == ["1.2.3"]
+        assert [item["version"] for item in other_releases] == ["2.0.0"]
+
+    def test_async_get_plugin_release_versions_coalesces_forced_repository_requests(self, monkeypatch):
+        """
+        同一仓库的并发强制刷新共享一个请求任务，避免缓存失效瞬间放大 GitHub 请求。
+        """
+        try:
+            from app.core.cache import async_fresh
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        payload = [
+            {
+                "tag_name": "DemoPlugin_v1.2.3",
+                "assets": [{"name": "demoplugin_v1.2.3.zip", "id": 1}],
+            },
+            {
+                "tag_name": "OtherPlugin_v2.0.0",
+                "assets": [{"name": "otherplugin_v2.0.0.zip", "id": 2}],
+            },
+        ]
+        request_count = 0
+
+        async def fake_request(*_args, **_kwargs):
+            nonlocal request_count
+            request_count += 1
+            await asyncio.sleep(0.01)
+            return _FakeTextResponse(200, payload)
+
+        async def run_test():
+            helper = PluginHelper()
+            await helper.async_get_plugin_release_versions.cache_clear()
+            monkeypatch.setattr(helper, "_PluginHelper__async_request_with_fallback", fake_request)
+            async with async_fresh(True):
+                return await asyncio.gather(
+                    helper.async_get_plugin_release_versions("DemoPlugin", REPO_URL),
+                    helper.async_get_plugin_release_versions("OtherPlugin", REPO_URL),
+                )
+
+        demo_releases, other_releases = asyncio.run(run_test())
+
+        assert request_count == 1
+        assert [item["version"] for item in demo_releases] == ["1.2.3"]
+        assert [item["version"] for item in other_releases] == ["2.0.0"]
+
+    def test_async_forced_release_refresh_does_not_reuse_normal_read_task(self, monkeypatch):
+        """强刷等待在途普通读取后再请求，最终缓存必须保留强刷结果。"""
+        try:
+            from app.core.cache import async_fresh
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        old_payload = [{
+            "tag_name": "DemoPlugin_v1.2.2",
+            "assets": [{"name": "demoplugin_v1.2.2.zip", "id": 1}],
+        }]
+        fresh_payload = [{
+            "tag_name": "DemoPlugin_v1.2.3",
+            "assets": [{"name": "demoplugin_v1.2.3.zip", "id": 2}],
+        }]
+        first_request_started = asyncio.Event()
+        release_first_request = asyncio.Event()
+        request_count = 0
+
+        async def fake_request(*_args, **_kwargs):
+            nonlocal request_count
+            request_count += 1
+            if request_count == 1:
+                first_request_started.set()
+                await release_first_request.wait()
+                return _FakeTextResponse(200, old_payload)
+            return _FakeTextResponse(200, fresh_payload)
+
+        async def run_test():
+            helper = PluginHelper()
+            await helper.async_get_plugin_release_versions.cache_clear()
+            monkeypatch.setattr(helper, "_PluginHelper__async_request_with_fallback", fake_request)
+            normal_task = asyncio.create_task(
+                helper.async_get_plugin_release_versions("DemoPlugin", REPO_URL)
+            )
+            await first_request_started.wait()
+            async with async_fresh(True):
+                force_task = asyncio.create_task(
+                    helper.async_get_plugin_release_versions("DemoPlugin", REPO_URL)
+                )
+                await asyncio.sleep(0.01)
+                request_count_before_normal_finished = request_count
+            release_first_request.set()
+            normal_result, force_result = await asyncio.gather(normal_task, force_task)
+            cached_result = await helper.async_get_plugin_release_versions("DemoPlugin", REPO_URL)
+            return request_count_before_normal_finished, normal_result, force_result, cached_result
+
+        request_count_before_normal_finished, normal_result, force_result, cached_result = asyncio.run(run_test())
+
+        assert request_count_before_normal_finished == 1
+        assert [item["version"] for item in normal_result] == ["1.2.2"]
+        assert [item["version"] for item in force_result] == ["1.2.3"]
+        assert [item["version"] for item in cached_result] == ["1.2.3"]
+        assert request_count == 2
+
+    def test_failed_forced_release_refresh_preserves_cached_repository_payload(self, monkeypatch):
+        """GitHub 强刷失败时不以空值覆盖该仓库已有 Release 缓存。"""
+        try:
+            from app.core.cache import fresh
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        payload = [{
+            "tag_name": "DemoPlugin_v1.2.3",
+            "assets": [{"name": "demoplugin_v1.2.3.zip", "id": 1}],
+        }]
+        responses = [_FakeTextResponse(200, payload), None]
+
+        def fake_request(*_args, **_kwargs):
+            return responses.pop(0)
+
+        helper = PluginHelper()
+        helper.get_plugin_release_versions.cache_clear()
+        monkeypatch.setattr(helper, "_PluginHelper__request_with_fallback", fake_request)
+
+        initial = helper.get_plugin_release_versions("DemoPlugin", REPO_URL)
+        with fresh(True):
+            failed_refresh = helper.get_plugin_release_versions("DemoPlugin", REPO_URL)
+        cached = helper.get_plugin_release_versions("DemoPlugin", REPO_URL)
+
+        assert [item["version"] for item in initial] == ["1.2.3"]
+        assert failed_refresh == []
+        assert [item["version"] for item in cached] == ["1.2.3"]
+        assert responses == []
+
+    def test_get_online_plugins_force_keeps_release_cache_scoped(self, monkeypatch):
+        """
+        全市场刷新不清理 Release 缓存，Release 接口按请求仓库协调刷新两类数据。
         """
         try:
             from app.core.plugin import PluginManager
@@ -342,7 +514,56 @@ class TestPluginHelper:
 
         PluginManager().get_online_plugins(force=True)
 
-        assert clear_calls == ["clear"]
+        assert clear_calls == []
+
+    def test_async_get_online_plugins_force_keeps_release_cache_scoped(self, monkeypatch):
+        """异步全市场刷新同样不得清理其他仓库的 Release 缓存。"""
+        try:
+            from app.core.plugin import PluginManager
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        clear_calls = []
+
+        async def fake_clear():
+            clear_calls.append("clear")
+
+        fake_release_method = SimpleNamespace(cache_clear=fake_clear)
+        fake_helper = SimpleNamespace(async_get_plugin_release_versions=fake_release_method)
+
+        async def fake_market(*_args, **_kwargs):
+            return []
+
+        monkeypatch.setattr("app.helper.plugin_manager.settings.PLUGIN_MARKET", "https://github.com/demo/plugins")
+        monkeypatch.setattr("app.helper.plugin.PluginHelper", lambda: fake_helper)
+        monkeypatch.setattr(PluginManager, "async_get_plugins_from_market", fake_market)
+
+        asyncio.run(PluginManager().async_get_online_plugins(force=True))
+
+        assert clear_calls == []
+
+    def test_get_local_plugin_version_reads_only_requested_installed_plugin(self, monkeypatch):
+        """单插件版本查询不构建全部本地插件信息。"""
+        try:
+            from app.core.plugin import PluginManager
+            from app.db.systemconfig_oper import SystemConfigOper
+            from app.schemas.types import SystemConfigKey
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        class DemoPlugin:
+            plugin_version = "1.2.0"
+
+        plugin_manager = PluginManager()
+        monkeypatch.setattr(plugin_manager, "_plugins", {"DemoPlugin": DemoPlugin})
+        monkeypatch.setattr(
+            SystemConfigOper,
+            "get",
+            lambda _self, key: ["DemoPlugin"] if key == SystemConfigKey.UserInstalledPlugins else None,
+        )
+
+        assert plugin_manager.get_local_plugin_version("DemoPlugin") == "1.2.0"
+        assert plugin_manager.get_local_plugin_version("OtherPlugin") is None
 
     def test_annotate_plugin_system_version_marks_incompatible(self):
         """

--- a/tests/test_plugin_local_sync.py
+++ b/tests/test_plugin_local_sync.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+from packaging.version import Version
+
+from app.helper.plugin_manager import PluginManager
+from app.helper.plugin import PluginHelper
+from app.schemas.types import SystemConfigKey
+from app.utils.singleton import Singleton
+
+
+@pytest.fixture
+def plugin_manager() -> Iterator[PluginManager]:
+    """构造隔离的插件管理器实例，避免单例状态污染其它用例。"""
+    Singleton._instances.pop((PluginManager, (), frozenset()), None)
+    manager = PluginManager()
+    yield manager
+    Singleton._instances.pop((PluginManager, (), frozenset()), None)
+
+
+def _build_local_plugin_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """构造带系统版本要求的本地 v2 插件仓库。"""
+    repo_path = tmp_path / "local-plugins"
+    source_dir = repo_path / "plugins.v2" / "demoplugin"
+    source_file = source_dir / "__init__.py"
+    source_dir.mkdir(parents=True)
+    source_file.write_text(
+        "from app.plugins import _PluginBase\n"
+        "class DemoPlugin(_PluginBase):\n"
+        "    plugin_name = 'Demo'\n",
+        encoding="utf-8",
+    )
+    (repo_path / "package.v2.json").write_text(
+        '{"DemoPlugin": {"version": "1.0.0", "system_version": ">=2.13.11"}}',
+        encoding="utf-8",
+    )
+    return repo_path, source_file
+
+
+def test_dev_local_plugin_candidate_keeps_hot_sync_allowed_when_system_version_lags(
+    tmp_path,
+    monkeypatch,
+    plugin_manager: PluginManager,
+) -> None:
+    """DEV 本地源码候选保留热同步资格，系统版本差异只作为兼容性提示。"""
+    repo_path, source_file = _build_local_plugin_repo(tmp_path)
+    runtime_dir = tmp_path / "app" / "plugins" / "demoplugin"
+
+    monkeypatch.setattr("app.helper.plugin_manager.settings", SimpleNamespace(DEV=True, ROOT_PATH=tmp_path))
+    monkeypatch.setattr("app.helper.plugin.settings.PLUGIN_LOCAL_REPO_PATHS", str(repo_path))
+    monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.13.10"))
+    monkeypatch.setattr(
+        "app.helper.plugin_manager.SystemConfigOper.get",
+        lambda _self, key: ["DemoPlugin"] if key == SystemConfigKey.UserInstalledPlugins else None,
+    )
+
+    candidate = plugin_manager._get_local_plugin_candidate_from_path(source_file)
+
+    assert candidate["system_version_compatible"] is False
+    assert candidate.get("compatible") is not False
+    assert plugin_manager._sync_local_plugin_if_installed("DemoPlugin", candidate)
+    assert (runtime_dir / "__init__.py").read_text(encoding="utf-8") == source_file.read_text(encoding="utf-8")
+
+
+def test_local_plugin_candidate_keeps_system_version_gate_outside_dev(
+    tmp_path,
+    monkeypatch,
+    plugin_manager: PluginManager,
+) -> None:
+    """非 DEV 本地候选继续受主系统版本门禁保护，避免自动热加载绕过安装约束。"""
+    repo_path, source_file = _build_local_plugin_repo(tmp_path)
+
+    monkeypatch.setattr("app.helper.plugin_manager.settings", SimpleNamespace(DEV=False, ROOT_PATH=tmp_path))
+    monkeypatch.setattr("app.helper.plugin.settings.PLUGIN_LOCAL_REPO_PATHS", str(repo_path))
+    monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.13.10"))
+
+    candidate = plugin_manager._get_local_plugin_candidate_from_path(source_file)
+
+    assert candidate["system_version_compatible"] is False
+    assert candidate["compatible"] is False
+    assert "MoviePilot 版本 >=2.13.11" in candidate["skip_reason"]
+
+
+def test_local_plugin_sync_without_candidate_respects_system_version_gate(
+    tmp_path,
+    monkeypatch,
+    plugin_manager: PluginManager,
+) -> None:
+    """未传候选时的本地同步兜底查询也必须遵守系统版本门禁。"""
+    repo_path, _source_file = _build_local_plugin_repo(tmp_path)
+    runtime_dir = tmp_path / "app" / "plugins" / "demoplugin"
+    settings_stub = SimpleNamespace(
+        DEV=False,
+        ROOT_PATH=tmp_path,
+        VERSION_FLAG="v2",
+        PLUGIN_LOCAL_REPO_PATHS=str(repo_path),
+    )
+
+    monkeypatch.setattr("app.helper.plugin_manager.settings", settings_stub)
+    monkeypatch.setattr("app.helper.plugin.settings", settings_stub)
+    monkeypatch.setattr(PluginHelper, "get_current_system_version", lambda: Version("2.13.10"))
+    monkeypatch.setattr(
+        "app.helper.plugin_manager.SystemConfigOper.get",
+        lambda _self, key: ["DemoPlugin"] if key == SystemConfigKey.UserInstalledPlugins else None,
+    )
+
+    assert not plugin_manager._sync_local_plugin_if_installed("DemoPlugin")
+    assert not runtime_dir.exists()

--- a/tests/test_publish_moviepilot_plugin_skill.py
+++ b/tests/test_publish_moviepilot_plugin_skill.py
@@ -1,8 +1,9 @@
 import importlib.util
 import json
 import sys
+from argparse import Namespace
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 def load_publish_plugin_module() -> Any:
@@ -68,3 +69,159 @@ def test_merge_package_content_preserves_other_plugins() -> None:
 
     assert package_data["OtherPlugin"] == {"name": "其他插件", "version": "1.0.0"}
     assert package_data["MyPlugin"] == {"name": "新插件", "version": "1.0.0"}
+
+
+def test_push_creates_public_repo_when_explicitly_requested(tmp_path: Path) -> None:
+    """显式允许自动建仓时，推送会默认创建公开仓库。"""
+    module = load_publish_plugin_module()
+    plugin_dir = tmp_path / "plugins.v2" / "myplugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text("class MyPlugin:\n    pass\n", encoding="utf-8")
+    (tmp_path / "package.v2.json").write_text(
+        json.dumps({"MyPlugin": {"name": "测试插件", "version": "1.0.0"}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    class FakeClient:
+        """模拟缺失仓库的 GitHub 客户端。"""
+
+        def __init__(self) -> None:
+            """初始化调用记录。"""
+            self.created_private = None
+            self.put_paths: list[str] = []
+
+        def repo_exists(self) -> bool:
+            """返回仓库不存在。"""
+            return False
+
+        def create_repo(self, private: bool = False) -> dict[str, Any]:
+            """记录建仓可见性。"""
+            self.created_private = private
+            return {"private": private, "html_url": "https://github.com/example/repo"}
+
+        def put_file(
+            self,
+            path: str,
+            content: bytes,
+            message: str,
+            sha: Optional[str] = None,
+        ) -> dict[str, Any]:
+            """记录上传路径。"""
+            self.put_paths.append(path)
+            return {"content": {"path": path}}
+
+        def delete_file(self, path: str, message: str, sha: str) -> dict[str, Any]:
+            """记录删除路径。"""
+            return {"content": {"path": path}}
+
+    fake_client = FakeClient()
+
+    def fake_build_context(args: Namespace, require_token: bool = False) -> dict[str, Any]:
+        """构造无需访问网络的推送上下文。"""
+        layout = module.Layout(package_file="package.v2.json", plugin_root="plugins.v2")
+        return {
+            "repo": args.repo,
+            "branch": args.branch,
+            "local_repo": tmp_path,
+            "layout": layout,
+            "plugin_id": args.plugin_id,
+            "remote_prefix": module.remote_plugin_prefix(layout, args.plugin_id),
+            "client": fake_client,
+            "excludes": list(module.DEFAULT_EXCLUDES),
+            "includes": [],
+        }
+
+    original_build_context = module.build_context
+    module.build_context = fake_build_context
+    try:
+        payload = module.push(
+            Namespace(
+                command="push",
+                repo="example/repo",
+                plugin_id="MyPlugin",
+                local_repo=str(tmp_path),
+                package_version="v2",
+                branch="main",
+                token="token",
+                message="Publish MyPlugin",
+                api_base=module.GITHUB_API_BASE,
+                proxy="",
+                timeout=module.DEFAULT_TIMEOUT,
+                include=[],
+                exclude=[],
+                delete_remote=False,
+                create_repo_if_missing=True,
+                private=False,
+                force=False,
+                dry_run=False,
+            )
+        )
+    finally:
+        module.build_context = original_build_context
+
+    assert payload["repo_existed"] is False
+    assert fake_client.created_private is False
+    assert "package.v2.json" in fake_client.put_paths
+    assert "plugins.v2/myplugin/__init__.py" in fake_client.put_paths
+
+
+def test_create_repo_dry_run_does_not_touch_github() -> None:
+    """建仓 dry-run 不访问 GitHub，只返回计划。"""
+    module = load_publish_plugin_module()
+
+    class FakeClient:
+        """模拟不应被调用的 GitHub 客户端。"""
+
+        def repo_exists(self) -> bool:
+            """如果被调用则说明 dry-run 行为错误。"""
+            raise AssertionError("dry-run should not query GitHub")
+
+        def create_repo(self, private: bool = False) -> dict[str, Any]:
+            """如果被调用则说明 dry-run 行为错误。"""
+            raise AssertionError("dry-run should not create GitHub repo")
+
+    def fake_build_context(args: Namespace, require_token: bool = False) -> dict[str, Any]:
+        """构造无需访问网络的建仓上下文。"""
+        return {
+            "repo": args.repo,
+            "branch": args.branch,
+            "local_repo": Path.cwd(),
+            "layout": module.Layout(package_file="package.v2.json", plugin_root="plugins.v2"),
+            "plugin_id": "",
+            "remote_prefix": "",
+            "client": FakeClient(),
+            "excludes": list(module.DEFAULT_EXCLUDES),
+            "includes": [],
+        }
+
+    original_build_context = module.build_context
+    module.build_context = fake_build_context
+    try:
+        payload = module.create_repo(
+            Namespace(
+                command="create-repo",
+                repo="example/repo",
+                plugin_id="",
+                local_repo="",
+                package_version="auto",
+                branch="main",
+                token="",
+                message="",
+                api_base=module.GITHUB_API_BASE,
+                proxy="",
+                timeout=module.DEFAULT_TIMEOUT,
+                include=[],
+                exclude=[],
+                delete_remote=False,
+                create_repo_if_missing=False,
+                private=False,
+                force=False,
+                dry_run=True,
+            )
+        )
+    finally:
+        module.build_context = original_build_context
+
+    assert payload["success"] is True
+    assert payload["dry_run"] is True
+    assert payload["private"] is False

--- a/tests/test_publish_moviepilot_plugin_skill.py
+++ b/tests/test_publish_moviepilot_plugin_skill.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_publish_plugin_module() -> Any:
+    """加载插件发布脚本模块。"""
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "skills"
+        / "publish-moviepilot-plugin"
+        / "scripts"
+        / "publish_plugin.py"
+    )
+    spec = importlib.util.spec_from_file_location("publish_plugin_skill", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_collect_local_files_excludes_secrets_and_keeps_dist(tmp_path: Path) -> None:
+    """收集本地插件文件时应排除敏感文件并保留前端构建产物。"""
+    module = load_publish_plugin_module()
+    plugin_dir = tmp_path / "plugins.v2" / "myplugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text("class MyPlugin:\n    pass\n", encoding="utf-8")
+    (plugin_dir / ".env").write_text("SECRET=1\n", encoding="utf-8")
+    (plugin_dir / "dist" / "assets").mkdir(parents=True)
+    (plugin_dir / "dist" / "assets" / "remoteEntry.js").write_text(
+        "export default {};\n",
+        encoding="utf-8",
+    )
+
+    layout = module.Layout(package_file="package.v2.json", plugin_root="plugins.v2")
+    files, rejected = module.collect_local_files(
+        tmp_path,
+        layout,
+        "MyPlugin",
+        list(module.DEFAULT_EXCLUDES),
+        [],
+    )
+
+    assert "plugins.v2/myplugin/__init__.py" in files
+    assert "plugins.v2/myplugin/dist/assets/remoteEntry.js" in files
+    assert rejected == {"plugins.v2/myplugin/.env": ".env"}
+
+
+def test_merge_package_content_preserves_other_plugins() -> None:
+    """合并 package 文件时只更新目标插件条目。"""
+    module = load_publish_plugin_module()
+    remote_content = json.dumps(
+        {
+            "OtherPlugin": {"name": "其他插件", "version": "1.0.0"},
+            "MyPlugin": {"name": "旧插件", "version": "0.9.0"},
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    merged = module.merge_package_content(
+        remote_content,
+        "MyPlugin",
+        {"name": "新插件", "version": "1.0.0"},
+    )
+    package_data = json.loads(merged.decode("utf-8"))
+
+    assert package_data["OtherPlugin"] == {"name": "其他插件", "version": "1.0.0"}
+    assert package_data["MyPlugin"] == {"name": "新插件", "version": "1.0.0"}

--- a/tests/test_search_ai_recommend.py
+++ b/tests/test_search_ai_recommend.py
@@ -122,7 +122,6 @@ class SearchChainAIRecommendTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual("[0, 2]", result)
         self.assertEqual(ReplyMode.CAPTURE_ONLY, captured["reply_mode"])
-        self.assertFalse(captured["persist_output_message"])
         self.assertFalse(captured["allow_message_tools"])
 
     def test_search_by_title_clears_previous_recommend_state_when_caching(self):

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -126,11 +126,13 @@ def _load_subscribe_chain_class():
                 setattr(self, key, value)
 
     class _NotExistMediaInfo:
-        def __init__(self, season=None, episodes=None, total_episode=None, start_episode=None):
+        def __init__(self, season=None, episodes=None, total_episode=None, start_episode=None,
+                     require_complete_coverage=False):
             self.season = season
             self.episodes = episodes or []
             self.total_episode = total_episode
             self.start_episode = start_episode
+            self.require_complete_coverage = require_complete_coverage
 
     class _SubscribeEpisodeInfo:
         def __init__(self):
@@ -461,7 +463,13 @@ class SubscribeChainTest(TestCase):
         """自定义开始集跳过季初集数时，缺失整季需要转成显式目标集。"""
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[], total_episode=48, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[],
+                    total_episode=48,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
 
@@ -483,7 +491,13 @@ class SubscribeChainTest(TestCase):
         """自定义开始集没有缩小范围时，仍保留空集列表表示整季缺失。"""
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[], total_episode=48, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[],
+                    total_episode=48,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
 
@@ -500,6 +514,331 @@ class SubscribeChainTest(TestCase):
         self.assertEqual(result["media-key"][1].episodes, [])
         self.assertEqual(result["media-key"][1].start_episode, 1)
         self.assertEqual(result["media-key"][1].total_episode, 48)
+
+    def test_resolve_subscribe_missing_combines_library_gap_and_download_history_without_side_effects(self):
+        """目标满足查询应复用主程序媒体库缺集与订阅下载历史的合并口径，且不推进订阅状态。"""
+        subscribe = self._build_subscribe(
+            best_version=0,
+            total_episode=20,
+            lack_episode=10,
+            note=list(range(11, 21)),
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: list(range(1, 21))},
+            title_year="Test Show (2026)",
+        )
+        library_missing = {
+            1: {
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=list(range(11, 21)),
+                    total_episode=20,
+                    start_episode=11,
+                    require_complete_coverage=False,
+                )
+            }
+        }
+        updates = []
+
+        class _DownloadChain:
+            def get_no_exists_info(self, **kwargs):
+                self.kwargs = kwargs
+                return False, library_missing
+
+        class _SubscribeOper:
+            def update(self, subscribe_id, payload):
+                updates.append((subscribe_id, payload))
+
+        chain = SubscribeChain()
+        chain.finish_subscribe_or_not = lambda **_kwargs: self.fail("resolve_subscribe_missing must not finish")
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "DownloadChain", _DownloadChain), patch.object(
+            SUBSCRIBE_CHAIN_MODULE,
+            "SubscribeOper",
+            _SubscribeOper,
+        ):
+            satisfied, no_exists = chain.resolve_subscribe_missing(
+                subscribe=subscribe,
+                meta=meta,
+                mediainfo=mediainfo,
+                mediakey=1,
+            )
+
+        self.assertTrue(satisfied)
+        self.assertEqual(no_exists, {})
+        self.assertEqual(updates, [])
+
+    def test_resolve_subscribe_missing_keeps_library_gap_when_download_history_does_not_cover_it(self):
+        """订阅前媒体库已有部分剧集时，目标满足查询应保留仍需下载的媒体库缺口。"""
+        subscribe = self._build_subscribe(
+            best_version=0,
+            total_episode=20,
+            lack_episode=20,
+            note=[],
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: list(range(1, 21))},
+            title_year="Test Show (2026)",
+        )
+        library_missing = {
+            1: {
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=list(range(11, 21)),
+                    total_episode=20,
+                    start_episode=11,
+                    require_complete_coverage=False,
+                )
+            }
+        }
+
+        class _DownloadChain:
+            def get_no_exists_info(self, **_kwargs):
+                return False, library_missing
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "DownloadChain", _DownloadChain):
+            satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+                subscribe=subscribe,
+                meta=meta,
+                mediainfo=mediainfo,
+                mediakey=1,
+            )
+
+        self.assertFalse(satisfied)
+        self.assertEqual(no_exists[1][1].episodes, list(range(11, 21)))
+        self.assertEqual(no_exists[1][1].start_episode, 1)
+        self.assertEqual(no_exists[1][1].total_episode, 20)
+
+    def test_resolve_subscribe_missing_uses_readonly_effective_total_from_mediainfo(self):
+        """只读目标查询应使用最新媒体信息扩大有效总集数，但不能写回订阅或发送刷新事件。"""
+        subscribe = self._build_subscribe(
+            best_version=0,
+            total_episode=10,
+            lack_episode=0,
+            note=list(range(1, 11)),
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: list(range(1, 21))},
+            title_year="Test Show (2026)",
+        )
+        captured_totals = []
+
+        class _DownloadChain:
+            def get_no_exists_info(self, **kwargs):
+                captured_totals.append(kwargs["totals"])
+                return False, {
+                    1: {
+                        1: SimpleNamespace(
+                            season=1,
+                            episodes=list(range(11, 21)),
+                            total_episode=20,
+                            start_episode=11,
+                            require_complete_coverage=False,
+                        )
+                    }
+                }
+
+        class _EventManager:
+            def send_event(self, *_args, **_kwargs):
+                raise AssertionError("resolve_subscribe_missing must not send refresh events")
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "DownloadChain", _DownloadChain), patch.object(
+            SUBSCRIBE_CHAIN_MODULE,
+            "eventmanager",
+            _EventManager(),
+        ):
+            satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+                subscribe=subscribe,
+                meta=meta,
+                mediainfo=mediainfo,
+                mediakey=1,
+            )
+
+        self.assertFalse(satisfied)
+        self.assertEqual(captured_totals, [{1: 20}])
+        self.assertEqual(no_exists[1][1].episodes, list(range(11, 21)))
+        self.assertEqual(subscribe.total_episode, 10)
+        self.assertEqual(subscribe.lack_episode, 0)
+        self.assertEqual(subscribe.note, list(range(1, 11)))
+
+    def test_resolve_subscribe_missing_accepts_downloaded_episode_best_version_targets(self):
+        """外部完成守卫可按任意已下载版本判定分集洗版目标已满足。"""
+        subscribe = self._build_subscribe(
+            best_version=1,
+            best_version_full=0,
+            total_episode=3,
+            note=[1],
+            episode_priority={"2": 80, "3": 99},
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: [1, 2, 3]},
+            title_year="Test Show (2026)",
+        )
+
+        satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+            subscribe=subscribe,
+            meta=meta,
+            mediainfo=mediainfo,
+            mediakey=1,
+            best_version_accept_downloaded=True,
+        )
+
+        self.assertTrue(satisfied)
+        self.assertEqual(no_exists, {})
+
+    def test_resolve_subscribe_missing_default_best_version_requires_top_priority(self):
+        """主程序洗版完成口径默认仍要求目标分集达到最高优先级。"""
+        subscribe = self._build_subscribe(
+            best_version=1,
+            best_version_full=0,
+            total_episode=3,
+            note=[1],
+            episode_priority={"2": 80, "3": 99},
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: [1, 2, 3]},
+            title_year="Test Show (2026)",
+        )
+
+        satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+            subscribe=subscribe,
+            meta=meta,
+            mediainfo=mediainfo,
+            mediakey=1,
+        )
+
+        self.assertFalse(satisfied)
+        self.assertEqual(no_exists[1][1].episodes, [1, 2, 3])
+        self.assertEqual(no_exists[1][1].total_episode, 3)
+
+    def test_resolve_subscribe_missing_default_best_version_uses_readonly_effective_total(self):
+        """只读目标查询扩大有效总集数时，默认洗版口径应把新增集纳入待洗范围。"""
+        subscribe = self._build_subscribe(
+            best_version=1,
+            best_version_full=0,
+            total_episode=3,
+            episode_priority={"1": 100, "2": 100, "3": 100},
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: [1, 2, 3, 4, 5]},
+            title_year="Test Show (2026)",
+        )
+
+        satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+            subscribe=subscribe,
+            meta=meta,
+            mediainfo=mediainfo,
+            mediakey=1,
+        )
+
+        self.assertFalse(satisfied)
+        self.assertEqual(no_exists[1][1].episodes, [4, 5])
+        self.assertEqual(no_exists[1][1].total_episode, 5)
+        self.assertEqual(subscribe.total_episode, 3)
+
+    def test_resolve_subscribe_missing_accept_downloaded_keeps_best_version_gap(self):
+        """任意版本满足口径仍应保留从未下载过的目标分集。"""
+        subscribe = self._build_subscribe(
+            best_version=1,
+            best_version_full=0,
+            total_episode=3,
+            note=[1],
+            episode_priority={"2": 80},
+        )
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(
+            type=MediaType.TV,
+            seasons={1: [1, 2, 3]},
+            title_year="Test Show (2026)",
+        )
+
+        satisfied, no_exists = SubscribeChain().resolve_subscribe_missing(
+            subscribe=subscribe,
+            meta=meta,
+            mediainfo=mediainfo,
+            mediakey=1,
+            best_version_accept_downloaded=True,
+        )
+
+        self.assertFalse(satisfied)
+        self.assertEqual(no_exists[1][1].episodes, [3])
+        self.assertEqual(no_exists[1][1].total_episode, 3)
+
+    def test_get_subscribe_no_exists_preserves_complete_coverage_requirement(self):
+        """缺集裁剪重建 NotExistMediaInfo 时必须保留全集洗版完整覆盖约束。"""
+        no_exists = {
+            "media-key": {
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=list(range(1, 13)),
+                    total_episode=12,
+                    start_episode=1,
+                    require_complete_coverage=True,
+                )
+            }
+        }
+
+        exist_flag, result = SubscribeChain._SubscribeChain__get_subscribe_no_exits(
+            subscribe_name="主角 S01",
+            no_exists=no_exists,
+            mediakey="media-key",
+            begin_season=1,
+            total_episode=12,
+            start_episode=1,
+            downloaded_episodes=[1, 2, 3],
+        )
+
+        self.assertFalse(exist_flag)
+        self.assertTrue(result["media-key"][1].require_complete_coverage)
+        self.assertEqual(result["media-key"][1].episodes, list(range(4, 13)))
+
+    def test_check_existing_media_refreshes_total_before_resolving_missing(self):
+        """主流程应先执行完成前总集数刷新，再复用无副作用缺集查询口径。"""
+        subscribe = self._build_subscribe(best_version=0, total_episode=10, lack_episode=0)
+        meta = SimpleNamespace(type=MediaType.TV, begin_season=1, season=1)
+        mediainfo = SimpleNamespace(type=MediaType.TV, title_year="Test Show (2026)")
+        calls = []
+
+        def fake_refresh(_self, subscribe, mediainfo):
+            calls.append(("refresh", subscribe.total_episode))
+            subscribe.total_episode = 20
+
+        def fake_resolve(_self, subscribe, meta, mediainfo, mediakey=None):
+            calls.append(("resolve", subscribe.total_episode))
+            return False, {"media-key": {1: SimpleNamespace(episodes=[11], total_episode=20, start_episode=1)}}
+
+        chain = SubscribeChain()
+        with patch.object(
+            SubscribeChain,
+            "_SubscribeChain__refresh_total_episode_before_completion",
+            fake_refresh,
+        ), patch.object(
+            SubscribeChain,
+            "resolve_subscribe_missing",
+            fake_resolve,
+        ):
+            exist_flag, no_exists = chain.check_and_handle_existing_media(
+                subscribe=subscribe,
+                meta=meta,
+                mediainfo=mediainfo,
+                mediakey="media-key",
+            )
+
+        self.assertFalse(exist_flag)
+        self.assertEqual(calls, [("refresh", 10), ("resolve", 20)])
+        self.assertEqual(no_exists["media-key"][1].episodes, [11])
 
     def test_best_version_full_pack_first_keeps_whole_missing_for_custom_start_episode(self):
         """分集洗版优先全集时，空集列表仍表示下载链按整季资源处理。"""
@@ -588,7 +927,13 @@ class SubscribeChainTest(TestCase):
         )
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[2], total_episode=3, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[2],
+                    total_episode=3,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
         calls = []
@@ -632,7 +977,13 @@ class SubscribeChainTest(TestCase):
         )
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[2], total_episode=3, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[2],
+                    total_episode=3,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
         calls = []
@@ -680,7 +1031,13 @@ class SubscribeChainTest(TestCase):
         )
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[2], total_episode=3, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[2],
+                    total_episode=3,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
         calls = []
@@ -721,7 +1078,13 @@ class SubscribeChainTest(TestCase):
         )
         no_exists = {
             "media-key": {
-                1: SimpleNamespace(season=1, episodes=[2], total_episode=3, start_episode=1)
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[2],
+                    total_episode=3,
+                    start_episode=1,
+                    require_complete_coverage=False,
+                )
             }
         }
         calls = []

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -238,3 +238,50 @@ def test_send_msg_markdown_escaping(telegram):
 
     # 验证返回值：send_msg 失败时返回 {"success": False}（非空字典），故显式断言 success
     assert result and result.get("success")
+
+
+def test_edit_msg_falls_back_to_caption_when_original_message_has_no_text(telegram):
+    """编辑图片消息时应在文本编辑失败后回退为 caption 编辑。"""
+    telegram.bot.edit_message_text.side_effect = Exception(
+        "Bad Request: there is no text in the message to edit"
+    )
+
+    result = telegram.edit_msg(
+        chat_id="1051253579",
+        message_id="110502",
+        title="【真人快打2】请选择下载目录",
+        text="1. 默认目录 (/volume1/Download/)\n2. 目录监控 (/volume1/Download/目录监控/)",
+        buttons=[
+            [
+                {"text": "1", "callback_data": "media:f64b855a2be7:download-dir:1"},
+                {"text": "2", "callback_data": "media:f64b855a2be7:download-dir:2"},
+            ]
+        ],
+    )
+
+    assert result is True
+    telegram.bot.edit_message_text.assert_called_once()
+    telegram.bot.edit_message_caption.assert_called_once()
+    caption_kwargs = telegram.bot.edit_message_caption.call_args.kwargs
+    assert caption_kwargs["chat_id"] == "1051253579"
+    assert caption_kwargs["message_id"] == 110502
+    assert "请选择下载目录" in caption_kwargs["caption"]
+    assert caption_kwargs["reply_markup"] is not None
+
+
+def test_edit_msg_keeps_other_edit_errors_failed(telegram):
+    """非图片 caption 场景的编辑错误不应被错误标记为成功。"""
+    telegram.bot.edit_message_text.side_effect = Exception(
+        "Bad Request: message is not modified"
+    )
+
+    result = telegram.edit_msg(
+        chat_id="1051253579",
+        message_id="110502",
+        title="测试标题",
+        text="测试内容",
+    )
+
+    assert result is False
+    telegram.bot.edit_message_text.assert_called_once()
+    telegram.bot.edit_message_caption.assert_not_called()

--- a/tests/test_web_agent_stream.py
+++ b/tests/test_web_agent_stream.py
@@ -8,6 +8,8 @@ from app.agent import ReplyMode
 from app.api.endpoints.agent import (
     _WebAgentMoviePilotAgent,
     _WEB_AGENT_FILE_REGISTRY,
+    _apply_web_agent_display_event,
+    _build_web_agent_input_attachments,
     _build_web_agent_notification_events,
     _build_web_agent_session_id,
     _prepare_web_agent_audio_attachment_path,
@@ -16,6 +18,7 @@ from app.api.endpoints.agent import (
     _resolve_web_agent_choice_payload,
     _split_web_agent_output,
 )
+from app.db.agentchat_oper import AgentChatOper
 from app.helper.interaction import AgentInteractionOption, agent_interaction_manager
 from app.schemas.message import ChannelCapability, ChannelCapabilityManager
 from app.schemas.types import MessageChannel, NotificationType
@@ -72,6 +75,73 @@ def test_build_web_agent_session_id_is_stable_per_user_and_seed():
     assert first == second
     assert first != other
     assert first.startswith("web-agent:")
+
+
+def test_build_web_agent_session_id_reuses_accessible_history():
+    """传入已有历史会话 ID 时应直接复用，避免跨渠道继续对话丢上下文。"""
+    user = SimpleNamespace(id=1, name="admin", is_superuser=True)
+    AgentChatOper().save_display_messages(
+        session_id="telegram-session",
+        user_id="telegram-user",
+        username="tester",
+        channel=MessageChannel.Telegram.value,
+        source="telegram-main",
+        messages=[],
+        title="Telegram 会话",
+    )
+
+    assert _build_web_agent_session_id(user, "telegram-session") == "telegram-session"
+
+
+def test_apply_web_agent_display_event_updates_snapshot():
+    """WebAgent SSE 事件应可聚合为服务端展示快照。"""
+    message = {
+        "id": "assistant-1",
+        "role": "assistant",
+        "content": "",
+        "createdAt": 1,
+        "status": "streaming",
+        "tools": [],
+        "attachments": [],
+        "choices": [],
+    }
+
+    _apply_web_agent_display_event({"type": "delta", "content": "你好"}, message)
+    _apply_web_agent_display_event({"type": "tool", "message": "查询订阅"}, message)
+    _apply_web_agent_display_event(
+        {
+            "type": "attachment",
+            "attachment": {"kind": "file", "url": "message/agent/file/a"},
+        },
+        message,
+    )
+    _apply_web_agent_display_event({"type": "done"}, message)
+
+    assert message["content"] == "你好"
+    assert message["status"] == "done"
+    assert len(message["tools"]) == 1
+    assert message["tools"][0]["message"] == "查询订阅"
+    assert message["tools"][0]["status"] == "done"
+    assert message["attachments"] == [{"kind": "file", "url": "message/agent/file/a"}]
+
+
+def test_build_web_agent_input_attachments_marks_kinds():
+    """WebAgent 用户输入附件应转换为可展示的附件记录。"""
+    attachments = _build_web_agent_input_attachments(
+        images=["data:image/png;base64,abc"],
+        files=[
+            {
+                "ref": "message/agent/file/file-1",
+                "name": "report.txt",
+                "mime_type": "text/plain",
+                "size": 5,
+            }
+        ],
+        audio_refs=["message/agent/file/audio-1"],
+    )
+
+    assert [item["kind"] for item in attachments] == ["image", "file", "audio"]
+    assert attachments[1]["name"] == "report.txt"
 
 
 def test_web_agent_admin_context_uses_current_user_id():

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -679,6 +679,58 @@ def test_workflow_executor_filter_action_replaces_artifact_outputs(monkeypatch):
     assert executor.context.artifacts["torrents"] == ["keep"]
 
 
+def test_workflow_executor_filter_action_replaces_with_empty_outputs(monkeypatch):
+    """过滤节点结果为空时也应清空上游资源，避免后续继续下载。"""
+    calls = []
+    stale_torrents = ["old", "drop"]
+    filtered_torrents = []
+
+    def run_fetch(action, context):
+        """模拟上游搜索节点产出资源池。"""
+        context.torrents = stale_torrents.copy()
+        return ActionResult(
+            success=True,
+            message=f"{action.name}完成",
+            context=context,
+            outputs={"torrents": stale_torrents.copy()}
+        )
+
+    def run_filter(action, context):
+        """模拟过滤节点把资源全部过滤掉。"""
+        context.torrents = filtered_torrents.copy()
+        return ActionResult(
+            success=True,
+            message=f"{action.name}完成",
+            context=context,
+            outputs={"torrents": filtered_torrents.copy()}
+        )
+
+    fake_manager = _FakeWorkflowManager(
+        calls,
+        results={
+            "A": run_fetch,
+            "B": run_filter,
+        }
+    )
+    workflow = _build_workflow(
+        actions=[
+            {"id": "A", "type": "FetchTorrentsAction", "name": "搜索站点资源", "data": {}},
+            {"id": "B", "type": "FilterTorrentsAction", "name": "过滤资源", "data": {}},
+        ],
+    )
+
+    monkeypatch.setattr(workflow_module, "WorkFlowManager", lambda: fake_manager)
+    monkeypatch.setattr(workflow_module.global_vars, "workflow_resume", lambda workflow_id: None)
+    monkeypatch.setattr(workflow_module.global_vars, "is_workflow_stopped", lambda workflow_id: False)
+
+    executor = workflow_module.WorkflowExecutor(workflow)
+    executor.execute()
+
+    assert executor.context.torrents == filtered_torrents
+    assert executor.context.artifacts["torrents"] == filtered_torrents
+    assert executor.context.node_outputs["B"]["torrents"] == filtered_torrents
+
+
 def test_workflow_executor_stop_is_not_success(monkeypatch):
     """停止信号不应被执行器汇报为成功完成。"""
     calls = []


### PR DESCRIPTION
## 集成上游 v2 2.13.12 同步到 v3-python

合入 `chore/sync-upstream-v2-2.13.12`（26 提交：上游 2.13.12 端口 #5958–#5973 等 + v3 适配），把上游 2.13.12 的新特性/修复带入已含 Q1 模块开放注册（S1–S6 / PR #50–#55）的 v3-python。

### 冲突解决（唯一冲突文件）
`app/helper/plugin_manager.py` 两处 hunk，均为**纯加法、两侧正交皆保留**：
- 保留 **Q1 模块开放注册接线** `_register_plugin_modules` / `_unregister_plugin_modules`（`start` / `init_plugin` 运行期动态上下线）
- 保留**上游插件智能体工具注册表缓存** `clear_plugin_agent_tools_cache` 及其在 `start`/`init_plugin`/`stop` 的调用

`app/schemas/message.py` 自动合并；其余 71 个上游改动文件无冲突。

### 验证
- `app.helper.plugin_manager` 导入正常，`clear_plugin_agent_tools_cache` / `_register_plugin_modules` / `_unregister_plugin_modules` 三方法俱在；`py_compile` 通过。
- Q1 套件 6 文件 **31 passed**（模块开放注册行为穿过合并完整保留）。
- 全量套件 **1197 passed / 27 failed / 33 errors**：失败/错误全部为本 dev venv 缺 `jieba_next`（`app.agent` 链）导致的上游 agent 工具测试 + 1 个预存失败（`test_security_utils` signed_url，在合并前的 v3-python 上同样失败），**无一落在本次合并组合的模块注册/插件 SPI/渠道能力/存储面**。
