### PR TITLE
feat(数据源): 插件一等数据源(MediaRecognize)开放注册 + 契约校验

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -252,6 +252,28 @@ class ModuleManager(metaclass=Singleton):
                 pass  # 无法内省 → 降级跳过
         return (not reasons), reasons
 
+    @staticmethod
+    def verify_data_source_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验数据源（媒体识别/信息源，MediaRecognize 域）契约：在 _ModuleBase 基类契约之上，
+        要求 get_type()==ModuleType.MediaRecognize。识别能力方法（recognize_media /
+        search_medias / obtain_images 等）由框架按方法名分发、按需实现，故不在此强制
+        （避免误拒 thetvdb 这类仅实现部分/其它方法的真实源）。返回 (是否通过, 失败原因列表)。
+        """
+        ok, reasons = ModuleManager.verify_module_contract(module_cls)
+        reasons = list(reasons)
+        # 数据源须声明为 MediaRecognize 类型
+        _get_type = getattr(module_cls, "get_type", None)
+        if not callable(_get_type):
+            reasons.append("缺少 get_type")
+        else:
+            try:
+                if _get_type() != ModuleType.MediaRecognize:
+                    reasons.append(f"get_type 须为 ModuleType.MediaRecognize（实际 {_get_type()}）")
+            except Exception as err:
+                reasons.append(f"get_type 调用失败：{err}")
+        return (not reasons), reasons
+
     def register_module(self, module_cls: type, owner: str) -> bool:
         """
         注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -649,6 +649,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                             getattr(caps, "channel", None), caps, owner=plugin_id)
                     except Exception as err:
                         logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
+        # 注册插件经 provides_data_sources 声明新增的数据源（媒体识别/信息源，MediaRecognize 域），
+        # 经数据源契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 recognize_media 识别流水线。
+        provided_data_sources = plugin_metadata.get_plugin_provided_data_sources(self._running_plugins, pid)
+        for plugin_id, source_classes in provided_data_sources.items():
+            for source_cls in source_classes:
+                _ds_ok, _ds_reasons = ModuleManager.verify_data_source_contract(source_cls)
+                if not _ds_ok:
+                    logger.warning(f"插件 {plugin_id} 数据源 "
+                                   f"{getattr(source_cls, '__name__', source_cls)} 未通过数据源契约校验，拒绝注册："
+                                   f"{'；'.join(_ds_reasons)}")
+                    continue
+                try:
+                    ModuleManager().register_module(source_cls, owner=plugin_id)
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 数据源 "
+                                 f"{getattr(source_cls, '__name__', source_cls)} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -168,6 +168,31 @@ def get_plugin_provided_modules(running_plugins, pid: Optional[str] = None) -> D
                 logger.error(f"获取插件 {plugin_id} 注册模块出错：{str(e)}")
     return ret_modules
 
+def get_plugin_provided_data_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_data_sources() 声明【新增】的数据源（MediaRecognize 域）类，
+    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [source_cls, ...]
+    }
+    """
+    ret_sources: Dict[str, List[type]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_data_sources") and ObjectUtils.check_method(plugin.provides_data_sources):
+            try:
+                if not plugin.get_state():
+                    continue
+                sources = plugin.provides_data_sources() or []
+                if sources:
+                    ret_sources[plugin_id] = list(sources)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册数据源出错：{str(e)}")
+    return ret_sources
+
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
     """
     聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -238,6 +238,19 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_data_sources(self) -> List[Type]:
+        """
+        声明本插件向模块层【新增】的数据源（媒体识别/信息源，MediaRecognize 域）类，
+        如新的 TMDB / IMDB / 豆瓣式来源。provides_modules 的语法糖 + 数据源契约校验：
+        返回的【类】（非实例）须实现 _ModuleBase 契约且 get_type()==ModuleType.MediaRecognize。
+        识别能力方法（recognize_media / search_medias / obtain_images 等）按需实现——
+        框架经 ModuleManager 注册（owner=plugin_id）后按方法名分发，实现哪个就参与哪个
+        识别/搜索/取图流水线；子类型用 get_subtype_id() 返回字符串 id（无需扩展封闭枚举）。默认不新增。
+
+        [TmdbLikeSourceClass, ImdbLikeSourceClass, ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/tests/test_data_source_registration.py
+++ b/tests/test_data_source_registration.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+数据源（MediaRecognize 域）一等开放注册回归：
+
+  1. verify_data_source_contract 对合法数据源（_ModuleBase + get_type=MediaRecognize +
+     recognize_media/search_medias/obtain_images）通过；
+  2. 对错误 ModuleType / 缺数据源方法 / 非模块类 判定失败并给出原因；
+  3. 合法数据源经 register_module 严格验证后正常注册；
+  4. get_plugin_provided_data_sources 聚合器按 owner 归集插件声明的数据源。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_metadata import get_plugin_provided_data_sources
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType
+
+
+class _MediaRecognizeBase(_ModuleBase):
+    """实现 _ModuleBase 契约 + 数据源核心方法的基类。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def recognize_media(self, *args, **kwargs):
+        return None
+
+    def search_medias(self, *args, **kwargs):
+        return []
+
+    def obtain_images(self, *args, **kwargs):
+        return None
+
+
+class _ValidDataSource(_MediaRecognizeBase):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaRecognize
+
+
+class _WrongTypeSource(_MediaRecognizeBase):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader  # 非 MediaRecognize
+
+
+class _MinimalSource(_ModuleBase):
+    """MediaRecognize 源但不实现任何识别能力方法（如真实的 thetvdb）——契约应通过。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaRecognize
+
+
+class TestVerifyDataSourceContract(TestCase):
+    def test_valid_data_source_passes(self):
+        ok, reasons = ModuleManager.verify_data_source_contract(_ValidDataSource)
+        self.assertTrue(ok, reasons)
+        self.assertEqual(reasons, [])
+
+    def test_wrong_module_type_rejected(self):
+        ok, reasons = ModuleManager.verify_data_source_contract(_WrongTypeSource)
+        self.assertFalse(ok)
+        self.assertTrue(any("MediaRecognize" in r for r in reasons))
+
+    def test_minimal_media_recognize_passes(self):
+        # MediaRecognize 源即便未实现识别方法也应通过（识别方法按需、框架按名分发；如真实 thetvdb）
+        ok, reasons = ModuleManager.verify_data_source_contract(_MinimalSource)
+        self.assertTrue(ok, reasons)
+
+    def test_non_module_rejected(self):
+        ok, reasons = ModuleManager.verify_data_source_contract(str)
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestDataSourceRegistration(TestCase):
+    def setUp(self):
+        self.mgr = ModuleManager()
+        self.owner = "test_ds_owner"
+
+    def tearDown(self):
+        self.mgr.unregister_modules(self.owner)
+
+    def test_valid_data_source_registers(self):
+        accepted = self.mgr.register_module(_ValidDataSource, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(_ValidDataSource.__name__, self.mgr.get_external_module_ids(self.owner))
+
+
+class TestDataSourceAggregator(TestCase):
+    def test_aggregator_collects_enabled_plugin_sources(self):
+        class _FakePlugin:
+            def get_state(self):
+                return True
+
+            def provides_data_sources(self):
+                return [_ValidDataSource]
+
+        result = get_plugin_provided_data_sources({"fakeplugin": _FakePlugin()})
+        self.assertEqual(result, {"fakeplugin": [_ValidDataSource]})
+
+    def test_aggregator_skips_disabled_plugin(self):
+        class _DisabledPlugin:
+            def get_state(self):
+                return False
+
+            def provides_data_sources(self):
+                return [_ValidDataSource]
+
+        result = get_plugin_provided_data_sources({"off": _DisabledPlugin()})
+        self.assertEqual(result, {})


### PR DESCRIPTION
让插件能像下载器/储存器/渠道那样，把**数据源**（媒体识别/信息源，MediaRecognize 域，如 TMDB/IMDB/豆瓣式来源）作为一等域注册。

## 改动
- `_PluginBase.provides_data_sources()` — 声明式 SPI 钩子。
- `ModuleManager.verify_data_source_contract()` — 数据源契约 = _ModuleBase 严格契约 + `get_type()==ModuleType.MediaRecognize`。**识别能力方法按需、不强制**（真实源核查：bangumi 无 obtain_images、thetvdb 三者皆无，强制会误拒）。
- `plugin_metadata.get_plugin_provided_data_sources()` — 按 owner 聚合。
- `PluginManager._register_plugin_modules` — 校验通过后经 ModuleManager 注册，参与 recognize_media 识别流水线；卸载由 unregister_modules(owner) 自动覆盖。

## 说明
爱奇艺/腾讯视频等**具体源由社区插件实现，本 PR 只建框架**。

## 验证
真实源核查：TMDB/douban/bangumi/thetvdb 4 个 MediaRecognize 模块**均通过校验、不误拒**（此自检捕获并修正了初版过严的必需方法检查）。新增 7 例测试；全量套件 **1570 passed / 0 failed / 0 error**。