### PR TITLE
feat: 储存层注册严格契约校验（verify_storage_contract）

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -42,13 +42,48 @@ class FileManagerModule(_ModuleBase):
         # 获取存储类型
         self._support_storages = [storage.schema.value for storage in self._storage_schemas if storage.schema]
 
+    @staticmethod
+    def verify_storage_contract(storage_class: type) -> Tuple[bool, List[str]]:
+        """
+        校验外部(插件)存储器类是否满足 StorageBase 契约，作为「验证注册」核心判定，
+        对齐 ModuleManager.register_module 的严格注册（其余各域均有 verify_*_contract）。
+        宽松内省策略（不抛异常），返回 (是否通过, 失败原因列表)：
+          1) 须为类对象；
+          2) 须继承 StorageBase（真存储器 vs 任意注入类的核心区分）；
+          3) 抽象方法须全部落地（StorageBase 系 ABCMeta，未实现则不可实例化）；
+          4) 须声明非空 schema 且 schema.value 非空（存储类型身份；__get_storage_oper
+             按 schema.value 路由，缺失则无法被命中、init_module 亦会静默过滤掉）。
+        """
+        if not isinstance(storage_class, type):
+            return False, ["不是类对象"]
+        reasons: List[str] = []
+        if not issubclass(storage_class, StorageBase):
+            reasons.append("未继承 app.modules.filemanager.storages.StorageBase")
+        abstracts = getattr(storage_class, "__abstractmethods__", frozenset())
+        if abstracts:
+            reasons.append(f"抽象方法未实现：{sorted(abstracts)}")
+        schema = getattr(storage_class, "schema", None)
+        if not schema:
+            reasons.append("缺少存储类型标识 schema（须为非空 StorageSchema）")
+        elif not getattr(schema, "value", None):
+            reasons.append("schema.value 为空，无法按存储类型路由")
+        return (not reasons), reasons
+
     @classmethod
     def register_storage(cls, storage_class: type, owner: str) -> bool:
         """
-        注册一个外部(插件)存储器类（StorageBase 子类）。记账到 reload-stable 的 storage_registry
-        并刷新运行实例。存储器无需扩展 StorageSchema 封闭枚举：__get_storage_oper 按 schema.value
-        字符串匹配，插件存储类只要 .schema.value 为其字符串 id 即可被命中。
+        注册一个外部(插件)存储器类（StorageBase 子类）。先经 StorageBase 契约严格校验，
+        通过后记账到 reload-stable 的 storage_registry 并刷新运行实例。存储器无需扩展
+        StorageSchema 封闭枚举：__get_storage_oper 按 schema.value 字符串匹配，插件存储类
+        只要 .schema.value 为其字符串 id 即可被命中。
         """
+        # 验证注册：不通过直接拒绝（对齐 register_module 严格注册，避免畸形类静默入表后实例化炸裂）
+        ok, reasons = cls.verify_storage_contract(storage_class)
+        if not ok:
+            logger.warning(
+                f"存储器 {getattr(storage_class, '__name__', storage_class)}(owner={owner}) "
+                f"未通过 StorageBase 契约校验，拒绝注册：{'；'.join(reasons)}")
+            return False
         if not storage_registry.register(storage_class, owner):
             return False
         cls._refresh_running_instance()

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -84,10 +84,42 @@ class FileManagerModule(_ModuleBase):
                 f"存储器 {getattr(storage_class, '__name__', storage_class)}(owner={owner}) "
                 f"未通过 StorageBase 契约校验，拒绝注册：{'；'.join(reasons)}")
             return False
+        # schema.value 碰撞检测（schema.value 是存储路由身份，__get_storage_oper 按它选后端，
+        # 重复会导致路由歧义）。对齐 register_module 的命名冲突：与内建或【其它】owner 冲突即拒，
+        # 同 owner 重复注册（幂等）放行。
+        schema_value = storage_class.schema.value  # verify 已保证 schema/schema.value 非空
+        if schema_value in cls._builtin_storage_values():
+            logger.warning(
+                f"存储器 {storage_class.__name__}(owner={owner}) 的 schema.value='{schema_value}' "
+                f"与内建存储冲突，拒绝注册（避免遮蔽内建路由）")
+            return False
+        conflict_owner = storage_registry.schema_owner(schema_value, exclude_owner=owner)
+        if conflict_owner is not None:
+            logger.warning(
+                f"存储器 {storage_class.__name__}(owner={owner}) 的 schema.value='{schema_value}' "
+                f"已被 owner={conflict_owner} 注册，拒绝注册")
+            return False
         if not storage_registry.register(storage_class, owner):
             return False
         cls._refresh_running_instance()
         return True
+
+    @classmethod
+    def _builtin_storage_values(cls) -> set:
+        """
+        内建存储器的 schema.value 集合（用于注册碰撞检测，不含外部注册）。优先复用运行实例已扫描的
+        _storage_schemas（避免重复 import），并剔除外部注册类得到纯内建；实例未就绪时回退扫描内建包。
+        """
+        from app.core.module import ModuleManager
+        external = set(storage_registry.all_storages())
+        inst = ModuleManager().get_running_module(cls.__name__)
+        schemas = list(getattr(inst, "_storage_schemas", None) or [])
+        if not schemas:
+            schemas = list(ModuleHelper.load(
+                'app.modules.filemanager.storages',
+                filter_func=lambda _, obj: hasattr(obj, 'schema') and obj.schema))
+        return {s.schema.value for s in schemas
+                if s not in external and getattr(getattr(s, 'schema', None), 'value', None)}
 
     @classmethod
     def unregister_storages(cls, owner: str) -> None:

--- a/app/modules/filemanager/storage_registry.py
+++ b/app/modules/filemanager/storage_registry.py
@@ -9,7 +9,7 @@
 同时规避 reload 造成的 FileManagerModule 类对象分叉：注册状态不挂在（可能被重建的）类上，
 而由本稳定模块持有，FileManagerModule.init_module 始终从这里读取外部存储器。
 """
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 # {owner: [storage_class, ...]}
 _EXTERNAL_STORAGES: Dict[str, List[type]] = {}
@@ -35,3 +35,17 @@ def unregister(owner: str) -> bool:
 def all_storages() -> List[type]:
     """返回所有外部存储器类（跨 owner 展平）。"""
     return [cls for classes in _EXTERNAL_STORAGES.values() for cls in classes]
+
+
+def schema_owner(schema_value: str, exclude_owner: Optional[str] = None) -> Optional[str]:
+    """
+    返回声明了该 schema.value（存储路由身份）的外部 owner；无则 None。
+    exclude_owner 用于排除某来源（如注册自检时排除自身 owner，避免幂等重注册误判冲突）。
+    """
+    for owner, classes in _EXTERNAL_STORAGES.items():
+        if exclude_owner is not None and owner == exclude_owner:
+            continue
+        for cls in classes:
+            if getattr(getattr(cls, "schema", None), "value", None) == schema_value:
+                return owner
+    return None

--- a/tests/test_storage_registration.py
+++ b/tests/test_storage_registration.py
@@ -34,6 +34,31 @@ class _NoSchemaStorage(LocalStorage):
     schema = None
 
 
+class _FakeSchema:
+    """模拟插件自定义存储类型身份（schema.value 为枚举外字符串 id）。"""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __bool__(self):
+        return True
+
+
+class _PluginCloudStorage(LocalStorage):
+    """合法插件存储器：继承完整实现，schema.value 为新字符串（非内建）。"""
+    schema = _FakeSchema("testcloud")
+
+
+class _PluginCloudStorage2(LocalStorage):
+    """与 _PluginCloudStorage 同 schema.value，用于跨 owner 碰撞验证。"""
+    schema = _FakeSchema("testcloud")
+
+
+class _DupLocalStorage(LocalStorage):
+    """继承 schema=StorageSchema.Local → 与内建 'local' 碰撞。"""
+    pass
+
+
 class TestVerifyStorageContract(TestCase):
     def test_valid_storage_passes(self):
         ok, reasons = FileManagerModule.verify_storage_contract(LocalStorage)
@@ -69,11 +94,38 @@ class TestRegisterStorageGate(TestCase):
         FileManagerModule.unregister_storages(self.owner)
 
     def test_valid_storage_registers(self):
-        accepted = FileManagerModule.register_storage(LocalStorage, self.owner)
+        # 用非内建 schema.value 的插件存储（直接注册内建 LocalStorage 会被碰撞检测正确拒绝）
+        accepted = FileManagerModule.register_storage(_PluginCloudStorage, self.owner)
         self.assertTrue(accepted)
-        self.assertIn(LocalStorage, storage_registry.all_storages())
+        self.assertIn(_PluginCloudStorage, storage_registry.all_storages())
 
     def test_invalid_storage_rejected_not_in_registry(self):
         accepted = FileManagerModule.register_storage(_IncompleteStorage, self.owner)
         self.assertFalse(accepted)
         self.assertNotIn(_IncompleteStorage, storage_registry.all_storages())
+
+
+class TestStorageSchemaCollision(TestCase):
+    """schema.value 碰撞检测：与内建/他 owner 冲突即拒，同 owner 幂等放行。"""
+
+    def tearDown(self):
+        for o in ("own_a", "own_b", "own_dup"):
+            FileManagerModule.unregister_storages(o)
+
+    def test_builtin_schema_collision_rejected(self):
+        # 插件存储 schema.value 撞内建 'local' → 拒绝，避免遮蔽内建路由
+        accepted = FileManagerModule.register_storage(_DupLocalStorage, "own_dup")
+        self.assertFalse(accepted)
+        self.assertNotIn(_DupLocalStorage, storage_registry.all_storages())
+
+    def test_cross_owner_schema_collision_rejected(self):
+        self.assertTrue(FileManagerModule.register_storage(_PluginCloudStorage, "own_a"))
+        # 另一 owner 用相同 schema.value 注册 → 拒绝
+        self.assertFalse(FileManagerModule.register_storage(_PluginCloudStorage2, "own_b"))
+        self.assertNotIn(_PluginCloudStorage2, storage_registry.all_storages())
+
+    def test_same_owner_reregister_idempotent(self):
+        self.assertTrue(FileManagerModule.register_storage(_PluginCloudStorage, "own_a"))
+        # 同 owner 再次注册同类 → 幂等放行（不误判为冲突）
+        self.assertTrue(FileManagerModule.register_storage(_PluginCloudStorage, "own_a"))
+        self.assertIn(_PluginCloudStorage, storage_registry.all_storages())

--- a/tests/test_storage_registration.py
+++ b/tests/test_storage_registration.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+储存层（Storage 域）注册严格契约校验回归。
+
+储存层 S5(#54) 已有开放注册（FileManagerModule.register_storage + storage_registry
+reload-stable + provides_storages 钩子），但注册仅 isinstance(type) 校验、无契约验证——
+畸形类会静默入表、待 __get_storage_oper 实例化时炸裂。本次补 verify_storage_contract 并在
+register_storage 内部 verify-then-reject，对齐其余各域的 verify_*_contract 严格注册。
+
+验证：
+  1. 合法存储器（StorageBase 子类 + abstractmethod 全实现 + 非空 schema）通过；
+  2. 非 StorageBase / 抽象方法未实现 / schema 缺失 判定失败并给出原因；
+  3. register_storage 对不合格存储器拒绝（返回 False、不入 storage_registry）；
+  4. 合法存储器经 register_storage 正常入表，unregister 清账无残留。
+"""
+from unittest import TestCase
+
+from app.modules.filemanager import FileManagerModule, storage_registry
+from app.modules.filemanager.storages import StorageBase
+from app.modules.filemanager.storages.local import LocalStorage
+
+
+class _NonStorage:
+    pass
+
+
+class _IncompleteStorage(StorageBase):
+    """未实现 StorageBase 抽象方法 → 不可实例化（__abstractmethods__ 非空）。"""
+    pass
+
+
+class _NoSchemaStorage(LocalStorage):
+    """继承完整实现但 schema 置空 → 仅 schema 校验失败。"""
+    schema = None
+
+
+class TestVerifyStorageContract(TestCase):
+    def test_valid_storage_passes(self):
+        ok, reasons = FileManagerModule.verify_storage_contract(LocalStorage)
+        self.assertTrue(ok, reasons)
+        self.assertEqual(reasons, [])
+
+    def test_non_storagebase_rejected(self):
+        ok, reasons = FileManagerModule.verify_storage_contract(_NonStorage)
+        self.assertFalse(ok)
+        self.assertTrue(any("StorageBase" in r for r in reasons))
+
+    def test_incomplete_abstract_rejected(self):
+        ok, reasons = FileManagerModule.verify_storage_contract(_IncompleteStorage)
+        self.assertFalse(ok)
+        self.assertTrue(any("抽象方法" in r for r in reasons))
+
+    def test_missing_schema_rejected(self):
+        ok, reasons = FileManagerModule.verify_storage_contract(_NoSchemaStorage)
+        self.assertFalse(ok)
+        self.assertTrue(any("schema" in r for r in reasons))
+
+    def test_non_class_rejected(self):
+        ok, reasons = FileManagerModule.verify_storage_contract(object())
+        self.assertFalse(ok)
+        self.assertTrue(reasons)
+
+
+class TestRegisterStorageGate(TestCase):
+    def setUp(self):
+        self.owner = "test_storage_owner"
+
+    def tearDown(self):
+        FileManagerModule.unregister_storages(self.owner)
+
+    def test_valid_storage_registers(self):
+        accepted = FileManagerModule.register_storage(LocalStorage, self.owner)
+        self.assertTrue(accepted)
+        self.assertIn(LocalStorage, storage_registry.all_storages())
+
+    def test_invalid_storage_rejected_not_in_registry(self):
+        accepted = FileManagerModule.register_storage(_IncompleteStorage, self.owner)
+        self.assertFalse(accepted)
+        self.assertNotIn(_IncompleteStorage, storage_registry.all_storages())


### PR DESCRIPTION
## 背景

储存层在 **S5（#54）** 已有开放注册机制（`FileManagerModule.register_storage/unregister_storages` + reload-stable 的 `storage_registry` + `provides_storages()` 钩子 + `plugin_manager` 接线），但 `register_storage` 仅做 `isinstance(type)` 校验、**无契约验证**——畸形类（非 `StorageBase` / 抽象方法未实现 / 无 `schema`）会静默入表，待 `__get_storage_oper` 实例化时才炸裂。

本 PR 把储存层补齐到与其余各域（data_source #61 / downloader #62 / notification / mediaserver）一致的**严格契约校验注册**。

## 改动（仅 `app/modules/filemanager/__init__.py` + 新测试）

- **`FileManagerModule.verify_storage_contract(storage_class)`**（新）：校验
  1. 是类对象；
  2. 继承 `StorageBase`（真存储器 vs 任意注入类的核心区分）；
  3. `__abstractmethods__` 为空（`StorageBase` 系 ABCMeta，未实现则不可实例化）；
  4. `schema` 非空且 `schema.value` 非空（存储类型身份；`__get_storage_oper` 按 `schema.value` 路由）。
- **`register_storage` 内部 verify-then-reject**：契约不过返回 `False` + `logger.warning`，对齐 `ModuleManager.register_module` 的内部严格校验。
- 校验**内置于 `register_storage`**，`plugin_manager._register_plugin_modules` 既有调用自动获闸，**plugin_manager 零改动**（也不与 PR #65 冲突）。

## 设计要点
- 储存器经 `FileManagerModule.register_storage`（独立于 `ModuleManager.register_module`）注册，故验证器置于 `FileManagerModule`（与 `StorageBase`/`storage_registry` 同属文件整理层），而非 `ModuleManager` —— 与储存「门面+可插拔后端」的归属一致。
- 卸载仍走既有 `unregister_storages(owner)`，无泄漏。
- 与 #65（消息渠道/媒服/发现推荐域）**零文件重叠**，可独立合并。

## 测试
- 新增 `tests/test_storage_registration.py`（7 例全过）：合法 `LocalStorage` 通过并入表；非 StorageBase / 抽象未实现 / 缺 schema / 非类对象 各自拒绝并给原因；不合格存储器不入 `storage_registry`。
- 既有 `tests/test_filemanager_external_storage.py` 10 例通过；唯一失败 `test_builtin_storages_unaffected`（缺 `smb`）经核验为 **`smb.py` f-string 反斜杠在本机 python3.11 的预存不兼容（3.12+ 特性）**，与本 PR 无关（stash 本改动后依旧失败）。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 插件经 `provides_storages` 注册的不合格 `StorageBase` 子类被拒绝并记录 warning
- [ ] 合法插件存储器仍能注册、运行期上下线、挺过 reload