### PR TITLE
test: 修 security_utils stale settings + conftest 预导入下载器 SDK（套件全绿）

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,14 @@ prepare_backend()
 
 # 复用共享 autouse 网络守卫；同一实现亦供各插件仓 conftest import 复用，避免逐仓维护
 from app.testing.network_guard import block_real_network  # noqa: E402,F401
+
+# 已安装的真实下载器 SDK 须先于测试桩进入 sys.modules：部分测试以
+# ``sys.modules.setdefault("qbittorrentapi", ...)`` 注入仅含 TorrentFilesList 的假模块供无该包的 CI 用；
+# 若假桩在真包导入前先落位，会令 test_downloader_file_normalization 的
+# ``from qbittorrentapi import TorrentDictionary`` 失败。已装环境下此处优先导入真包使桩 setdefault no-op，
+# 未装环境走 except 由桩兜底。
+for _downloader_sdk in ("qbittorrentapi", "transmission_rpc"):
+    try:
+        __import__(_downloader_sdk)
+    except ImportError:
+        pass

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -69,14 +69,14 @@ class SecurityUtilsTest(TestCase):
         url = "http://192.168.1.50:8096/Items/abc/Images/Primary"
 
         with patch(
-            "app.utils.security.settings.RESOURCE_SECRET_KEY",
+            "app.core.config.settings.RESOURCE_SECRET_KEY",
             "old-secret-value-aaaaaaaaaaaaaaaaaaaaaaaa",
         ):
             signed_url = SecurityUtils.sign_url(url)
             self.assertEqual(SecurityUtils.verify_signed_url(signed_url), url)
 
         with patch(
-            "app.utils.security.settings.RESOURCE_SECRET_KEY",
+            "app.core.config.settings.RESOURCE_SECRET_KEY",
             "new-secret-value-bbbbbbbbbbbbbbbbbbbbbbbb",
         ):
             self.assertIsNone(SecurityUtils.verify_signed_url(signed_url))


### PR DESCRIPTION
补齐 jieba_next/lark_oapi 后让测试套件在本机完全绿（1556 passed / 0 failed / 0 error）。

- **test_security_utils**：v3 解耦后 security.py 在函数内 lazy `from app.core.config import settings`，模块级 `app.utils.security.settings` 不存在 → 2 处 patch 目标改指真实位置 `app.core.config.settings.RESOURCE_SECRET_KEY`。
- **conftest**：已装真实 `qbittorrentapi`/`transmission_rpc` 时优先导入，使部分测试的 `sys.modules.setdefault` 假桩 no-op，修复全量套件下 `test_downloader_file_normalization` 的收集错误；未装环境走 except 由桩兜底。

纯测试基建改动，无生产代码变更。