### PR TITLE
feat: 下载器域升级为门面+后端模式（DownloaderManager）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -16,6 +16,7 @@ from app.core.context import Context, MediaInfo, SubtitleInfo, TorrentInfo
 from app.core.event import EventManager
 from app.core.meta import MetaBase
 from app.core.module import ModuleManager
+from app.helper.downloader_manager import DownloaderManager
 from app.helper.plugin_manager import PluginManager
 from app.db.message_oper import MessageOper
 from app.db.user_oper import UserOper
@@ -60,6 +61,7 @@ class ChainBase(metaclass=ABCMeta):
         self,
         *,
         modulemanager=None,
+        downloadermanager=None,
         eventmanager=None,
         messageoper=None,
         messagehelper=None,
@@ -77,6 +79,8 @@ class ChainBase(metaclass=ABCMeta):
         杜绝位置传参歧义（原 __init__(self) 不接受位置参，无调用方受影响）。
         """
         self.modulemanager = modulemanager or ModuleManager()
+        # 下载器（Downloader 域）门面：下载器相关包装方法经此分发，取代 run_module 字符串 ABI。
+        self.downloadermanager = downloadermanager or DownloaderManager()
         self.eventmanager = eventmanager or EventManager()
         self.messageoper = messageoper or MessageOper()
         self.messagehelper = messagehelper or MessageHelper()
@@ -1206,8 +1210,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: 下载器名称、种子Hash、种子文件布局、错误原因
         """
-        return self.run_module(
-            "download",
+        return self.downloadermanager.download(
             content=content,
             download_dir=download_dir,
             cookie=cookie,
@@ -1252,8 +1255,7 @@ class ChainBase(metaclass=ABCMeta):
         :param include_all_tags:  是否包含未打内置标签的下载任务
         :return: 下载器中符合状态的种子列表
         """
-        return self.run_module(
-            "list_torrents",
+        return self.downloadermanager.list_torrents(
             status=status,
             hashs=hashs,
             downloader=downloader,
@@ -1319,7 +1321,7 @@ class ChainBase(metaclass=ABCMeta):
         :param hashs:  种子Hash
         :param downloader:  下载器
         """
-        return self.run_module("transfer_completed", hashs=hashs, downloader=downloader)
+        return self.downloadermanager.transfer_completed(hashs=hashs, downloader=downloader)
 
     def remove_torrents(
             self,
@@ -1334,8 +1336,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: bool
         """
-        return self.run_module(
-            "remove_torrents",
+        return self.downloadermanager.remove_torrents(
             hashs=hashs,
             delete_file=delete_file,
             downloader=downloader,
@@ -1350,7 +1351,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: bool
         """
-        return self.run_module("start_torrents", hashs=hashs, downloader=downloader)
+        return self.downloadermanager.start_torrents(hashs=hashs, downloader=downloader)
 
     def stop_torrents(
             self, hashs: Union[list, str], downloader: Optional[str] = None
@@ -1361,7 +1362,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: bool
         """
-        return self.run_module("stop_torrents", hashs=hashs, downloader=downloader)
+        return self.downloadermanager.stop_torrents(hashs=hashs, downloader=downloader)
 
     def set_torrents_tag(
             self, hashs: Union[list, str], tags: list, downloader: Optional[str] = None
@@ -1373,7 +1374,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: bool
         """
-        return self.run_module("set_torrents_tag", hashs=hashs, tags=tags, downloader=downloader)
+        return self.downloadermanager.set_torrents_tag(hashs=hashs, tags=tags, downloader=downloader)
 
     def update_torrent(
             self,
@@ -1400,8 +1401,7 @@ class ChainBase(metaclass=ABCMeta):
         :param seeding_time_limit: 做种时间限制，单位分钟
         :return: 各项修改结果
         """
-        return self.run_module(
-            "update_torrent",
+        return self.downloadermanager.update_torrent(
             hash_string=hash_string,
             downloader=downloader,
             download_limit=download_limit,
@@ -1424,8 +1424,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader: 下载器
         :return: 下载器名称到Tracker列表的映射
         """
-        return self.run_module(
-            "get_torrent_trackers",
+        return self.downloadermanager.get_torrent_trackers(
             hash_string=hash_string,
             downloader=downloader,
         )
@@ -1439,7 +1438,7 @@ class ChainBase(metaclass=ABCMeta):
         :param downloader:  下载器
         :return: 种子文件
         """
-        return self.run_module("torrent_files", tid=tid, downloader=downloader)
+        return self.downloadermanager.torrent_files(tid=tid, downloader=downloader)
 
     def media_exists(
             self,

--- a/app/chain/dashboard.py
+++ b/app/chain/dashboard.py
@@ -18,4 +18,4 @@ class DashboardChain(ChainBase):
         """
         下载器信息
         """
-        return self.run_module("downloader_info", downloader=downloader)
+        return self.downloadermanager.downloader_info(downloader=downloader)

--- a/app/helper/downloader_manager.py
+++ b/app/helper/downloader_manager.py
@@ -1,0 +1,253 @@
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+from app.core.event import eventmanager
+from app.core.module import ModuleManager
+from app.helper.message import MessageHelper
+from app.log import logger
+from app.schemas import DownloaderTorrent, DownloaderFile, DownloaderInfo
+from app.schemas.types import EventType, TorrentStatus
+from app.utils.object import ObjectUtils
+from app.utils.singleton import Singleton
+
+
+class DownloaderManager(metaclass=Singleton):
+    """
+    下载器（Downloader 域）门面。
+
+    对照存储域的 FileManager：把"下载器"领域升级为"门面 + 后端"模式——对外提供一组
+    类型化、可发现的统一方法（实现 app.modules.IDownloader 契约的对外面），对内按方法名分发
+    到所有 ModuleType.Downloader 后端模块（内建 Qbittorrent/Transmission/Rtorrent 以及插件经
+    provides_downloaders() 注册的下载器），并按与 ChainBase.run_module 完全一致的合并语义
+    （列表 extend / 非列表取首个非 None）汇总结果。
+
+    设计要点：
+    - **行为等价**：_dispatch 忠实复刻 ChainBase.__execute_system_modules 的分发与合并（含
+      check_signature 分支、异常逐后端续跑、SystemError 事件与消息上报），调用的是与 run_module
+      同一批后端模块方法（后端方法体零改动），故对真实下载器客户端的行为不变；唯一被收敛的是
+      "字符串 ABI 分发"这一隐式面，被显式、类型化的门面取代。tests/test_downloader_facade.py
+      以等价性测试证明门面与 run_module 在各返回形态下结果全等。
+    - **v2 兼容路径保留**：内建下载器仍作为 _ModuleBase 模块注册，ChainBase.run_module("download")
+      等字符串分发仍可用（标记为 v2 兼容路径、计划后续废弃，见各下载器模块类 docstring）。门面
+      不替换该路径，只作为新代码的首选入口叠加其上。
+    - **后端发现**：每次分发实时查询 ModuleManager().get_running_modules(method)，自动纳入运行期
+      注册/卸载的插件下载器，无需门面侧维护后端清单。
+
+    注意：门面只复刻 run_module 的"系统模块"分发面；run_module 另有 get_module 劫持的"插件模块"
+    面（__execute_plugin_modules），实测下载器域无任何插件经该面劫持（劫持集中在存储/整理域），
+    故门面覆盖完整；如需该面的极端兼容场景，run_module 仍在。
+    """
+
+    def __init__(self):
+        self._modulemanager = ModuleManager()
+        self._messagehelper = MessageHelper()
+
+    @staticmethod
+    def _is_valid_empty(ret: Any) -> bool:
+        """
+        判断结果是否为空（与 ChainBase.__is_valid_empty 同义）：元组要求全 None，否则判 is None。
+        """
+        if isinstance(ret, tuple):
+            return all(value is None for value in ret)
+        return ret is None
+
+    def _handle_error(self, err: Exception, module_id: str, module_name: str,
+                      method: str, raise_exception: bool) -> None:
+        """
+        后端方法执行出错处理（复刻 ChainBase.__handle_system_error 的对外可见行为）：
+        raise_exception 为真则抛出；否则记录日志 + 推送系统错误消息 + 发送 SystemError 事件后续跑。
+        """
+        if raise_exception:
+            raise err
+        logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{module_name}发生了错误", message=str(err), role="system")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "module",
+                "module_id": module_id,
+                "module_name": module_name,
+                "module_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    def _dispatch(self, method: str, *args, **kwargs) -> Any:
+        """
+        将下载器方法按方法名分发到所有 Downloader 后端模块并合并结果。
+
+        合并语义与 ChainBase.__execute_system_modules 严格一致：按 get_priority() 升序遍历后端，
+        - 结果为空（None/全 None 元组）→ 取该后端返回值；
+        - 结果与方法签名一致（check_signature，下载器方法因参数数 ≠1 恒为 False）→ 透传；
+        - 结果为列表 → 合并后续后端的列表结果；
+        - 否则（非空非列表，如 bool/tuple/dict）→ 短路停止。
+        单后端异常逐个捕获续跑，不影响其它后端；raise_exception=True 时透传首个异常。
+        """
+        # pop 而非 get：raise_exception 是分发器控制位，不应透传给不接受该参数的后端 func
+        # （下载器后端方法无 raise_exception 形参，透传会触发 TypeError）。
+        raise_exception = bool(kwargs.pop("raise_exception", False))
+        result: Any = None
+        for module in sorted(
+                self._modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            try:
+                func = getattr(module, method)
+                if self._is_valid_empty(result):
+                    result = func(*args, **kwargs)
+                elif ObjectUtils.check_signature(func, result):
+                    result = func(result)
+                elif isinstance(result, list):
+                    temp = func(*args, **kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except Exception as err:
+                self._handle_error(err, module_id, module_name, method, raise_exception)
+        return result
+
+    # ------------------------------------------------------------------ #
+    # IDownloader 对外面：签名与 ChainBase 下载器包装方法一致，便于调用方平滑切换。
+    # ------------------------------------------------------------------ #
+
+    def download(
+            self,
+            content: Union[Path, str, bytes],
+            download_dir: Path,
+            cookie: str,
+            episodes: Set[int] = None,
+            category: Optional[str] = None,
+            label: Optional[str] = None,
+            downloader: Optional[str] = None,
+    ) -> Optional[Tuple[Optional[str], Optional[str], Optional[str], str]]:
+        """
+        添加下载任务。
+        :return: 下载器名称、种子Hash、种子文件布局、错误原因
+        """
+        return self._dispatch(
+            "download",
+            content=content,
+            download_dir=download_dir,
+            cookie=cookie,
+            episodes=episodes,
+            category=category,
+            label=label,
+            downloader=downloader,
+        )
+
+    def list_torrents(
+            self,
+            status: TorrentStatus = None,
+            hashs: Union[list, str] = None,
+            downloader: Optional[str] = None,
+            include_all_tags: bool = False,
+    ) -> Optional[List[DownloaderTorrent]]:
+        """
+        获取下载器种子列表。
+        """
+        return self._dispatch(
+            "list_torrents",
+            status=status,
+            hashs=hashs,
+            downloader=downloader,
+            include_all_tags=include_all_tags,
+        )
+
+    def remove_torrents(
+            self,
+            hashs: Union[str, list],
+            delete_file: bool = True,
+            downloader: Optional[str] = None,
+    ) -> Optional[bool]:
+        """
+        删除下载器种子。
+        """
+        return self._dispatch(
+            "remove_torrents",
+            hashs=hashs,
+            delete_file=delete_file,
+            downloader=downloader,
+        )
+
+    def start_torrents(self, hashs: Union[list, str], downloader: Optional[str] = None) -> Optional[bool]:
+        """
+        开始下载。
+        """
+        return self._dispatch("start_torrents", hashs=hashs, downloader=downloader)
+
+    def stop_torrents(self, hashs: Union[list, str], downloader: Optional[str] = None) -> Optional[bool]:
+        """
+        停止下载。
+        """
+        return self._dispatch("stop_torrents", hashs=hashs, downloader=downloader)
+
+    def set_torrents_tag(
+            self, hashs: Union[list, str], tags: list, downloader: Optional[str] = None
+    ) -> Optional[bool]:
+        """
+        设置种子标签。
+        """
+        return self._dispatch("set_torrents_tag", hashs=hashs, tags=tags, downloader=downloader)
+
+    def update_torrent(
+            self,
+            hash_string: str,
+            downloader: Optional[str] = None,
+            download_limit: Optional[float] = None,
+            upload_limit: Optional[float] = None,
+            tracker_list: Optional[list] = None,
+            save_path: Optional[str] = None,
+            category: Optional[str] = None,
+            ratio_limit: Optional[float] = None,
+            seeding_time_limit: Optional[int] = None,
+    ) -> Optional[Dict[str, bool]]:
+        """
+        修改下载任务属性。
+        """
+        return self._dispatch(
+            "update_torrent",
+            hash_string=hash_string,
+            downloader=downloader,
+            download_limit=download_limit,
+            upload_limit=upload_limit,
+            tracker_list=tracker_list,
+            save_path=save_path,
+            category=category,
+            ratio_limit=ratio_limit,
+            seeding_time_limit=seeding_time_limit,
+        )
+
+    def get_torrent_trackers(
+            self, hash_string: str, downloader: Optional[str] = None
+    ) -> Optional[Dict[str, List[str]]]:
+        """
+        查询下载任务 Tracker 列表。
+        """
+        return self._dispatch("get_torrent_trackers", hash_string=hash_string, downloader=downloader)
+
+    def torrent_files(self, tid: str, downloader: Optional[str] = None) -> Optional[List[DownloaderFile]]:
+        """
+        获取种子文件列表。
+        """
+        return self._dispatch("torrent_files", tid=tid, downloader=downloader)
+
+    def downloader_info(self, downloader: Optional[str] = None) -> Optional[List[DownloaderInfo]]:
+        """
+        获取下载器统计信息。
+        """
+        return self._dispatch("downloader_info", downloader=downloader)
+
+    def transfer_completed(self, hashs: str, downloader: Optional[str] = None) -> None:
+        """
+        下载器转移完成后的处理。
+        """
+        return self._dispatch("transfer_completed", hashs=hashs, downloader=downloader)

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABCMeta
 from enum import Enum
-from typing import Generic, Tuple, Union, TypeVar, Type, Dict, Optional, Callable
+from typing import Generic, Tuple, Union, TypeVar, Type, Dict, List, Set, Optional, Callable, \
+    Protocol, runtime_checkable, TYPE_CHECKING
 from pathlib import Path
 
 from app.helper.service import ServiceConfigHelper
@@ -8,6 +9,11 @@ from app.schemas import Notification, NotificationConf, MediaServerConf, Downloa
 from app.schemas.types import ModuleType, DownloaderType, MediaServerType, MessageChannel, StorageSchema, \
     OtherModulesType, SystemConfigKey
 from app.utils.mixins import ConfigReloadMixin
+
+if TYPE_CHECKING:
+    # 仅用于类型注解，避免在早期导入的 app.modules 顶层引入 schemas 重负载/潜在环。
+    from app.schemas import DownloaderTorrent, DownloaderFile, DownloaderInfo
+    from app.schemas.types import TorrentStatus
 
 
 class _ModuleBase(ConfigReloadMixin, metaclass=ABCMeta):
@@ -239,6 +245,109 @@ class _MessageBase(ServiceBase[TService, NotificationConf]):
                 if message.mtype.value not in switchs:
                     return False
         return True
+
+
+@runtime_checkable
+class IDownloader(Protocol):
+    """
+    下载器（Downloader 域）行为接口契约。
+
+    这是下载器领域的稳定行为接口（对照存储域的 StorageBase）：声明门面
+    app.helper.downloader.DownloaderManager 统一对外暴露、并按方法名分发到各后端的
+    下载器操作面。采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足
+    契约，无需显式继承，避免与 _ModuleBase(ABCMeta)/ServiceBase(Generic) 的元类冲突，
+    亦保证对既有 Qbittorrent/Transmission/Rtorrent 模块零改动即结构兼容。
+
+    `@runtime_checkable` 使 isinstance(obj, IDownloader) 可在运行期校验"是否实现了这些方法名"
+    （注意 Protocol 的 isinstance 只校验方法存在性，不校验签名）。
+
+    约定（与 ChainBase 下载器包装方法签名一致）：
+    - 多实例路由：downloader 参数为具体下载器配置名（config_name）；为 None 时由后端广播到其
+      全部启用实例，门面再跨后端按"列表 extend / 非列表取首个非 None"合并。
+    - torrent_files 统一返回 List[DownloaderFile]（rtorrent 当前仍返回 List[Dict]，属待归一化的
+      P0.5 后端修复项，见 app/modules/rtorrent/__init__.py 的 TODO，本接口声明目标类型）。
+    """
+
+    def download(
+            self,
+            content: "Union[Path, str, bytes]",
+            download_dir: Path,
+            cookie: str,
+            episodes: "Set[int]" = None,
+            category: Optional[str] = None,
+            label: Optional[str] = None,
+            downloader: Optional[str] = None,
+    ) -> "Optional[Tuple[Optional[str], Optional[str], Optional[str], str]]":
+        """添加下载任务，返回 (下载器名, 种子Hash, 种子文件布局, 错误原因)。"""
+        ...
+
+    def list_torrents(
+            self,
+            status: "TorrentStatus" = None,
+            hashs: "Union[list, str]" = None,
+            downloader: Optional[str] = None,
+            include_all_tags: bool = False,
+    ) -> "Optional[List[DownloaderTorrent]]":
+        """获取下载器种子列表。"""
+        ...
+
+    def remove_torrents(
+            self,
+            hashs: "Union[str, list]",
+            delete_file: bool = True,
+            downloader: Optional[str] = None,
+    ) -> Optional[bool]:
+        """删除下载器种子。"""
+        ...
+
+    def start_torrents(self, hashs: "Union[list, str]", downloader: Optional[str] = None) -> Optional[bool]:
+        """开始下载。"""
+        ...
+
+    def stop_torrents(self, hashs: "Union[list, str]", downloader: Optional[str] = None) -> Optional[bool]:
+        """停止下载。"""
+        ...
+
+    def set_torrents_tag(
+            self, hashs: "Union[list, str]", tags: list, downloader: Optional[str] = None
+    ) -> Optional[bool]:
+        """设置种子标签。"""
+        ...
+
+    def update_torrent(
+            self,
+            hash_string: str,
+            downloader: Optional[str] = None,
+            download_limit: Optional[float] = None,
+            upload_limit: Optional[float] = None,
+            tracker_list: Optional[list] = None,
+            save_path: Optional[str] = None,
+            category: Optional[str] = None,
+            ratio_limit: Optional[float] = None,
+            seeding_time_limit: Optional[int] = None,
+    ) -> "Optional[Dict[str, bool]]":
+        """修改下载任务属性。"""
+        ...
+
+    def get_torrent_trackers(
+            self, hash_string: str, downloader: Optional[str] = None
+    ) -> "Optional[Dict[str, List[str]]]":
+        """查询下载任务 Tracker 列表。"""
+        ...
+
+    def torrent_files(
+            self, tid: str, downloader: Optional[str] = None
+    ) -> "Optional[List[DownloaderFile]]":
+        """获取种子文件列表。"""
+        ...
+
+    def downloader_info(self, downloader: Optional[str] = None) -> "Optional[List[DownloaderInfo]]":
+        """获取下载器统计信息。"""
+        ...
+
+    def transfer_completed(self, hashs: str, downloader: Optional[str] = None) -> None:
+        """下载器转移完成后的处理。"""
+        ...
 
 
 class _DownloaderBase(ServiceBase[TService, DownloaderConf]):

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -39,6 +39,15 @@ _QBITTORRENT_PAUSED_STATES = {
 
 
 class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
+    """
+    Qbittorrent 下载器模块（app.modules.IDownloader 后端）。
+
+    作为 Downloader 域后端，由门面 app.helper.downloader_manager.DownloaderManager 统一分发调用。
+
+    .. deprecated::
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
+        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+    """
 
     def init_module(self) -> None:
         """

--- a/app/modules/rtorrent/__init__.py
+++ b/app/modules/rtorrent/__init__.py
@@ -22,6 +22,24 @@ from app.utils.string import StringUtils
 
 
 class RtorrentModule(_ModuleBase, _DownloaderBase[Rtorrent]):
+    """
+    Rtorrent 下载器模块（app.modules.IDownloader 后端）。
+
+    作为 Downloader 域后端，由门面 app.helper.downloader_manager.DownloaderManager 统一分发调用。
+
+    .. deprecated::
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
+        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+
+    TODO(IDownloader 归一化): 本模块 torrent_files() 当前返回 List[Dict]，而 qbittorrent/transmission
+        已归一化为 List[schemas.DownloaderFile]。IDownloader 契约声明统一返回 List[DownloaderFile]，
+        rtorrent 的归一化属独立的 P0.5 后端修复项（需 Rtorrent.get_files() 字段映射 + 真实 rtorrent
+        集成验证），本次门面改造不动其行为，留待后续单独修复。
+
+    已知能力缺口: 本模块为部分后端，未实现 get_torrent_trackers（qb/tr 已实现）。下载器方法按名分发，
+        门面/run_module 仅把实现了该方法的后端纳入调用，故缺该方法不影响其它操作；如需补齐另行处理。
+    """
+
     def init_module(self) -> None:
         """
         初始化模块

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -30,6 +30,15 @@ _TRANSMISSION_PAUSED_STATES = {
 
 
 class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
+    """
+    Transmission 下载器模块（app.modules.IDownloader 后端）。
+
+    作为 Downloader 域后端，由门面 app.helper.downloader_manager.DownloaderManager 统一分发调用。
+
+    .. deprecated::
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
+        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+    """
 
     def init_module(self) -> None:
         """

--- a/tests/test_downloader_facade.py
+++ b/tests/test_downloader_facade.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+"""
+下载器门面 DownloaderManager 回归测试。
+
+核心是 **等价性测试**：证明门面 _dispatch 与 ChainBase.run_module 在各返回形态下结果全等——
+门面调用的是与 run_module 同一批后端模块方法，唯一可能分歧的是分发/合并逻辑，本测试以受控
+mock 后端覆盖 None / 列表合并 / bool 短路 / tuple 短路 / dict 短路 / 优先级排序 各分支，
+锁死"门面 == run_module"。另含：公开方法路由、后端异常逐个续跑、raise_exception 透传、
+内建 qb/tr/rtorrent 结构化满足 IDownloader 契约。
+"""
+from unittest import TestCase
+
+from app.chain import ChainBase
+from app.core.module import ModuleManager
+from app.helper.downloader_manager import DownloaderManager
+from app.modules import IDownloader, _ModuleBase
+from app.schemas.types import ModuleType
+
+
+class _TestChain(ChainBase):
+    """用于对照 run_module 的可实例化 ChainBase 子类。"""
+    pass
+
+
+class _ProbeBackend(_ModuleBase):
+    """
+    受控 mock 下载器后端：以自定义 probe 方法承载各返回形态，priority/name 可配置。
+    probe 对列表返回值每次返回新副本，避免 run_module 的 result.extend 原地修改污染
+    后续（门面）调用的返回值。
+    """
+
+    def __init__(self, name="mock", priority=1, probe_return=None, raises=False):
+        super().__init__()
+        self._name = name
+        self._priority = priority
+        self._probe_return = probe_return
+        self._raises = raises
+        self.probe_calls = []
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self):
+        pass
+
+    def test(self):
+        return True, ""
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return self._priority
+
+    def get_type(self):
+        return ModuleType.Downloader
+
+    def probe(self, *args, **kwargs):
+        self.probe_calls.append(kwargs)
+        if self._raises:
+            raise RuntimeError(f"{self._name} boom")
+        ret = self._probe_return
+        return list(ret) if isinstance(ret, list) else ret
+
+
+class _DownloaderBackend(_ModuleBase):
+    """实现真实下载器方法名的 mock 后端，用于验证门面公开方法的路由与传参。"""
+
+    def __init__(self, name="dl"):
+        super().__init__()
+        self._name = name
+        self.calls = {}
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self):
+        pass
+
+    def test(self):
+        return True, ""
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return 1
+
+    def get_type(self):
+        return ModuleType.Downloader
+
+    def download(self, **kwargs):
+        self.calls["download"] = kwargs
+        return ("dl", "HASH", "layout", "")
+
+    def list_torrents(self, **kwargs):
+        self.calls["list_torrents"] = kwargs
+        return ["t1"]
+
+    def remove_torrents(self, **kwargs):
+        self.calls["remove_torrents"] = kwargs
+        return True
+
+    def downloader_info(self, **kwargs):
+        self.calls["downloader_info"] = kwargs
+        return ["info"]
+
+    def transfer_completed(self, **kwargs):
+        self.calls["transfer_completed"] = kwargs
+        return None
+
+
+def _patch_running(backends):
+    """把给定后端注入 ModuleManager 单例的 _running_modules，返回 (mgr, 原字典) 以便还原。"""
+    mgr = ModuleManager()
+    orig = mgr._running_modules
+    mgr._running_modules = {b._name: b for b in backends}
+    return mgr, orig
+
+
+class TestDispatchEquivalence(TestCase):
+    """门面 _dispatch 与 ChainBase.run_module 行为等价。"""
+
+    def _both(self, backends, **kwargs):
+        mgr, orig = _patch_running(backends)
+        try:
+            chain = _TestChain()
+            via_run_module = chain.run_module("probe", **kwargs)
+            via_facade = DownloaderManager()._dispatch("probe", **kwargs)
+            return via_run_module, via_facade
+        finally:
+            mgr._running_modules = orig
+
+    def test_all_none(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, None), _ProbeBackend("b", 2, None)])
+        self.assertIsNone(rm)
+        self.assertEqual(rm, fc)
+
+    def test_list_merge_two_backends(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, [1, 2]), _ProbeBackend("b", 2, [3])])
+        self.assertEqual(rm, [1, 2, 3])
+        self.assertEqual(rm, fc)
+
+    def test_list_merge_with_leading_none(self):
+        rm, fc = self._both([
+            _ProbeBackend("a", 1, None),
+            _ProbeBackend("b", 2, [3, 4]),
+            _ProbeBackend("c", 3, [5]),
+        ])
+        self.assertEqual(rm, [3, 4, 5])
+        self.assertEqual(rm, fc)
+
+    def test_bool_short_circuit(self):
+        # 首个非空非列表（bool）短路，后续列表不应被合并
+        rm, fc = self._both([_ProbeBackend("a", 1, True), _ProbeBackend("b", 2, [9])])
+        self.assertEqual(rm, True)
+        self.assertEqual(rm, fc)
+
+    def test_tuple_short_circuit(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, ("x", "y")), _ProbeBackend("b", 2, ("z", "w"))])
+        self.assertEqual(rm, ("x", "y"))
+        self.assertEqual(rm, fc)
+
+    def test_all_none_tuple_treated_empty(self):
+        # 全 None 元组视为空 → 继续下一后端（与 __is_valid_empty 一致）
+        rm, fc = self._both([
+            _ProbeBackend("a", 1, (None, None)),
+            _ProbeBackend("b", 2, ("got", None)),
+        ])
+        self.assertEqual(rm, ("got", None))
+        self.assertEqual(rm, fc)
+
+    def test_dict_result(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, None), _ProbeBackend("b", 2, {"x": True})])
+        self.assertEqual(rm, {"x": True})
+        self.assertEqual(rm, fc)
+
+    def test_priority_ordering(self):
+        # 以插入逆序提供，应按 priority 升序遍历得到 [low_priority_first]
+        rm, fc = self._both([
+            _ProbeBackend("late", 9, [99]),
+            _ProbeBackend("early", 1, [1]),
+        ])
+        self.assertEqual(rm, [1, 99])
+        self.assertEqual(rm, fc)
+
+
+class TestPublicMethodRouting(TestCase):
+    """门面公开方法路由到正确后端方法并透传参数。"""
+
+    def setUp(self):
+        self.backend = _DownloaderBackend("dl")
+        self.mgr, self.orig = _patch_running([self.backend])
+        self.dm = DownloaderManager()
+
+    def tearDown(self):
+        self.mgr._running_modules = self.orig
+
+    def test_download_routes(self):
+        from pathlib import Path
+        ret = self.dm.download(content="magnet:x", download_dir=Path("/d"), cookie="c", downloader="dl")
+        self.assertEqual(ret, ("dl", "HASH", "layout", ""))
+        self.assertEqual(self.backend.calls["download"]["content"], "magnet:x")
+        self.assertEqual(self.backend.calls["download"]["downloader"], "dl")
+
+    def test_list_torrents_routes(self):
+        ret = self.dm.list_torrents(downloader="dl")
+        self.assertEqual(ret, ["t1"])
+        self.assertIn("list_torrents", self.backend.calls)
+
+    def test_remove_torrents_routes(self):
+        ret = self.dm.remove_torrents(hashs="H", downloader="dl")
+        self.assertTrue(ret)
+        self.assertEqual(self.backend.calls["remove_torrents"]["hashs"], "H")
+
+    def test_downloader_info_routes(self):
+        ret = self.dm.downloader_info(downloader="dl")
+        self.assertEqual(ret, ["info"])
+
+    def test_transfer_completed_routes(self):
+        ret = self.dm.transfer_completed(hashs="H", downloader="dl")
+        self.assertIsNone(ret)
+        self.assertEqual(self.backend.calls["transfer_completed"]["hashs"], "H")
+
+
+class TestErrorHandling(TestCase):
+    """后端异常逐个续跑；raise_exception 透传。"""
+
+    def test_error_continues_to_next_backend(self):
+        backends = [_ProbeBackend("boom", 1, raises=True), _ProbeBackend("ok", 2, "value")]
+        mgr, orig = _patch_running(backends)
+        try:
+            ret = DownloaderManager()._dispatch("probe")
+            self.assertEqual(ret, "value")
+            # 同样地 run_module 也续跑到下一个后端
+            self.assertEqual(_TestChain().run_module("probe"), "value")
+        finally:
+            mgr._running_modules = orig
+
+    def test_raise_exception_propagates(self):
+        backends = [_ProbeBackend("boom", 1, raises=True)]
+        mgr, orig = _patch_running(backends)
+        try:
+            with self.assertRaises(RuntimeError):
+                DownloaderManager()._dispatch("probe", raise_exception=True)
+        finally:
+            mgr._running_modules = orig
+
+
+class TestIDownloaderContract(TestCase):
+    """
+    内建下载器模块对 IDownloader 契约的符合度。
+
+    IDownloader 是下载器域的 **最大化** 行为面（11 方法）：门面对外暴露全部，后端按方法名分发、
+    可只实现子集（run_module/门面经 get_running_modules(method) 仅纳入实现了该方法的后端）。
+    因此强制核心仅 download/list_torrents/remove_torrents（与 verify_downloader_contract 一致），
+    其余方法可选。本测试固定该事实：核心方法所有内建下载器必有；完整面仅 qb/tr 满足；
+    rtorrent 为部分后端（已知缺 get_torrent_trackers，见其模块 docstring 的 TODO）。
+    """
+
+    _CORE = ("download", "list_torrents", "remove_torrents")
+    _FULL = (
+        "download", "list_torrents", "remove_torrents", "start_torrents", "stop_torrents",
+        "set_torrents_tag", "update_torrent", "get_torrent_trackers", "torrent_files",
+        "downloader_info", "transfer_completed",
+    )
+
+    def test_all_builtins_implement_core(self):
+        from app.modules.qbittorrent import QbittorrentModule
+        from app.modules.transmission import TransmissionModule
+        from app.modules.rtorrent import RtorrentModule
+        for cls in (QbittorrentModule, TransmissionModule, RtorrentModule):
+            for name in self._CORE:
+                self.assertTrue(callable(getattr(cls, name, None)),
+                                f"{cls.__name__} 缺少下载器核心方法 {name}")
+
+    def test_qb_tr_satisfy_full_contract(self):
+        from app.modules.qbittorrent import QbittorrentModule
+        from app.modules.transmission import TransmissionModule
+        for cls in (QbittorrentModule, TransmissionModule):
+            for name in self._FULL:
+                self.assertTrue(callable(getattr(cls, name, None)),
+                                f"{cls.__name__} 缺少 IDownloader 方法 {name}")
+            # runtime_checkable Protocol：方法齐全的类应被识别为 IDownloader 子类
+            self.assertTrue(issubclass(cls, IDownloader), f"{cls.__name__} 未结构化满足 IDownloader")
+
+    def test_rtorrent_is_partial_backend(self):
+        # 锁定已知缺口：rtorrent 实现完整面减去 get_torrent_trackers。若后续补齐应同步放宽此断言。
+        from app.modules.rtorrent import RtorrentModule
+        missing = [name for name in self._FULL if not callable(getattr(RtorrentModule, name, None))]
+        self.assertEqual(missing, ["get_torrent_trackers"])
+
+    def test_facade_exposes_full_contract(self):
+        for name in self._FULL:
+            self.assertTrue(callable(getattr(DownloaderManager, name, None)),
+                            f"DownloaderManager 缺少 IDownloader 方法 {name}")


### PR DESCRIPTION
## 概述

照存储域 `FileManager` 范式，把"下载器"领域升级为 **门面 + 后端** 模式。**门面作叠加层、v2 字符串分发路径保留并标记废弃**，对真实下载器客户端行为**零变更**。续 #62（下载器开放注册）的接口地基，落地门面化路线的增量 ②③④。

## 改动

| 类型 | 文件 | 说明 |
|------|------|------|
| 新增 | `app/helper/downloader_manager.py` | `DownloaderManager` 单例门面。`_dispatch` 忠实复刻 `ChainBase.__execute_system_modules`（四分支合并 + 优先级排序 + 异常逐后端续跑 + SystemError 事件/消息上报），按方法名分发到所有 `ModuleType.Downloader` 后端；对外 11 个类型化方法 |
| 新增 | `app/modules/IDownloader` | Downloader 域最大化行为接口（`runtime_checkable` Protocol，结构化类型，不强制继承避免元类冲突；按名分发，后端可只实现子集） |
| 改 | `app/chain/__init__.py` | DI 注入 `downloadermanager`；10 个下载器包装方法改走门面；`download_added`/`transfer`（非下载器域）保持 `run_module` 不变 |
| 改 | `app/chain/dashboard.py` | `downloader_info` 改走门面 |
| 改 | qb/tr/rtorrent 模块 | docstring 标注 v2 字符串分发路径即将废弃；rtorrent 记 `torrent_files` 归一化 + `get_torrent_trackers` 缺口两个 TODO |

## 设计与安全论证

- **行为等价**：门面调用的是与 `run_module` **同一批后端模块方法**（后端方法体零改动），唯一可能分歧的是分发/合并逻辑。`check_signature(func,result)` 对下载器方法（参数 ≥2）**恒 False**，故下载器分发是「列表 extend / 非列表取首个非 None」的简单合并，门面可忠实复刻。
- **v2 兼容**：内建下载器仍作为 `_ModuleBase` 模块注册，`run_module("download")` 等字符串分发**仍可用**；门面不替换该路径，只作为新代码首选入口叠加其上。
- **门面只复刻系统模块分发面**；`run_module` 的 get_module 劫持「插件模块」面下载器域无任何插件使用，覆盖完整。

## 测试

`tests/test_downloader_facade.py`（19 用例）：
- **等价性测试**：门面 `_dispatch` == `run_module` 在 None / 列表合并 / bool 短路 / tuple 短路 / dict / 优先级排序 各返回形态下结果全等
- 公开方法路由与传参、后端异常逐个续跑、`raise_exception` 透传、内建 qb/tr/rtorrent 对 IDownloader 契约符合度（核心 3 方法全后端必有；完整面 qb/tr 满足；rtorrent 为部分后端，已知缺 `get_torrent_trackers`）

全量 **1596 passed / 19 skipped / 0 failed**，零回归。经 code-reviewer 审查 APPROVE（0 Critical/High），已采纳 1 MEDIUM（`raise_exception` pop 防 TypeError 地雷）+ 1 LOW（get_name 异常补 debug 日志）。

## 后续（独立项，本 PR 不含）

- rtorrent `torrent_files` 归一化为 `List[DownloaderFile]`（需真实 rtorrent 集成验证）
- 媒体服务器域可照此门面化