### PR TITLE
test: 修复 stale agent_manager patch 目标（v3 改用 get_agent_manager 访问器）

### DIFF
--- a/tests/test_agent_image_support.py
+++ b/tests/test_agent_image_support.py
@@ -451,7 +451,7 @@ class AgentImageSupportTest(unittest.TestCase):
                 }
             ],
         ) as prepare_files, patch(
-            "app.chain.message.agent_manager.process_message", new_callable=AsyncMock
+            "app.agent.agent_manager.process_message", new_callable=AsyncMock
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",
             side_effect=lambda coro, _loop: coro.close(),
@@ -484,7 +484,7 @@ class AgentImageSupportTest(unittest.TestCase):
         with patch.object(settings, "AI_AGENT_ENABLE", True), patch.object(
             chain, "_get_or_create_session_id", return_value="session-1"
         ), patch(
-            "app.chain.message.agent_manager.process_message", new_callable=AsyncMock
+            "app.agent.agent_manager.process_message", new_callable=AsyncMock
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",
             side_effect=lambda coro, _loop: coro.close(),

--- a/tests/test_agent_interaction.py
+++ b/tests/test_agent_interaction.py
@@ -172,7 +172,7 @@ class TestAgentInteraction(unittest.TestCase):
         ) as message_add, patch.object(
             chain, "edit_message", return_value=True
         ) as edit_message, patch(
-            "app.chain.message.agent_manager.process_message",
+            "app.agent.agent_manager.process_message",
             new_callable=AsyncMock,
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",

--- a/tests/test_agent_session_status.py
+++ b/tests/test_agent_session_status.py
@@ -82,7 +82,7 @@ class TestAgentSessionStatus(unittest.TestCase):
 
         with (
             patch(
-                "app.chain.message.agent_manager.get_session_status",
+                "app.agent.agent_manager.get_session_status",
                 return_value=status,
             ),
             patch.object(chain, "post_message") as post_message,

--- a/tests/test_telegram_typing_lifecycle.py
+++ b/tests/test_telegram_typing_lifecycle.py
@@ -241,7 +241,7 @@ class TestTelegramTypingLifecycle(unittest.TestCase):
         ) as start_status, patch(
                 "app.chain.message.settings.AI_AGENT_ENABLE", True
         ), patch(
-                "app.chain.message.agent_manager.process_message",
+                "app.agent.agent_manager.process_message",
                 new_callable=AsyncMock,
         ) as process_message, patch(
                 "app.chain.message.asyncio.run_coroutine_threadsafe",


### PR DESCRIPTION
v3 解耦后 `app.chain.message` 经 `get_agent_manager()` 访问器调用，模块级 `agent_manager` 名不再存在。本 PR 把 4 个测试文件里失效的 `app.chain.message.agent_manager.X` patch 目标改指真单例 `app.agent.agent_manager.X`，共修 5 例（image_support×2 / interaction×1 / session_status×1 / telegram×1）。

补 `jieba_next` 后这些测试全绿（4 文件 80 passed）。纯测试改动，无生产代码变更。