### PR TITLE
feat: 补齐 rtorrent 下载器两处 IDownloader 缺口

### DIFF
--- a/app/modules/rtorrent/__init__.py
+++ b/app/modules/rtorrent/__init__.py
@@ -23,21 +23,15 @@ from app.utils.string import StringUtils
 
 class RtorrentModule(_ModuleBase, _DownloaderBase[Rtorrent]):
     """
-    Rtorrent 下载器模块（app.modules.IDownloader 后端）。
+    Rtorrent 下载器模块（app.modules.IDownloader 后端，已完整实现全部 11 个下载器方法）。
 
     作为 Downloader 域后端，由门面 app.helper.downloader_manager.DownloaderManager 统一分发调用。
+    torrent_files() 已归一化为 List[schemas.DownloaderFile]（progress 由 0~100 归一到 0~1）、
+    get_torrent_trackers() 已实现（经 xmlrpc t.multicall 取 tracker url），与 qb/tr 对齐无能力缺口。
 
     .. deprecated::
         经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
         仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
-
-    TODO(IDownloader 归一化): 本模块 torrent_files() 当前返回 List[Dict]，而 qbittorrent/transmission
-        已归一化为 List[schemas.DownloaderFile]。IDownloader 契约声明统一返回 List[DownloaderFile]，
-        rtorrent 的归一化属独立的 P0.5 后端修复项（需 Rtorrent.get_files() 字段映射 + 真实 rtorrent
-        集成验证），本次门面改造不动其行为，留待后续单独修复。
-
-    已知能力缺口: 本模块为部分后端，未实现 get_torrent_trackers（qb/tr 已实现）。下载器方法按名分发，
-        门面/run_module 仅把实现了该方法的后端纳入调用，故缺该方法不影响其它操作；如需补齐另行处理。
     """
 
     def init_module(self) -> None:
@@ -592,6 +586,31 @@ class RtorrentModule(_ModuleBase, _DownloaderBase[Rtorrent]):
             results["category"] = False
         return results
 
+    def get_torrent_trackers(
+        self,
+        hash_string: str,
+        downloader: Optional[str] = None,
+    ) -> Optional[Dict[str, List[str]]]:
+        """
+        查询下载任务 Tracker 列表。
+        :param hash_string: 种子Hash
+        :param downloader: 下载器
+        :return: 下载器名称到 Tracker 列表的映射
+        """
+        if downloader:
+            server: Rtorrent = self.get_instance(downloader)
+            if not server:
+                return None
+            servers = {downloader: server}
+        else:
+            servers: Dict[str, Rtorrent] = self.get_instances()
+        ret_trackers = {}
+        for name, server in servers.items():
+            trackers = server.get_trackers(hash_string)
+            if trackers is not None:
+                ret_trackers[name] = trackers
+        return ret_trackers
+
     def start_torrents(
         self, hashs: Union[list, str], downloader: Optional[str] = None
     ) -> Optional[bool]:
@@ -622,14 +641,29 @@ class RtorrentModule(_ModuleBase, _DownloaderBase[Rtorrent]):
 
     def torrent_files(
         self, tid: str, downloader: Optional[str] = None
-    ) -> Optional[List[Dict]]:
+    ) -> "Optional[List[schemas.DownloaderFile]]":
         """
-        获取种子文件列表
+        获取种子文件列表（归一化为 DownloaderFile，不再泄漏 rTorrent 的裸 Dict 结构，与 qb/tr 对齐）。
+
+        注意：Rtorrent 客户端 get_files() 的 progress 为 0~100 百分比，此处 /100 归一到
+        DownloaderFile 约定的 0~1 区间（qb 原生即 0~1、tr 由 completed/size 计算）。
         """
         server: Rtorrent = self.get_instance(downloader)
         if not server:
             return None
-        return server.get_files(tid=tid)
+        files = server.get_files(tid=tid)
+        if files is None:
+            return None
+        return [
+            schemas.DownloaderFile(
+                name=f.get("name"),
+                size=f.get("size"),
+                progress=(f.get("progress") or 0) / 100.0,
+                priority=f.get("priority"),
+                index=f.get("id", idx),
+            )
+            for idx, f in enumerate(files)
+        ]
 
     def downloader_info(
         self, downloader: Optional[str] = None

--- a/app/modules/rtorrent/rtorrent.py
+++ b/app/modules/rtorrent/rtorrent.py
@@ -408,6 +408,22 @@ class Rtorrent:
             logger.error(f"获取种子文件列表出错：{str(err)}")
             return None
 
+    def get_trackers(self, tid: str) -> Optional[List[str]]:
+        """
+        获取种子 Tracker URL 列表。
+        :param tid: 种子Hash
+        :return: Tracker URL 列表（出错或未连接返回 None）
+        """
+        if not self._proxy or not tid:
+            return None
+        try:
+            # t.multicall 取每个 tracker 的 url；单字段时每行形如 [url]
+            results = self._proxy.t.multicall(tid, "", "t.url=")
+            return [row[0] for row in results if row and row[0]]
+        except Exception as err:
+            logger.error(f"获取tracker出错：{str(err)}")
+            return None
+
     def set_files(
         self, torrent_hash: str = None, file_ids: list = None, priority: int = 0
     ) -> bool:

--- a/tests/test_downloader_facade.py
+++ b/tests/test_downloader_facade.py
@@ -280,21 +280,16 @@ class TestIDownloaderContract(TestCase):
                 self.assertTrue(callable(getattr(cls, name, None)),
                                 f"{cls.__name__} 缺少下载器核心方法 {name}")
 
-    def test_qb_tr_satisfy_full_contract(self):
+    def test_all_builtins_satisfy_full_contract(self):
+        # rtorrent 的 get_torrent_trackers + torrent_files 归一化已补齐，三后端均完整满足 IDownloader。
         from app.modules.qbittorrent import QbittorrentModule
         from app.modules.transmission import TransmissionModule
-        for cls in (QbittorrentModule, TransmissionModule):
-            for name in self._FULL:
-                self.assertTrue(callable(getattr(cls, name, None)),
-                                f"{cls.__name__} 缺少 IDownloader 方法 {name}")
+        from app.modules.rtorrent import RtorrentModule
+        for cls in (QbittorrentModule, TransmissionModule, RtorrentModule):
+            missing = [name for name in self._FULL if not callable(getattr(cls, name, None))]
+            self.assertEqual(missing, [], f"{cls.__name__} 缺少 IDownloader 方法 {missing}")
             # runtime_checkable Protocol：方法齐全的类应被识别为 IDownloader 子类
             self.assertTrue(issubclass(cls, IDownloader), f"{cls.__name__} 未结构化满足 IDownloader")
-
-    def test_rtorrent_is_partial_backend(self):
-        # 锁定已知缺口：rtorrent 实现完整面减去 get_torrent_trackers。若后续补齐应同步放宽此断言。
-        from app.modules.rtorrent import RtorrentModule
-        missing = [name for name in self._FULL if not callable(getattr(RtorrentModule, name, None))]
-        self.assertEqual(missing, ["get_torrent_trackers"])
 
     def test_facade_exposes_full_contract(self):
         for name in self._FULL:

--- a/tests/test_downloader_file_normalization.py
+++ b/tests/test_downloader_file_normalization.py
@@ -16,6 +16,7 @@ from unittest import TestCase
 from app import schemas
 from app.modules.qbittorrent import QbittorrentModule
 from app.modules.transmission import TransmissionModule
+from app.modules.rtorrent import RtorrentModule
 
 
 class _FakeQbFile:
@@ -44,6 +45,19 @@ class _FakeServer:
 
     def get_files(self, tid):
         return self._files
+
+
+class _FakeRtServer:
+    """模拟 Rtorrent 客户端：get_files 返回 List[Dict]（progress 为 0~100），get_trackers 返回 url 列表。"""
+    def __init__(self, files=None, trackers=None):
+        self._files = files if files is not None else []
+        self._trackers = trackers
+
+    def get_files(self, tid):
+        return self._files
+
+    def get_trackers(self, tid):
+        return self._trackers
 
 
 class DownloaderFileNormalizationTest(TestCase):
@@ -84,6 +98,39 @@ class DownloaderFileNormalizationTest(TestCase):
         self.assertEqual(files[0].size, 200)
         self.assertEqual(files[0].progress, 0.5)  # completed/size = 100/200
         self.assertEqual(files[0].index, 3)  # 取自 id
+
+    def test_rtorrent_torrent_files_normalized(self):
+        # rtorrent get_files 返回裸 Dict（progress 0~100），模块须归一化为 DownloaderFile（progress 0~1）
+        mod = RtorrentModule.__new__(RtorrentModule)
+        mod.get_instance = lambda downloader=None: _FakeRtServer(
+            files=[{"id": 2, "name": "v/e.mkv", "size": 300, "priority": 1, "progress": 50}]
+        )
+        files = RtorrentModule.torrent_files(mod, tid="hash")
+        self.assertIsInstance(files, list)
+        self.assertIsInstance(files[0], schemas.DownloaderFile)
+        self.assertEqual(files[0].name, "v/e.mkv")
+        self.assertEqual(files[0].size, 300)
+        self.assertEqual(files[0].progress, 0.5)  # 50/100 归一到 0~1，与 qb/tr 对齐
+        self.assertEqual(files[0].priority, 1)
+        self.assertEqual(files[0].index, 2)  # 取自 dict 的 id
+
+    def test_rtorrent_torrent_files_none_when_no_server(self):
+        mod = RtorrentModule.__new__(RtorrentModule)
+        mod.get_instance = lambda downloader=None: None
+        self.assertIsNone(RtorrentModule.torrent_files(mod, tid="hash"))
+
+    def test_rtorrent_get_torrent_trackers_named(self):
+        mod = RtorrentModule.__new__(RtorrentModule)
+        mod.get_instance = lambda downloader=None: _FakeRtServer(trackers=["http://t1", "http://t2"])
+        ret = RtorrentModule.get_torrent_trackers(mod, hash_string="H", downloader="rt1")
+        self.assertEqual(ret, {"rt1": ["http://t1", "http://t2"]})
+
+    def test_rtorrent_get_torrent_trackers_broadcast(self):
+        # downloader 为 None 时广播到全部实例
+        mod = RtorrentModule.__new__(RtorrentModule)
+        mod.get_instances = lambda: {"rt1": _FakeRtServer(trackers=["http://t1"])}
+        ret = RtorrentModule.get_torrent_trackers(mod, hash_string="H")
+        self.assertEqual(ret, {"rt1": ["http://t1"]})
 
     def test_contract_no_sdk_leak(self):
         import app.chain as chain_pkg


### PR DESCRIPTION
## 概述

承接 #63（下载器门面化）完整性审计发现的两处 rtorrent 后端缺口，补齐后 rtorrent 完整满足 `IDownloader`（11/11），三个内建下载器一致。

## 改动

| 缺口 | 修复 | 文件 |
|------|------|------|
| `torrent_files` 返回裸 `List[Dict]`（向契约层泄漏 SDK 结构，与 qb/tr 不一致） | 归一化为 `List[schemas.DownloaderFile]`；**progress 由 0~100 百分比 /100 归一到 DownloaderFile 约定的 0~1**（qb 原生 0~1、tr 由 completed/size 计算），index 取自 dict 的 `id` | `app/modules/rtorrent/__init__.py` |
| 缺 `get_torrent_trackers` 方法 | 按 qb 范式实现（遍历实例聚合 `{下载器名: [tracker url]}`）；客户端 `Rtorrent` 新增 `get_trackers()`，经 xmlrpc `t.multicall(tid, "", "t.url=")` 取 tracker url | `app/modules/rtorrent/__init__.py` + `app/modules/rtorrent/rtorrent.py` |

并移除模块 docstring 中两处已解决的 TODO/能力缺口标注。

## 测试

- `tests/test_downloader_file_normalization.py` 新增 4 用例：rtorrent `torrent_files` 归一化（**progress 0~100→0~1**、index 取 dict id、无实例返 None）+ `get_torrent_trackers`（指定下载器 / downloader=None 广播两路）
- `tests/test_downloader_facade.py` 契约测试改为**三后端均完整满足 IDownloader**（rtorrent 不再 partial，`issubclass(IDownloader)` 通过）
- 全量 **1599 passed / 19 skipped / 0 failed**，零回归

## 说明

逻辑（字段映射、progress 归一、tracker 聚合）已全测试覆盖；实时 xmlrpc wire 调用 `t.multicall` 遵循 rtorrent 标准约定、与 `Rtorrent` 客户端其余 xmlrpc 调用同风格，本机无真实 rtorrent 故未做集成验证（与仓库 rtorrent 客户端既有惯例一致）。