### PR TITLE
refactor(模块注册): 移除 v3 引入的注入兼容软路径，改为严格验证注册

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,7 +1,6 @@
 import inspect
 import threading
 import traceback
-import warnings
 from enum import Enum
 from typing import Generator, Optional, Tuple, Any, Union, List, Dict
 
@@ -266,18 +265,14 @@ class ModuleManager(metaclass=Singleton):
         if not owner or not isinstance(module_cls, type):
             return False
         module_id = module_cls.__name__
-        # 验证注册：校验 _ModuleBase 基类契约。不通过仅发废弃提醒（软废弃），不阻断注册——
-        # 旧「注入」式（未达契约即接受）路径将废弃，引导插件实现完整契约走「验证注册」。
+        # 验证注册：校验 _ModuleBase 基类契约，不通过直接拒绝（严格注册）。
+        # register_module 系 v3-python 新增且未发布，无外部插件依赖宽松行为，故不保留注入兼容路径。
         _ok, _reasons = self.verify_module_contract(module_cls)
         if not _ok:
-            _msg = (f"模块 {module_id}(owner={owner}) 未通过 _ModuleBase 契约校验："
-                    f"{'；'.join(_reasons)}。当前按兼容『注入』路径接受，该路径将废弃，"
-                    f"请使其继承 app.modules._ModuleBase 并实现完整契约以走『验证注册』。")
-            logger.warning(f"[DEPRECATED] {_msg}")
-            try:
-                warnings.warn(_msg, DeprecationWarning, stacklevel=2)
-            except Exception:
-                pass  # 即便告警被升格为异常(-W error)也不得阻断注册（零破坏铁律）
+            logger.warning(
+                f"模块 {module_id}(owner={owner}) 未通过 _ModuleBase 契约校验，拒绝注册："
+                f"{'；'.join(_reasons)}。请使其继承 app.modules._ModuleBase 并实现完整契约。")
+            return False
         with self._lock:
             # 命名冲突：已存在且不归属本 owner(内建或他插件) → 拒绝，避免遮蔽
             existing_owner = self._find_owner(module_id)

--- a/tests/test_module_registration_validation.py
+++ b/tests/test_module_registration_validation.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-验证注册机制回归：register_module 从「注入」升级为「_ModuleBase 基类契约验证」（软废弃）。
+验证注册机制回归：register_module 从「注入」升级为「_ModuleBase 基类契约严格验证注册」。
 
 验证：
   1. verify_module_contract 对合法 _ModuleBase 子类通过（无原因）；
   2. 对未继承 _ModuleBase / 缺契约方法 / 签名不兼容 / 非类对象 判定失败并给出原因；
-  3. register_module 对不合规类发 DeprecationWarning 但仍兼容接受（软废弃，零插件破坏）；
-  4. register_module 对合规类不发 DeprecationWarning。
+  3. register_module 对不合规类直接拒绝（return False、不进注册表，不保留注入兼容路径）；
+  4. register_module 对合规类正常注册。
 """
-import warnings
 from unittest import TestCase
 
 from app.core.module import ModuleManager
@@ -135,7 +134,7 @@ class TestVerifyModuleContract(TestCase):
         self.assertTrue(reasons)
 
 
-class TestRegisterModuleSoftDeprecation(TestCase):
+class TestRegisterModuleStrictValidation(TestCase):
     def setUp(self):
         self.mgr = ModuleManager()
         self.owner = "test_validation_owner"
@@ -143,27 +142,14 @@ class TestRegisterModuleSoftDeprecation(TestCase):
     def tearDown(self):
         self.mgr.unregister_modules(self.owner)
 
-    def test_injected_class_warns_but_accepted(self):
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            accepted = self.mgr.register_module(_InjectedModule, self.owner)
-        # 软废弃：仍接受进注册表（零插件破坏）
-        self.assertTrue(accepted)
-        self.assertIn(_InjectedModule.__name__, self.mgr.get_external_module_ids(self.owner))
-        # 但发出废弃提醒
-        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+    def test_invalid_class_rejected(self):
+        """未过 _ModuleBase 契约校验的类被严格拒绝，不进注册表（不保留注入兼容路径）。"""
+        accepted = self.mgr.register_module(_InjectedModule, self.owner)
+        self.assertFalse(accepted)
+        self.assertNotIn(_InjectedModule.__name__, self.mgr.get_external_module_ids(self.owner))
 
-    def test_valid_class_no_deprecation(self):
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            accepted = self.mgr.register_module(_ValidModule, self.owner)
+    def test_valid_class_accepted(self):
+        """合法 _ModuleBase 子类正常注册。"""
+        accepted = self.mgr.register_module(_ValidModule, self.owner)
         self.assertTrue(accepted)
-        self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
-
-    def test_injected_class_accepted_even_when_warnings_are_errors(self):
-        """-W error::DeprecationWarning 下告警升格为异常，也不得阻断注册（零破坏铁律）。"""
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            accepted = self.mgr.register_module(_InjectedModule, self.owner)
-        self.assertTrue(accepted)
-        self.assertIn(_InjectedModule.__name__, self.mgr.get_external_module_ids(self.owner))
+        self.assertIn(_ValidModule.__name__, self.mgr.get_external_module_ids(self.owner))


### PR DESCRIPTION
承接 PR #59。`register_module` 系 v3-python Q1 新增（官方 v2 **无**此 API）、且 v3-python 未发布——无任何外部插件依赖其『不校验即接受』的宽松行为，故 #59 引入的『软废弃·warn+兼容接受』**注入兼容路径属多余内容**，移除之。

## 改动
- `register_module`：未过 `_ModuleBase` 契约校验的类**直接拒绝**（`logger.warning` + `return False`、不进注册表），不再发 `DeprecationWarning`、不再兼容接受。
- 删除随之不再使用的 `import warnings`。
- `verify_module_contract` 校验逻辑不变。
- `get_module()`（官方 v2 既有的方法胁持）**非 v3 引入，保持不动**（留作 v2 兼容）。

## 验证
测试改严格语义（不合规→拒绝/合规→接受）；Q1 注册的合法 `_ModuleBase` 子类正常通过；全量套件 **1563 passed / 0 failed / 0 error**。