### PR TITLE
feat(模块注册): 验证注册机制 + 注入路径软废弃提醒

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,5 +1,7 @@
+import inspect
 import threading
 import traceback
+import warnings
 from enum import Enum
 from typing import Generator, Optional, Tuple, Any, Union, List, Dict
 
@@ -209,6 +211,48 @@ class ModuleManager(metaclass=Singleton):
     # 无差别接管，无需改动分发链。运行期线程安全，支持热插拔。
     # ---------------------------------------------------------------------
 
+    @staticmethod
+    def verify_module_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验外部模块类是否满足 _ModuleBase 基类契约，作为「验证注册」的核心判定。
+
+        宽松策略（缺注解/不可内省时降级跳过、不抛异常），返回 (是否通过, 失败原因列表)。
+        供 register_module 把旧「注入」式注册升级为「验证后注册」——不通过仅作废弃提醒、
+        不强制拒绝，保证零插件破坏。
+        """
+        if not isinstance(module_cls, type):
+            return False, ["不是类对象"]
+        reasons: List[str] = []
+        # 1) 应继承 _ModuleBase（真模块 vs 任意注入类的核心区分）；lazy import 避免 import-time 环
+        try:
+            from app.modules import _ModuleBase
+            if not issubclass(module_cls, _ModuleBase):
+                reasons.append("未继承 app.modules._ModuleBase")
+        except ImportError:
+            pass  # app.modules 依赖未就绪时仅降级跳过该项；其它异常照常上报
+        # 2) 抽象方法须全部落地，否则不可实例化
+        abstracts = getattr(module_cls, "__abstractmethods__", frozenset())
+        if abstracts:
+            reasons.append(f"抽象方法未实现：{sorted(abstracts)}")
+        # 3) 契约方法存在且可调用 + 签名宽松兼容（生命周期/声明方法不应要求额外必填位置参）
+        for _name in ("init_module", "init_setting", "stop", "test", "get_type", "get_subtype"):
+            _fn = getattr(module_cls, _name, None)
+            if not callable(_fn):
+                reasons.append(f"缺少契约方法：{_name}")
+                continue
+            try:
+                _extra = [
+                    p.name for p in inspect.signature(_fn).parameters.values()
+                    if p.name not in ("self", "cls")
+                    and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+                    and p.default is p.empty
+                ]
+                if _extra:
+                    reasons.append(f"{_name} 签名不兼容：要求额外必填参 {_extra}")
+            except (ValueError, TypeError):
+                pass  # 无法内省 → 降级跳过
+        return (not reasons), reasons
+
     def register_module(self, module_cls: type, owner: str) -> bool:
         """
         注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，
@@ -222,6 +266,18 @@ class ModuleManager(metaclass=Singleton):
         if not owner or not isinstance(module_cls, type):
             return False
         module_id = module_cls.__name__
+        # 验证注册：校验 _ModuleBase 基类契约。不通过仅发废弃提醒（软废弃），不阻断注册——
+        # 旧「注入」式（未达契约即接受）路径将废弃，引导插件实现完整契约走「验证注册」。
+        _ok, _reasons = self.verify_module_contract(module_cls)
+        if not _ok:
+            _msg = (f"模块 {module_id}(owner={owner}) 未通过 _ModuleBase 契约校验："
+                    f"{'；'.join(_reasons)}。当前按兼容『注入』路径接受，该路径将废弃，"
+                    f"请使其继承 app.modules._ModuleBase 并实现完整契约以走『验证注册』。")
+            logger.warning(f"[DEPRECATED] {_msg}")
+            try:
+                warnings.warn(_msg, DeprecationWarning, stacklevel=2)
+            except Exception:
+                pass  # 即便告警被升格为异常(-W error)也不得阻断注册（零破坏铁律）
         with self._lock:
             # 命名冲突：已存在且不归属本 owner(内建或他插件) → 拒绝，避免遮蔽
             existing_owner = self._find_owner(module_id)

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -9,6 +9,7 @@
 """
 import inspect
 import posixpath
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from fastapi import HTTPException
@@ -128,6 +129,15 @@ def get_plugin_modules(running_plugins, pid: Optional[str] = None) -> Dict[tuple
                 if not plugin.get_state():
                     continue
                 plugin_module = plugin.get_module() or []
+                if plugin_module and not getattr(plugin, "_get_module_deprecation_warned", False):
+                    setattr(plugin, "_get_module_deprecation_warned", True)
+                    _dep_msg = (f"插件 {plugin_id} 使用 get_module() 方法胁持（无契约校验，已废弃），"
+                                f"请改用 provides_modules() 走验证注册。")
+                    logger.warning(f"[DEPRECATED] {_dep_msg}")
+                    try:
+                        warnings.warn(_dep_msg, DeprecationWarning, stacklevel=2)
+                    except Exception:
+                        pass  # 告警升格(-W error)不得影响模块聚合
                 ret_modules[(plugin_id, plugin.get_name())] = plugin_module
             except Exception as e:
                 logger.error(f"获取插件 {plugin_id} 模块出错：{str(e)}")

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -191,7 +191,11 @@ class _PluginBase(metaclass=ABCMeta):
 
     def get_module(self) -> Dict[str, Any]:
         """
-        获取插件模块声明，用于胁持系统模块实现（方法名：方法实现）
+        【已废弃，将移除】获取插件模块声明，用于胁持系统模块实现（方法名：方法实现）。
+
+        本「方法胁持/注入」路径无契约校验、易与内建实现冲突，已废弃；
+        请改用 provides_modules() 走「验证注册」——框架统一注册到 ModuleManager
+        并参与 chain 分发，无需 monkey-patch app.modules。
         {
             "id1": self.xxx1,
             "id2": self.xxx2,

--- a/tests/test_module_registration_validation.py
+++ b/tests/test_module_registration_validation.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+验证注册机制回归：register_module 从「注入」升级为「_ModuleBase 基类契约验证」（软废弃）。
+
+验证：
+  1. verify_module_contract 对合法 _ModuleBase 子类通过（无原因）；
+  2. 对未继承 _ModuleBase / 缺契约方法 / 签名不兼容 / 非类对象 判定失败并给出原因；
+  3. register_module 对不合规类发 DeprecationWarning 但仍兼容接受（软废弃，零插件破坏）；
+  4. register_module 对合规类不发 DeprecationWarning。
+"""
+import warnings
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType, DownloaderType
+
+
+class _ValidModule(_ModuleBase):
+    """合法外部模块：继承 _ModuleBase 且实现全部契约方法。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_name() -> str:
+        return "ValidStub"
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        return DownloaderType.Qbittorrent
+
+    @staticmethod
+    def get_priority() -> int:
+        return 99
+
+
+class _InjectedModule:
+    """旧「注入」路径：未继承 _ModuleBase，仅鸭子实现契约方法。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type():
+        return None
+
+    @staticmethod
+    def get_subtype():
+        return None
+
+
+class _MissingMethodModule:
+    """未继承且缺 get_type 契约方法。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_subtype():
+        return None
+
+
+class _BadSignatureModule(_ModuleBase):
+    """契约方法要求额外必填位置参 → 签名不兼容。"""
+
+    def init_module(self, extra) -> None:  # noqa: 故意的不兼容签名
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+
+class TestVerifyModuleContract(TestCase):
+    def test_valid_module_passes(self):
+        ok, reasons = ModuleManager.verify_module_contract(_ValidModule)
+        self.assertTrue(ok)
+        self.assertEqual(reasons, [])
+
+    def test_non_subclass_fails_with_reason(self):
+        ok, reasons = ModuleManager.verify_module_contract(_InjectedModule)
+        self.assertFalse(ok)
+        self.assertTrue(any("未继承" in r for r in reasons))
+
+    def test_missing_method_reported(self):
+        ok, reasons = ModuleManager.verify_module_contract(_MissingMethodModule)
+        self.assertFalse(ok)
+        self.assertTrue(any("get_type" in r for r in reasons))
+
+    def test_bad_signature_reported(self):
+        ok, reasons = ModuleManager.verify_module_contract(_BadSignatureModule)
+        self.assertFalse(ok)
+        self.assertTrue(any(("init_module" in r and "签名" in r) for r in reasons))
+
+    def test_non_type_rejected(self):
+        ok, reasons = ModuleManager.verify_module_contract("not-a-class")
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestRegisterModuleSoftDeprecation(TestCase):
+    def setUp(self):
+        self.mgr = ModuleManager()
+        self.owner = "test_validation_owner"
+
+    def tearDown(self):
+        self.mgr.unregister_modules(self.owner)
+
+    def test_injected_class_warns_but_accepted(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            accepted = self.mgr.register_module(_InjectedModule, self.owner)
+        # 软废弃：仍接受进注册表（零插件破坏）
+        self.assertTrue(accepted)
+        self.assertIn(_InjectedModule.__name__, self.mgr.get_external_module_ids(self.owner))
+        # 但发出废弃提醒
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_valid_class_no_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            accepted = self.mgr.register_module(_ValidModule, self.owner)
+        self.assertTrue(accepted)
+        self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_injected_class_accepted_even_when_warnings_are_errors(self):
+        """-W error::DeprecationWarning 下告警升格为异常，也不得阻断注册（零破坏铁律）。"""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            accepted = self.mgr.register_module(_InjectedModule, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(_InjectedModule.__name__, self.mgr.get_external_module_ids(self.owner))


### PR DESCRIPTION
把 `ModuleManager.register_module` 从『注入』(只校验 isinstance+owner+命名冲突) 升级为『_ModuleBase 基类契约**验证注册**』，并把旧注入路径标记**废弃提醒**（软废弃·零插件破坏）。

## 改动
- 新增 `ModuleManager.verify_module_contract`：校验 `issubclass(_ModuleBase)` + 抽象方法全落地 + 契约方法存在且签名宽松兼容（正确处理 `*args/**kwargs`/默认值/kw-only、缺注解降级为名/数量）。
- `register_module` 调用校验：不过仅发 `DeprecationWarning`+logger 但**仍兼容接受注册**（软废弃）。
- `_PluginBase.get_module()` docstring 标废弃 + 其消费点按插件实例去重发一次废弃提醒，引导改用 `provides_modules()`。

## 对抗审查(code-reviewer)修正
- **HIGH**：`warnings.warn` 包 try/except —— `-W error::DeprecationWarning` 下也不得阻断注册（附回归测试）。
- **MEDIUM**：lazy import 的 `except` 收窄为 `ImportError`。
- **LOW**：签名检查补 `KEYWORD_ONLY` 必填参检测。

## 验证
新增 8 例测试（含 -W error 回归）；Q1 模块注册回归零破坏；全量套件 **1564 passed / 0 failed / 0 error**。