### PR TITLE
feat: 消息渠道/媒体服务器/发现推荐域开放注册（对齐 #61/#62 范式）

### DIFF
--- a/app/api/endpoints/discover.py
+++ b/app/api/endpoints/discover.py
@@ -8,6 +8,7 @@ from app.chain.douban import DoubanChain
 from app.chain.tmdb import TmdbChain
 from app.core.event import eventmanager
 from app.core.security import verify_token
+from app.helper.plugin_manager import PluginManager
 from app.schemas import DiscoverSourceEventData
 from app.schemas.types import ChainEventType, MediaType
 
@@ -21,17 +22,30 @@ router = APIRouter()
 )
 def source(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
-    获取探索数据源
+    获取探索数据源：合并插件声明式注册（provides_discover_sources）与事件扩展
+    （ChainEventType.DiscoverSource），按 api_path 去重。
     """
-    # 广播事件，请示额外的探索数据源支持
+    sources: List[schemas.DiscoverMediaSource] = []
+    seen_paths = set()
+
+    def _collect(items):
+        for src in items or []:
+            api_path = getattr(src, "api_path", None)
+            if not src or api_path in seen_paths:
+                continue
+            seen_paths.add(api_path)
+            sources.append(src)
+
+    # 1) 插件声明式注册的探索数据源
+    for plugin_sources in PluginManager().get_plugin_provided_discover_sources().values():
+        _collect(plugin_sources)
+    # 2) 广播事件，请示额外的探索数据源支持（向后兼容既有事件扩展）
     event_data = DiscoverSourceEventData()
     event = eventmanager.send_event(ChainEventType.DiscoverSource, event_data)
-    # 使用事件返回的上下文数据
     if event and event.event_data:
         event_data: DiscoverSourceEventData = event.event_data
-        if event_data.extra_sources:
-            return event_data.extra_sources
-    return []
+        _collect(event_data.extra_sources)
+    return sources
 
 
 @router.get("/bangumi", summary="探索Bangumi", response_model=List[schemas.MediaInfo])

--- a/app/api/endpoints/discover.py
+++ b/app/api/endpoints/discover.py
@@ -30,8 +30,9 @@ def source(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
 
     def _collect(items):
         for src in items or []:
-            api_path = getattr(src, "api_path", None)
-            if not src or api_path in seen_paths:
+            api_path = getattr(src, "api_path", None) if src else None
+            # 跳过畸形源（无 api_path），逐个忽略而非把 None 塞进去重集吞掉后续源
+            if api_path is None or api_path in seen_paths:
                 continue
             seen_paths.add(api_path)
             sources.append(src)

--- a/app/api/endpoints/recommend.py
+++ b/app/api/endpoints/recommend.py
@@ -28,8 +28,9 @@ def source(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
 
     def _collect(items):
         for src in items or []:
-            api_path = getattr(src, "api_path", None)
-            if not src or api_path in seen_paths:
+            api_path = getattr(src, "api_path", None) if src else None
+            # 跳过畸形源（无 api_path），逐个忽略而非把 None 塞进去重集吞掉后续源
+            if api_path is None or api_path in seen_paths:
                 continue
             seen_paths.add(api_path)
             sources.append(src)

--- a/app/api/endpoints/recommend.py
+++ b/app/api/endpoints/recommend.py
@@ -6,6 +6,7 @@ from app import schemas
 from app.chain.recommend import RecommendChain
 from app.core.event import eventmanager
 from app.core.security import verify_token
+from app.helper.plugin_manager import PluginManager
 from app.schemas import RecommendSourceEventData
 from app.schemas.types import ChainEventType
 
@@ -19,17 +20,30 @@ router = APIRouter()
 )
 def source(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
-    获取推荐数据源
+    获取推荐数据源：合并插件声明式注册（provides_recommend_sources）与事件扩展
+    （ChainEventType.RecommendSource），按 api_path 去重。
     """
-    # 广播事件，请示额外的推荐数据源支持
+    sources: List[schemas.RecommendMediaSource] = []
+    seen_paths = set()
+
+    def _collect(items):
+        for src in items or []:
+            api_path = getattr(src, "api_path", None)
+            if not src or api_path in seen_paths:
+                continue
+            seen_paths.add(api_path)
+            sources.append(src)
+
+    # 1) 插件声明式注册的推荐数据源
+    for plugin_sources in PluginManager().get_plugin_provided_recommend_sources().values():
+        _collect(plugin_sources)
+    # 2) 广播事件，请示额外的推荐数据源支持（向后兼容既有事件扩展）
     event_data = RecommendSourceEventData()
     event = eventmanager.send_event(ChainEventType.RecommendSource, event_data)
-    # 使用事件返回的上下文数据
     if event and event.event_data:
         event_data: RecommendSourceEventData = event.event_data
-        if event_data.extra_sources:
-            return event_data.extra_sources
-    return []
+        _collect(event_data.extra_sources)
+    return sources
 
 
 @router.get(

--- a/app/core/module.py
+++ b/app/core/module.py
@@ -299,6 +299,30 @@ class ModuleManager(metaclass=Singleton):
                 reasons.append(f"缺少下载器方法：{_name}")
         return (not reasons), reasons
 
+    @staticmethod
+    def verify_notification_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验消息渠道（Notification 域）契约：在 _ModuleBase 基类契约之上，要求
+        get_type()==ModuleType.Notification 且实现消息发送核心方法 post_message。
+        其余消息能力方法（post_medias/post_torrents/delete_message/register_commands 等）
+        由 run_module 按方法名分发、按需实现。供 provides_notifications() 注册前严格校验。
+        返回 (是否通过, 失败原因列表)。
+        """
+        ok, reasons = ModuleManager.verify_module_contract(module_cls)
+        reasons = list(reasons)
+        _get_type = getattr(module_cls, "get_type", None)
+        if not callable(_get_type):
+            reasons.append("缺少 get_type")
+        else:
+            try:
+                if _get_type() != ModuleType.Notification:
+                    reasons.append(f"get_type 须为 ModuleType.Notification（实际 {_get_type()}）")
+            except Exception as err:
+                reasons.append(f"get_type 调用失败：{err}")
+        if not callable(getattr(module_cls, "post_message", None)):
+            reasons.append("缺少消息渠道方法：post_message")
+        return (not reasons), reasons
+
     def register_module(self, module_cls: type, owner: str) -> bool:
         """
         注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，

--- a/app/core/module.py
+++ b/app/core/module.py
@@ -323,6 +323,29 @@ class ModuleManager(metaclass=Singleton):
             reasons.append("缺少消息渠道方法：post_message")
         return (not reasons), reasons
 
+    @staticmethod
+    def verify_mediaserver_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验媒体服务器（MediaServer 域）契约：在 _ModuleBase 基类契约之上，要求
+        get_type()==ModuleType.MediaServer。媒体服务器能力方法（mediaserver_librarys /
+        media_statistic / mediaserver_playing / mediaserver_items 等）由 run_module 按方法名
+        分发、按需实现，各后端（emby/jellyfin/plex/trimemedia/ugreen/zspace）实现的子集不同，
+        故不在此强制（避免误拒仅实现部分方法的真实媒体服务器）。供 provides_mediaservers()
+        注册前严格校验。返回 (是否通过, 失败原因列表)。
+        """
+        ok, reasons = ModuleManager.verify_module_contract(module_cls)
+        reasons = list(reasons)
+        _get_type = getattr(module_cls, "get_type", None)
+        if not callable(_get_type):
+            reasons.append("缺少 get_type")
+        else:
+            try:
+                if _get_type() != ModuleType.MediaServer:
+                    reasons.append(f"get_type 须为 ModuleType.MediaServer（实际 {_get_type()}）")
+            except Exception as err:
+                reasons.append(f"get_type 调用失败：{err}")
+        return (not reasons), reasons
+
     def register_module(self, module_cls: type, owner: str) -> bool:
         """
         注册一个外部(插件)模块类。复用内建加载流程(check_setting/init_setting/init_module)，

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -886,6 +886,12 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     def get_plugin_actions(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
         return plugin_metadata.get_plugin_actions(self._running_plugins, pid)
 
+    def get_plugin_provided_discover_sources(self, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+        return plugin_metadata.get_plugin_provided_discover_sources(self._running_plugins, pid)
+
+    def get_plugin_provided_recommend_sources(self, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+        return plugin_metadata.get_plugin_provided_recommend_sources(self._running_plugins, pid)
+
     @staticmethod
     def _copy_plugin_agent_tools(
         tools_info: List[Dict[str, Any]]

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -697,6 +697,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} 消息渠道 "
                                  f"{getattr(notification_cls, '__name__', notification_cls)} 出错：{str(err)}")
+        # 注册插件经 provides_mediaservers 声明新增的媒体服务器（MediaServer 域），
+        # 经媒体服务器契约校验通过后注册到 ModuleManager（owner=plugin_id），参与媒体库分发。
+        provided_mediaservers = plugin_metadata.get_plugin_provided_mediaservers(self._running_plugins, pid)
+        for plugin_id, mediaserver_classes in provided_mediaservers.items():
+            for mediaserver_cls in mediaserver_classes:
+                _ms_ok, _ms_reasons = ModuleManager.verify_mediaserver_contract(mediaserver_cls)
+                if not _ms_ok:
+                    logger.warning(f"插件 {plugin_id} 媒体服务器 "
+                                   f"{getattr(mediaserver_cls, '__name__', mediaserver_cls)} 未通过媒体服务器契约校验，拒绝注册："
+                                   f"{'；'.join(_ms_reasons)}")
+                    continue
+                try:
+                    ModuleManager().register_module(mediaserver_cls, owner=plugin_id)
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 媒体服务器 "
+                                 f"{getattr(mediaserver_cls, '__name__', mediaserver_cls)} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -681,6 +681,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} 下载器 "
                                  f"{getattr(downloader_cls, '__name__', downloader_cls)} 出错：{str(err)}")
+        # 注册插件经 provides_notifications 声明新增的消息渠道（Notification 域），
+        # 经消息渠道契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 post_message 消息分发。
+        provided_notifications = plugin_metadata.get_plugin_provided_notifications(self._running_plugins, pid)
+        for plugin_id, notification_classes in provided_notifications.items():
+            for notification_cls in notification_classes:
+                _nf_ok, _nf_reasons = ModuleManager.verify_notification_contract(notification_cls)
+                if not _nf_ok:
+                    logger.warning(f"插件 {plugin_id} 消息渠道 "
+                                   f"{getattr(notification_cls, '__name__', notification_cls)} 未通过消息渠道契约校验，拒绝注册："
+                                   f"{'；'.join(_nf_reasons)}")
+                    continue
+                try:
+                    ModuleManager().register_module(notification_cls, owner=plugin_id)
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 消息渠道 "
+                                 f"{getattr(notification_cls, '__name__', notification_cls)} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -268,6 +268,58 @@ def get_plugin_provided_mediaservers(running_plugins, pid: Optional[str] = None)
                 logger.error(f"获取插件 {plugin_id} 注册媒体服务器出错：{str(e)}")
     return ret_mediaservers
 
+def get_plugin_provided_discover_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+    """
+    聚合插件经 provides_discover_sources() 声明【新增】的探索数据源（DiscoverMediaSource 数据对象），
+    按 plugin_id 归集。供 /api/discover/source 端点与事件扩展去重合并后供前端枚举。
+    {
+        plugin_id: [DiscoverMediaSource, ...]
+    }
+    """
+    ret_sources: Dict[str, List[Any]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_discover_sources") \
+                and ObjectUtils.check_method(plugin.provides_discover_sources):
+            try:
+                if not plugin.get_state():
+                    continue
+                sources = plugin.provides_discover_sources() or []
+                if sources:
+                    ret_sources[plugin_id] = list(sources)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册探索数据源出错：{str(e)}")
+    return ret_sources
+
+def get_plugin_provided_recommend_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+    """
+    聚合插件经 provides_recommend_sources() 声明【新增】的推荐数据源（RecommendMediaSource 数据对象），
+    按 plugin_id 归集。供 /api/recommend/source 端点与事件扩展去重合并后供前端枚举。
+    {
+        plugin_id: [RecommendMediaSource, ...]
+    }
+    """
+    ret_sources: Dict[str, List[Any]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_recommend_sources") \
+                and ObjectUtils.check_method(plugin.provides_recommend_sources):
+            try:
+                if not plugin.get_state():
+                    continue
+                sources = plugin.provides_recommend_sources() or []
+                if sources:
+                    ret_sources[plugin_id] = list(sources)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册推荐数据源出错：{str(e)}")
+    return ret_sources
+
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
     """
     聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -218,6 +218,31 @@ def get_plugin_provided_downloaders(running_plugins, pid: Optional[str] = None) 
                 logger.error(f"获取插件 {plugin_id} 注册下载器出错：{str(e)}")
     return ret_downloaders
 
+def get_plugin_provided_notifications(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_notifications() 声明【新增】的消息渠道（Notification 域）类，
+    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [notification_cls, ...]
+    }
+    """
+    ret_notifications: Dict[str, List[type]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_notifications") and ObjectUtils.check_method(plugin.provides_notifications):
+            try:
+                if not plugin.get_state():
+                    continue
+                notifications = plugin.provides_notifications() or []
+                if notifications:
+                    ret_notifications[plugin_id] = list(notifications)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册消息渠道出错：{str(e)}")
+    return ret_notifications
+
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
     """
     聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -243,6 +243,31 @@ def get_plugin_provided_notifications(running_plugins, pid: Optional[str] = None
                 logger.error(f"获取插件 {plugin_id} 注册消息渠道出错：{str(e)}")
     return ret_notifications
 
+def get_plugin_provided_mediaservers(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """
+    聚合插件经 provides_mediaservers() 声明【新增】的媒体服务器（MediaServer 域）类，
+    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
+    {
+        plugin_id: [mediaserver_cls, ...]
+    }
+    """
+    ret_mediaservers: Dict[str, List[type]] = {}
+    # 创建字典快照避免并发修改
+    running_plugins_snapshot = dict(running_plugins)
+    for plugin_id, plugin in running_plugins_snapshot.items():
+        if pid and pid != plugin_id:
+            continue
+        if hasattr(plugin, "provides_mediaservers") and ObjectUtils.check_method(plugin.provides_mediaservers):
+            try:
+                if not plugin.get_state():
+                    continue
+                mediaservers = plugin.provides_mediaservers() or []
+                if mediaservers:
+                    ret_mediaservers[plugin_id] = list(mediaservers)
+            except Exception as e:
+                logger.error(f"获取插件 {plugin_id} 注册媒体服务器出错：{str(e)}")
+    return ret_mediaservers
+
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
     """
     聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -289,6 +289,28 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_discover_sources(self) -> List[Any]:
+        """
+        声明本插件向探索页【新增】的数据源（Discover 域，声明式注册，与现有
+        ChainEventType.DiscoverSource 事件扩展并存、由框架去重合并）。返回 DiscoverMediaSource
+        实例列表，每个含 name / mediaid_prefix / api_path（指向本插件自有 API）/ filter_params /
+        filter_ui 等；由 /api/v1/discover/source 端点聚合后供前端枚举。默认不新增。
+
+        [DiscoverMediaSource(name=..., mediaid_prefix=..., api_path=...), ...]
+        """
+        return []
+
+    def provides_recommend_sources(self) -> List[Any]:
+        """
+        声明本插件向推荐页【新增】的数据源（Recommend 域，声明式注册，与现有
+        ChainEventType.RecommendSource 事件扩展并存、由框架去重合并）。返回 RecommendMediaSource
+        实例列表，每个含 name / api_path（指向本插件自有 API）/ type；由 /api/v1/recommend/source
+        端点聚合后供前端枚举。默认不新增。
+
+        [RecommendMediaSource(name=..., api_path=..., type=...), ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -276,6 +276,19 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_mediaservers(self) -> List[Type]:
+        """
+        声明本插件向模块层【新增】的媒体服务器（MediaServer 域）类，如新的影音库服务端。
+        provides_modules 的语法糖 + 媒体服务器契约校验：返回的【类】（非实例）须实现 _ModuleBase
+        契约且 get_type()==ModuleType.MediaServer。能力方法（mediaserver_librarys /
+        media_statistic / mediaserver_playing / mediaserver_items 等）由 run_module 按方法名
+        分发、按需实现（实现哪个就参与哪个媒体库流水线）。子类型用 get_subtype_id() 返回字符串 id
+        （无需扩展封闭 MediaServerType 枚举）。默认不新增。
+
+        [MyMediaServerClass, ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -263,6 +263,19 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_notifications(self) -> List[Type]:
+        """
+        声明本插件向模块层【新增】的消息渠道（Notification 域）类，如新的 IM/推送渠道。
+        provides_modules 的语法糖 + 消息渠道契约校验：返回的【类】（非实例）须实现 _ModuleBase
+        契约且 get_type()==ModuleType.Notification，并实现 post_message（其余 post_medias /
+        post_torrents / delete_message / register_commands 等由 run_module 按方法名分发、按需实现）。
+        子类型用 get_subtype_id() 返回字符串 id（无需扩展封闭 MessageChannel 枚举）；
+        渠道的按钮/Markdown/分段等能力矩阵另经 provides_channel_capabilities() 声明。默认不新增。
+
+        [MyNotificationClass, ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/tests/test_discover_recommend_registration.py
+++ b/tests/test_discover_recommend_registration.py
@@ -122,3 +122,27 @@ class TestRecommendSourceEndpointMerge(TestCase):
         self.assertEqual([s.api_path for s in result],
                          ["/plugin/p/recommend", "/plugin/e/recommend"])
         self.assertEqual([s.name for s in result], ["plug", "evt"])
+
+
+class TestDiscoverSourceEndpointSkipsMalformed(TestCase):
+    def test_sources_without_api_path_are_skipped_not_collapsed(self):
+        # 畸形源（无 api_path）应逐个跳过，而非把 None 塞进去重集吞掉后续合法源
+        from types import SimpleNamespace
+
+        from app.api.endpoints import discover as discover_ep
+
+        good = _disc("good", "/plugin/p/discover")
+        bad1 = SimpleNamespace(name="bad1")  # 无 api_path
+        bad2 = SimpleNamespace(name="bad2")  # 无 api_path
+
+        pm = MagicMock()
+        pm.get_plugin_provided_discover_sources.return_value = {"p": [bad1, good, bad2]}
+        event = MagicMock()
+        event.event_data = MagicMock()
+        event.event_data.extra_sources = []
+
+        with patch.object(discover_ep, "PluginManager", return_value=pm), \
+                patch.object(discover_ep.eventmanager, "send_event", return_value=event):
+            result = discover_ep.source()
+
+        self.assertEqual([s.name for s in result], ["good"])

--- a/tests/test_discover_recommend_registration.py
+++ b/tests/test_discover_recommend_registration.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+推荐/发现数据源（Discover/Recommend 域）声明式开放注册回归：
+
+  1. get_plugin_provided_discover_sources / get_plugin_provided_recommend_sources
+     聚合器按 owner 归集插件经 provides_*_sources() 声明的数据对象，跳过未启用插件；
+  2. /api/discover/source 与 /api/recommend/source 端点合并「插件声明式源」与
+     「事件扩展源（ChainEventType）」，并按 api_path 去重（声明式优先、向后兼容事件）。
+
+与消息渠道/媒体服务器（模块类注册）不同，发现/推荐是【数据对象】注册（DiscoverMediaSource /
+RecommendMediaSource），仿 provides_channel_capabilities 范式，仅在 /source 端点聚合枚举，
+不进入 run_module 分发。
+"""
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from app import schemas
+from app.helper.plugin_metadata import (
+    get_plugin_provided_discover_sources,
+    get_plugin_provided_recommend_sources,
+)
+
+
+def _disc(name, path):
+    return schemas.DiscoverMediaSource(name=name, mediaid_prefix=name, api_path=path)
+
+
+def _rec(name, path):
+    return schemas.RecommendMediaSource(name=name, api_path=path, type="movie")
+
+
+class TestDiscoverRecommendAggregators(TestCase):
+    def test_discover_aggregator_collects_enabled(self):
+        src = _disc("p", "/plugin/p/discover")
+
+        class _P:
+            def get_state(self):
+                return True
+
+            def provides_discover_sources(self):
+                return [src]
+
+        self.assertEqual(get_plugin_provided_discover_sources({"p": _P()}), {"p": [src]})
+
+    def test_discover_aggregator_skips_disabled(self):
+        class _P:
+            def get_state(self):
+                return False
+
+            def provides_discover_sources(self):
+                return [_disc("p", "/x")]
+
+        self.assertEqual(get_plugin_provided_discover_sources({"p": _P()}), {})
+
+    def test_recommend_aggregator_collects_enabled(self):
+        src = _rec("p", "/plugin/p/recommend")
+
+        class _P:
+            def get_state(self):
+                return True
+
+            def provides_recommend_sources(self):
+                return [src]
+
+        self.assertEqual(get_plugin_provided_recommend_sources({"p": _P()}), {"p": [src]})
+
+    def test_recommend_aggregator_skips_disabled(self):
+        class _P:
+            def get_state(self):
+                return False
+
+            def provides_recommend_sources(self):
+                return [_rec("p", "/x")]
+
+        self.assertEqual(get_plugin_provided_recommend_sources({"p": _P()}), {})
+
+
+class TestDiscoverSourceEndpointMerge(TestCase):
+    def test_merges_plugin_and_event_dedup_by_api_path(self):
+        from app.api.endpoints import discover as discover_ep
+
+        plugin_src = _disc("plug", "/plugin/p/discover")
+        dup_event_src = _disc("plug-dup", "/plugin/p/discover")  # 同 api_path → 去重
+        uniq_event_src = _disc("evt", "/plugin/e/discover")
+
+        pm = MagicMock()
+        pm.get_plugin_provided_discover_sources.return_value = {"p": [plugin_src]}
+
+        event = MagicMock()
+        event.event_data = MagicMock()
+        event.event_data.extra_sources = [dup_event_src, uniq_event_src]
+
+        with patch.object(discover_ep, "PluginManager", return_value=pm), \
+                patch.object(discover_ep.eventmanager, "send_event", return_value=event):
+            result = discover_ep.source()
+
+        # 声明式源优先 + 唯一事件源；同 api_path 的事件源被去重
+        self.assertEqual([s.api_path for s in result],
+                         ["/plugin/p/discover", "/plugin/e/discover"])
+        self.assertEqual([s.name for s in result], ["plug", "evt"])
+
+
+class TestRecommendSourceEndpointMerge(TestCase):
+    def test_merges_plugin_and_event_dedup_by_api_path(self):
+        from app.api.endpoints import recommend as recommend_ep
+
+        plugin_src = _rec("plug", "/plugin/p/recommend")
+        dup_event_src = _rec("plug-dup", "/plugin/p/recommend")
+        uniq_event_src = _rec("evt", "/plugin/e/recommend")
+
+        pm = MagicMock()
+        pm.get_plugin_provided_recommend_sources.return_value = {"p": [plugin_src]}
+
+        event = MagicMock()
+        event.event_data = MagicMock()
+        event.event_data.extra_sources = [dup_event_src, uniq_event_src]
+
+        with patch.object(recommend_ep, "PluginManager", return_value=pm), \
+                patch.object(recommend_ep.eventmanager, "send_event", return_value=event):
+            result = recommend_ep.source()
+
+        self.assertEqual([s.api_path for s in result],
+                         ["/plugin/p/recommend", "/plugin/e/recommend"])
+        self.assertEqual([s.name for s in result], ["plug", "evt"])

--- a/tests/test_mediaserver_registration.py
+++ b/tests/test_mediaserver_registration.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""
+媒体服务器（MediaServer 域）一等开放注册回归：
+
+  1. verify_mediaserver_contract 对合法媒体服务器（_ModuleBase + get_type=MediaServer）通过；
+  2. 对错误 ModuleType / 非模块类 判定失败并给出原因；
+  3. 合法媒体服务器经 register_module 严格验证后正常注册；
+  4. get_plugin_provided_mediaservers 聚合器按 owner 归集插件声明的媒体服务器，
+     并跳过未启用插件。
+
+媒体服务器契约仅校验类型（不强制具体能力方法）——各后端 emby/jellyfin/plex/trimemedia/
+ugreen/zspace 实现的方法子集不同，由 run_module 按方法名分发、按需实现，与数据源域一致。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_metadata import get_plugin_provided_mediaservers
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType
+
+
+class _MediaServerOps(_ModuleBase):
+    """实现 _ModuleBase 契约的媒体服务器基类（能力方法按需实现，此处给一个示例方法）。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def mediaserver_librarys(self, *args, **kwargs):
+        return []
+
+
+class _ValidMediaServer(_MediaServerOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaServer
+
+
+class _WrongTypeMediaServer(_MediaServerOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Downloader  # 非 MediaServer
+
+
+class _NoMethodMediaServer(_ModuleBase):
+    """仅声明类型、不实现任何能力方法——类型契约下应仍通过（方法按需分发）。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaServer
+
+
+class TestVerifyMediaServerContract(TestCase):
+    def test_valid_mediaserver_passes(self):
+        ok, reasons = ModuleManager.verify_mediaserver_contract(_ValidMediaServer)
+        self.assertTrue(ok, reasons)
+        self.assertEqual(reasons, [])
+
+    def test_type_only_contract_allows_no_capability_methods(self):
+        # 仅类型契约：不实现具体能力方法也应通过（与数据源域一致）
+        ok, reasons = ModuleManager.verify_mediaserver_contract(_NoMethodMediaServer)
+        self.assertTrue(ok, reasons)
+
+    def test_wrong_module_type_rejected(self):
+        ok, reasons = ModuleManager.verify_mediaserver_contract(_WrongTypeMediaServer)
+        self.assertFalse(ok)
+        self.assertTrue(any("MediaServer" in r for r in reasons))
+
+    def test_non_module_rejected(self):
+        ok, reasons = ModuleManager.verify_mediaserver_contract(str)
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestMediaServerRegistration(TestCase):
+    def setUp(self):
+        self.mgr = ModuleManager()
+        self.owner = "test_ms_owner"
+
+    def tearDown(self):
+        self.mgr.unregister_modules(self.owner)
+
+    def test_valid_mediaserver_registers(self):
+        accepted = self.mgr.register_module(_ValidMediaServer, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(_ValidMediaServer.__name__, self.mgr.get_external_module_ids(self.owner))
+
+
+class TestMediaServerAggregator(TestCase):
+    def test_aggregator_collects_enabled_plugin_mediaservers(self):
+        class _FakePlugin:
+            def get_state(self):
+                return True
+
+            def provides_mediaservers(self):
+                return [_ValidMediaServer]
+
+        result = get_plugin_provided_mediaservers({"fakeplugin": _FakePlugin()})
+        self.assertEqual(result, {"fakeplugin": [_ValidMediaServer]})
+
+    def test_aggregator_skips_disabled_plugin(self):
+        class _DisabledPlugin:
+            def get_state(self):
+                return False
+
+            def provides_mediaservers(self):
+                return [_ValidMediaServer]
+
+        result = get_plugin_provided_mediaservers({"off": _DisabledPlugin()})
+        self.assertEqual(result, {})

--- a/tests/test_metadata_source_registration.py
+++ b/tests/test_metadata_source_registration.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+元数据数据源（Metadata / MediaRecognize 域）开放注册「已覆盖」回归。
+
+结论性测试：元数据数据源已由既有 provides_data_sources(#61) 一等开放注册，本域无需新增结构。
+本测试把该事实钉死、可执行：
+
+  1. 内建识别型元数据源（TheMovieDb / Douban / Bangumi）均声明 get_type()==MediaRecognize；
+  2. 均通过 verify_data_source_contract（即插件可经 provides_data_sources 同等注册新元数据源）；
+  3. provides_data_sources 钩子 + get_plugin_provided_data_sources 聚合器机制已就位。
+
+边界事实：FanartModule 是 get_type()==Other 的【图片提供方】（非识别源），按设计走通用
+provides_modules() 而不归 provides_data_sources（后者严格要求 MediaRecognize），仍经 run_module
+按方法名参与 obtain_images 分发——故本域开放注册对象是三个 MediaRecognize 源，与 Fanart 解耦。
+
+注：推荐/发现方法（tmdb_discover 等）就挂在这些 MediaRecognize 模块上，模块级随本域注册即可
+参与分发；其 UI 源枚举的声明式注册见 test_discover_recommend_registration.py。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_metadata import get_plugin_provided_data_sources
+from app.modules import _ModuleBase
+from app.plugins import _PluginBase
+from app.schemas.types import ModuleType
+
+
+def _builtin_metadata_modules():
+    from app.modules.themoviedb import TheMovieDbModule
+    from app.modules.douban import DoubanModule
+    from app.modules.bangumi import BangumiModule
+    return [TheMovieDbModule, DoubanModule, BangumiModule]
+
+
+class _PluginMetaSource(_ModuleBase):
+    """模拟插件经 provides_data_sources 新增的元数据源（MediaRecognize）。"""
+
+    def init_module(self):
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self):
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type():
+        return ModuleType.MediaRecognize
+
+
+class TestBuiltinMetadataSourcesAreFirstClass(TestCase):
+    def test_all_builtins_declare_mediarecognize_type(self):
+        for cls in _builtin_metadata_modules():
+            self.assertEqual(cls.get_type(), ModuleType.MediaRecognize,
+                             f"{cls.__name__} 应声明 get_type()==MediaRecognize")
+
+    def test_all_builtins_pass_data_source_contract(self):
+        for cls in _builtin_metadata_modules():
+            ok, reasons = ModuleManager.verify_data_source_contract(cls)
+            self.assertTrue(ok, f"{cls.__name__} 未通过数据源契约：{reasons}")
+
+    def test_fanart_is_other_typed_image_provider(self):
+        # 边界：Fanart 是 Other（图片源），不归 provides_data_sources 的 MediaRecognize 契约
+        from app.modules.fanart import FanartModule
+        self.assertEqual(FanartModule.get_type(), ModuleType.Other)
+        ok, _ = ModuleManager.verify_data_source_contract(FanartModule)
+        self.assertFalse(ok)
+
+
+class TestMetadataOpenRegistrationMechanismPresent(TestCase):
+    def test_provides_data_sources_hook_exists(self):
+        # _PluginBase 默认提供 provides_data_sources 钩子，插件覆写即注册新元数据源
+        self.assertTrue(callable(getattr(_PluginBase, "provides_data_sources", None)))
+
+    def test_aggregator_collects_plugin_metadata_sources(self):
+        class _FakePlugin:
+            def get_state(self):
+                return True
+
+            def provides_data_sources(self):
+                return [_PluginMetaSource]
+
+        result = get_plugin_provided_data_sources({"meta_plugin": _FakePlugin()})
+        self.assertEqual(result, {"meta_plugin": [_PluginMetaSource]})
+        # 且该插件源能通过数据源契约
+        ok, reasons = ModuleManager.verify_data_source_contract(_PluginMetaSource)
+        self.assertTrue(ok, reasons)

--- a/tests/test_notification_registration.py
+++ b/tests/test_notification_registration.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""
+消息渠道（Notification 域）一等开放注册回归：
+
+  1. verify_notification_contract 对合法消息渠道（_ModuleBase + get_type=Notification +
+     post_message）通过；
+  2. 对错误 ModuleType / 缺 post_message / 非模块类 判定失败并给出原因；
+  3. 合法消息渠道经 register_module 严格验证后正常注册；
+  4. get_plugin_provided_notifications 聚合器按 owner 归集插件声明的消息渠道，
+     并跳过未启用插件。
+"""
+from unittest import TestCase
+
+from app.core.module import ModuleManager
+from app.helper.plugin_metadata import get_plugin_provided_notifications
+from app.modules import _ModuleBase
+from app.schemas.types import ModuleType
+
+
+class _NotificationOps(_ModuleBase):
+    """实现 _ModuleBase 契约 + 消息渠道核心方法的基类。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def post_message(self, *args, **kwargs):
+        return None
+
+
+class _ValidNotification(_NotificationOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Notification
+
+
+class _WrongTypeNotification(_NotificationOps):
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.MediaRecognize  # 非 Notification
+
+
+class _MissingMethodNotification(_ModuleBase):
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Notification
+    # 故意缺 post_message
+
+
+class TestVerifyNotificationContract(TestCase):
+    def test_valid_notification_passes(self):
+        ok, reasons = ModuleManager.verify_notification_contract(_ValidNotification)
+        self.assertTrue(ok, reasons)
+        self.assertEqual(reasons, [])
+
+    def test_wrong_module_type_rejected(self):
+        ok, reasons = ModuleManager.verify_notification_contract(_WrongTypeNotification)
+        self.assertFalse(ok)
+        self.assertTrue(any("Notification" in r for r in reasons))
+
+    def test_missing_method_rejected(self):
+        ok, reasons = ModuleManager.verify_notification_contract(_MissingMethodNotification)
+        self.assertFalse(ok)
+        self.assertTrue(any("post_message" in r for r in reasons))
+
+    def test_non_module_rejected(self):
+        ok, reasons = ModuleManager.verify_notification_contract(str)
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestNotificationRegistration(TestCase):
+    def setUp(self):
+        self.mgr = ModuleManager()
+        self.owner = "test_nf_owner"
+
+    def tearDown(self):
+        self.mgr.unregister_modules(self.owner)
+
+    def test_valid_notification_registers(self):
+        accepted = self.mgr.register_module(_ValidNotification, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(_ValidNotification.__name__, self.mgr.get_external_module_ids(self.owner))
+
+
+class TestNotificationAggregator(TestCase):
+    def test_aggregator_collects_enabled_plugin_notifications(self):
+        class _FakePlugin:
+            def get_state(self):
+                return True
+
+            def provides_notifications(self):
+                return [_ValidNotification]
+
+        result = get_plugin_provided_notifications({"fakeplugin": _FakePlugin()})
+        self.assertEqual(result, {"fakeplugin": [_ValidNotification]})
+
+    def test_aggregator_skips_disabled_plugin(self):
+        class _DisabledPlugin:
+            def get_state(self):
+                return False
+
+            def provides_notifications(self):
+                return [_ValidNotification]
+
+        result = get_plugin_provided_notifications({"off": _DisabledPlugin()})
+        self.assertEqual(result, {})


### PR DESCRIPTION
## 背景

延续已合入 v3-python 的开放注册范式（数据源 #61 / 下载器 #62 的 `provides_*` 钩子 + `verify_*_contract` 严格校验 + `plugin_manager` 接线），把同一套机制推广到用户点名的四个域：**消息渠道、媒体服务器、元数据数据源、推荐/发现数据源**。

先做 5 路并行勘察分清现状：
- **元数据数据源**（themoviedb/douban/bangumi，`MediaRecognize`）**已由 #61 完整开放**（`gaps=[]`），本 PR 仅补回归测试。
- **消息渠道 / 媒体服务器** 未开放（无钩子/契约/接线）→ 补全套五步范式。
- **推荐/发现** 方法挂在 MediaRecognize 模块上、靠 `provides_data_sources` 顺带可注册，但 UI 源枚举走事件广播、无专用钩子 → 加**数据对象**声明式钩子。

## 改动（单分支分域提交）

### 消息渠道（Notification）
- `module.py` 加 `verify_notification_contract`（`_ModuleBase` + `get_type==Notification` + 核心方法 `post_message`）
- `provides_notifications()` 钩子 + `get_plugin_provided_notifications` 聚合器 + `_register_plugin_modules` 接线
- 卸载统一经既有 `unregister_modules(owner)`，无需改 `_unregister`

### 媒体服务器（MediaServer）
- `verify_mediaserver_contract`（**仅类型契约**，能力方法按需分发——6 后端 emby/jellyfin/plex/trimemedia/ugreen/zspace 方法子集异构，与数据源域一致）
- `provides_mediaservers()` + 聚合器 + 接线

### 推荐/发现（Discover/Recommend）
- **数据对象子范式**（仿 `provides_channel_capabilities`，非模块注册）：`provides_discover_sources()` / `provides_recommend_sources()` 返回 `DiscoverMediaSource` / `RecommendMediaSource`
- 两聚合器 + `PluginManager` 公开访问器
- `/api/discover/source` 与 `/api/recommend/source` 端点**合并声明式源 + 事件源、按 `api_path` 去重**（向后兼容既有 `ChainEventType` 事件扩展；畸形无 `api_path` 源逐个跳过不 collapse）

### 元数据（Metadata）
- 仅回归测试钉死「已由 #61 覆盖」
- 记录边界事实：`FanartModule` 是 `ModuleType.Other`（图片源）非 MediaRecognize，按设计走 `provides_modules` 而非 `provides_data_sources`

## 设计要点
- 四域均为**叠加式开放注册**，对现有插件零影响（`provides_*` 默认 `[]`）。
- 发现/推荐**不是独立模块域、不新建 ModuleType**——只在 `/source` 端点聚合枚举，不进 `run_module` 分发。
- 消息渠道/媒服模块经 `register_module(owner)` 注册，统一由 `ModuleManager().unregister_modules(owner)` 回收，无泄漏。

## 测试
- 新增 `tests/test_{notification,mediaserver,discover_recommend,metadata_source}_registration.py`；注册/相邻测试 **62 全过**，端点导入冒烟通过。
- code-reviewer **APPROVE**（0 Critical/High）；唯一 MEDIUM（端点去重 None-collapse）已修并补用例。
- 注：本机 python3.11.2 下 `app/modules/telegram/telegram.py:500` 的 f-string 反斜杠为 3.12+ 特性，导致 4 个 telegram 依赖测试采集失败——**预存环境不兼容、与本 PR 无关**（CI 为 3.12）。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 插件经 `provides_notifications`/`provides_mediaservers` 注册的渠道/媒服参与 `run_module` 分发
- [ ] 插件经 `provides_discover_sources`/`provides_recommend_sources` 声明的源出现在 `/api/v1/discover|recommend/source`