### PR TITLE
feat(下载器): 插件一等下载器开放注册 + 契约校验（v4 P1 增量①）

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -274,6 +274,31 @@ class ModuleManager(metaclass=Singleton):
                 reasons.append(f"get_type 调用失败：{err}")
         return (not reasons), reasons
 
+    @staticmethod
+    def verify_downloader_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验下载器（Downloader 域）契约：在 _ModuleBase 基类契约之上，要求
+        get_type()==ModuleType.Downloader 且实现下载器核心操作（download/list_torrents/
+        remove_torrents）。完整 IDownloader 操作面（start/stop/torrent_files/downloader_info 等）
+        由 run_module 按方法名分发、按需实现。供 provides_downloaders() 注册前严格校验。
+        返回 (是否通过, 失败原因列表)。
+        """
+        ok, reasons = ModuleManager.verify_module_contract(module_cls)
+        reasons = list(reasons)
+        _get_type = getattr(module_cls, "get_type", None)
+        if not callable(_get_type):
+            reasons.append("缺少 get_type")
+        else:
+            try:
+                if _get_type() != ModuleType.Downloader:
+                    reasons.append(f"get_type 须为 ModuleType.Downloader（实际 {_get_type()}）")
+            except Exception as err:
+                reasons.append(f"get_type 调用失败：{err}")
+        for _name in ("download", "list_torrents", "remove_torrents"):
+            if not callable(getattr(module_cls, _name, None)):
+                reasons.append(f"缺少下载器方法：{_name}")
+        return (not reasons), reasons
+
     def register_module(self, module_cls: type, owner: str) -> bool:
         """
         注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -665,6 +665,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} 数据源 "
                                  f"{getattr(source_cls, '__name__', source_cls)} 出错：{str(err)}")
+        # 注册插件经 provides_downloaders 声明新增的下载器（Downloader 域），
+        # 经下载器契约校验通过后注册到 ModuleManager（owner=plugin_id），参与下载器分发。
+        provided_downloaders = plugin_metadata.get_plugin_provided_downloaders(self._running_plugins, pid)
+        for plugin_id, downloader_classes in provided_downloaders.items():
+            for downloader_cls in downloader_classes:
+                _dl_ok, _dl_reasons = ModuleManager.verify_downloader_contract(downloader_cls)
+                if not _dl_ok:
+                    logger.warning(f"插件 {plugin_id} 下载器 "
+                                   f"{getattr(downloader_cls, '__name__', downloader_cls)} 未通过下载器契约校验，拒绝注册："
+                                   f"{'；'.join(_dl_reasons)}")
+                    continue
+                try:
+                    ModuleManager().register_module(downloader_cls, owner=plugin_id)
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 下载器 "
+                                 f"{getattr(downloader_cls, '__name__', downloader_cls)} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -193,6 +193,31 @@ def get_plugin_provided_data_sources(running_plugins, pid: Optional[str] = None)
                 logger.error(f"获取插件 {plugin_id} 注册数据源出错：{str(e)}")
     return ret_sources
 
+def get_plugin_provided_downloaders(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_downloaders() 声明【新增】的下载器（Downloader 域）类，
+    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [downloader_cls, ...]
+    }
+    """
+    ret_downloaders: Dict[str, List[type]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_downloaders") and ObjectUtils.check_method(plugin.provides_downloaders):
+            try:
+                if not plugin.get_state():
+                    continue
+                downloaders = plugin.provides_downloaders() or []
+                if downloaders:
+                    ret_downloaders[plugin_id] = list(downloaders)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册下载器出错：{str(e)}")
+    return ret_downloaders
+
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
     """
     聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -251,6 +251,18 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_downloaders(self) -> List[Type]:
+        """
+        声明本插件向模块层【新增】的下载器（Downloader 域）类，如新的 BT/PT 下载器。
+        provides_modules 的语法糖 + 下载器契约校验：返回的【类】（非实例）须实现 _ModuleBase
+        契约且 get_type()==ModuleType.Downloader，并实现 download / list_torrents / remove_torrents
+        等下载器操作（完整 IDownloader 操作面由 run_module 按方法名分发、按需实现）。
+        子类型用 get_subtype_id() 返回字符串 id（无需扩展封闭 DownloaderType 枚举）。默认不新增。
+
+        [MyDownloaderClass, ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/tests/test_downloader_registration.py
+++ b/tests/test_downloader_registration.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""
+下载器（Downloader 域）一等开放注册回归：
+
+  1. verify_downloader_contract 对合法下载器（_ModuleBase + get_type=Downloader +
+     download/list_torrents/remove_torrents）通过；
+  2. 对错误 ModuleType / 缺下载器方法 / 非模块类 判定失败并给出原因；
+  3. 合法下载器经 register_module 严格验证后正常注册；
+  4. get_plugin_provided_downloaders 聚合器按 owner 归集插件声明的下载器。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_metadata import get_plugin_provided_downloaders
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType
+
+
+class _DownloaderOps(_ModuleBase):
+    """实现 _ModuleBase 契约 + 下载器核心操作的基类。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def download(self, *args, **kwargs):
+        return None
+
+    def list_torrents(self, *args, **kwargs):
+        return []
+
+    def remove_torrents(self, *args, **kwargs):
+        return True
+
+
+class _ValidDownloader(_DownloaderOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+
+
+class _WrongTypeDownloader(_DownloaderOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaRecognize  # 非 Downloader
+
+
+class _MissingMethodDownloader(_ModuleBase):
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def download(self, *args, **kwargs):
+        return None
+
+    def list_torrents(self, *args, **kwargs):
+        return []
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader
+    # 故意缺 remove_torrents
+
+
+class TestVerifyDownloaderContract(TestCase):
+    def test_valid_downloader_passes(self):
+        ok, reasons = ModuleManager.verify_downloader_contract(_ValidDownloader)
+        self.assertTrue(ok, reasons)
+        self.assertEqual(reasons, [])
+
+    def test_wrong_module_type_rejected(self):
+        ok, reasons = ModuleManager.verify_downloader_contract(_WrongTypeDownloader)
+        self.assertFalse(ok)
+        self.assertTrue(any("Downloader" in r for r in reasons))
+
+    def test_missing_method_rejected(self):
+        ok, reasons = ModuleManager.verify_downloader_contract(_MissingMethodDownloader)
+        self.assertFalse(ok)
+        self.assertTrue(any("remove_torrents" in r for r in reasons))
+
+    def test_non_module_rejected(self):
+        ok, reasons = ModuleManager.verify_downloader_contract(str)
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestDownloaderRegistration(TestCase):
+    def setUp(self):
+        self.mgr = ModuleManager()
+        self.owner = "test_dl_owner"
+
+    def tearDown(self):
+        self.mgr.unregister_modules(self.owner)
+
+    def test_valid_downloader_registers(self):
+        accepted = self.mgr.register_module(_ValidDownloader, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(_ValidDownloader.__name__, self.mgr.get_external_module_ids(self.owner))
+
+
+class TestDownloaderAggregator(TestCase):
+    def test_aggregator_collects_enabled_plugin_downloaders(self):
+        class _FakePlugin:
+            def get_state(self):
+                return True
+
+            def provides_downloaders(self):
+                return [_ValidDownloader]
+
+        result = get_plugin_provided_downloaders({"fakeplugin": _FakePlugin()})
+        self.assertEqual(result, {"fakeplugin": [_ValidDownloader]})
+
+    def test_aggregator_skips_disabled_plugin(self):
+        class _DisabledPlugin:
+            def get_state(self):
+                return False
+
+            def provides_downloaders(self):
+                return [_ValidDownloader]
+
+        result = get_plugin_provided_downloaders({"off": _DisabledPlugin()})
+        self.assertEqual(result, {})


### PR DESCRIPTION
下载器升级为门面+后端模式的**第①步（接口地基，纯加法低风险）**。

- `provides_downloaders()` SPI 钩子 + `verify_downloader_contract`(_ModuleBase + get_type==Downloader + download/list_torrents/remove_torrents) + 聚合器 + 接线。
- 真实源核查：**qb/tr/rtorrent 三下载器零误拒**。新增 7 测试；全量 **1577 passed / 0 failed / 0 error**。

后续增量：②DownloaderManager 门面 → ③qb/tr/rtorrent 迁后端 → ④调用方改走门面(最险、需集成测试)。