### PR TITLE
refactor: 储存层收敛为单索引 StorageRegistry（消除散落状态）

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, List, Tuple, Union, Dict, Callable
+from typing import Optional, List, Set, Tuple, Union, Dict, Callable
 
 from app.chain.tmdb import TmdbChain
 from app.core.config import settings
@@ -24,23 +24,25 @@ class FileManagerModule(_ModuleBase):
     文件整理模块
     """
 
-    _storage_schemas = []
-    _support_storages = []
-
     def __init__(self):
         super().__init__()
         self.directoryhelper = DirectoryHelper()
         self.messagehelper = MessageHelper()
 
     def init_module(self) -> None:
-        # 扫描内建存储器
-        scanned = ModuleHelper.load('app.modules.filemanager.storages',
-                                    filter_func=lambda _, obj: hasattr(obj, 'schema') and obj.schema)
-        # 合并外部(插件)注册的存储器（merge 非 replace；外部记账存于 reload-stable 的
-        # storage_registry，使运行期注册的存储挺过 ModuleManager.reload()）
-        self._storage_schemas = list(scanned) + storage_registry.all_storages()
-        # 获取存储类型
-        self._support_storages = [storage.schema.value for storage in self._storage_schemas if storage.schema]
+        # 存储器统一收敛到单索引 storage_registry（内建 owner=None + 外部插件），
+        # 此处仅确保内建已扫描入索引（幂等、仅一次）；外部注册随插件启停直接增删索引。
+        storage_registry.ensure_builtins()
+
+    @property
+    def _storage_schemas(self) -> List[type]:
+        """全部存储器类（内建+外部），直读单索引 storage_registry（保留属性名兼容既有读取方/测试）。"""
+        return storage_registry.all_classes()
+
+    @property
+    def _support_storages(self) -> Set[str]:
+        """当前支持的存储类型 schema.value 集合（内建+外部），直读单索引，供成员资格守卫 O(1) 判定。"""
+        return storage_registry.supported_values()
 
     @staticmethod
     def verify_storage_contract(storage_class: type) -> Tuple[bool, List[str]]:
@@ -72,71 +74,31 @@ class FileManagerModule(_ModuleBase):
     @classmethod
     def register_storage(cls, storage_class: type, owner: str) -> bool:
         """
-        注册一个外部(插件)存储器类（StorageBase 子类）。先经 StorageBase 契约严格校验，
-        通过后记账到 reload-stable 的 storage_registry 并刷新运行实例。存储器无需扩展
-        StorageSchema 封闭枚举：__get_storage_oper 按 schema.value 字符串匹配，插件存储类
+        注册一个外部(插件)存储器类（StorageBase 子类）：先经 StorageBase 契约严格校验，再交
+        单索引 storage_registry 做 schema.value 碰撞检测后入索引（运行实例经只读属性即时可见，
+        无需刷新）。存储器无需扩展 StorageSchema 封闭枚举：按 schema.value 字符串路由，插件存储类
         只要 .schema.value 为其字符串 id 即可被命中。
         """
-        # 验证注册：不通过直接拒绝（对齐 register_module 严格注册，避免畸形类静默入表后实例化炸裂）
+        # 验证注册：不通过直接拒绝（对齐 register_module 严格注册，避免畸形类静默入索引后实例化炸裂）
         ok, reasons = cls.verify_storage_contract(storage_class)
         if not ok:
             logger.warning(
                 f"存储器 {getattr(storage_class, '__name__', storage_class)}(owner={owner}) "
                 f"未通过 StorageBase 契约校验，拒绝注册：{'；'.join(reasons)}")
             return False
-        # schema.value 碰撞检测（schema.value 是存储路由身份，__get_storage_oper 按它选后端，
-        # 重复会导致路由歧义）。对齐 register_module 的命名冲突：与内建或【其它】owner 冲突即拒，
-        # 同 owner 重复注册（幂等）放行。
-        schema_value = storage_class.schema.value  # verify 已保证 schema/schema.value 非空
-        if schema_value in cls._builtin_storage_values():
+        # schema.value 碰撞检测 = 单索引内一次查（与内建或【其它】owner 冲突即拒，同 owner 幂等放行）
+        accepted, reason = storage_registry.register(storage_class, owner)
+        if not accepted:
             logger.warning(
-                f"存储器 {storage_class.__name__}(owner={owner}) 的 schema.value='{schema_value}' "
-                f"与内建存储冲突，拒绝注册（避免遮蔽内建路由）")
+                f"存储器 {getattr(storage_class, '__name__', storage_class)}(owner={owner}) "
+                f"注册被拒：{reason}")
             return False
-        conflict_owner = storage_registry.schema_owner(schema_value, exclude_owner=owner)
-        if conflict_owner is not None:
-            logger.warning(
-                f"存储器 {storage_class.__name__}(owner={owner}) 的 schema.value='{schema_value}' "
-                f"已被 owner={conflict_owner} 注册，拒绝注册")
-            return False
-        if not storage_registry.register(storage_class, owner):
-            return False
-        cls._refresh_running_instance()
         return True
 
     @classmethod
-    def _builtin_storage_values(cls) -> set:
-        """
-        内建存储器的 schema.value 集合（用于注册碰撞检测，不含外部注册）。优先复用运行实例已扫描的
-        _storage_schemas（避免重复 import），并剔除外部注册类得到纯内建；实例未就绪时回退扫描内建包。
-        """
-        from app.core.module import ModuleManager
-        external = set(storage_registry.all_storages())
-        inst = ModuleManager().get_running_module(cls.__name__)
-        schemas = list(getattr(inst, "_storage_schemas", None) or [])
-        if not schemas:
-            schemas = list(ModuleHelper.load(
-                'app.modules.filemanager.storages',
-                filter_func=lambda _, obj: hasattr(obj, 'schema') and obj.schema))
-        return {s.schema.value for s in schemas
-                if s not in external and getattr(getattr(s, 'schema', None), 'value', None)}
-
-    @classmethod
     def unregister_storages(cls, owner: str) -> None:
-        """卸载某来源(owner)注册的外部存储器并刷新运行实例。"""
-        if storage_registry.unregister(owner):
-            cls._refresh_running_instance()
-
-    @classmethod
-    def _refresh_running_instance(cls) -> None:
-        """
-        刷新运行态 FileManagerModule 实例的存储器列表（重跑 init_module 合并内建+外部）。
-        若实例尚未加载则跳过——记账仍在 storage_registry 保留，待 init_module 首次运行时自动合并。
-        """
-        from app.core.module import ModuleManager
-        inst = ModuleManager().get_running_module(cls.__name__)
-        if inst is not None:
-            inst.init_module()
+        """卸载某来源(owner)注册的外部存储器（从单索引移除；运行实例经只读属性即时反映）。"""
+        storage_registry.unregister(owner)
 
     @staticmethod
     def get_name() -> str:
@@ -206,14 +168,15 @@ class FileManagerModule(_ModuleBase):
 
     def __get_storage_oper(self, _storage: str, _func: Optional[str] = None) -> Optional[StorageBase]:
         """
-        获取存储操作对象
+        获取存储操作对象：按 schema.value 从单索引 O(1) 取后端类并新建实例。
+        _func 非空时门控——后端类须实现该可选方法（如 generate_qrcode/check_login）方返回。
         """
-        for storage_schema in self._storage_schemas:
-            if storage_schema.schema \
-                    and storage_schema.schema.value == _storage \
-                    and (not _func or hasattr(storage_schema, _func)):
-                return storage_schema()
-        return None
+        storage_class = storage_registry.get_class(_storage)
+        if not storage_class:
+            return None
+        if _func and not hasattr(storage_class, _func):
+            return None
+        return storage_class()
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:
         pass

--- a/app/modules/filemanager/storage_registry.py
+++ b/app/modules/filemanager/storage_registry.py
@@ -1,51 +1,132 @@
 # -*- coding: utf-8 -*-
 """
-外部(插件)存储器注册表（进程级，reload-stable）。
+存储器单索引注册表（进程级、reload-stable、线程安全）= 内建 + 外部插件存储器的【唯一事实源】。
 
-存于本独立子模块的模块级全局：ModuleManager.load_modules() 只对 app.modules 的【顶层】子包
-做 importlib.reload（即重载 app.modules.filemanager 的 __init__），不会递归重载本子模块，
-故本注册表全局字典不被重置——使运行期插件注册的存储器挺过 ModuleManager.reload()。
+索引：{schema.value(str): _Entry(cls, owner)}，owner=None 为内建、其余为插件 owner。
+schema.value 是存储路由身份（FileManagerModule 按它选后端），全局唯一——
+故路由 = 一次 dict 查、注册碰撞检测 = 一次 dict 查，无需多表同步/全量重扫。
 
-同时规避 reload 造成的 FileManagerModule 类对象分叉：注册状态不挂在（可能被重建的）类上，
-而由本稳定模块持有，FileManagerModule.init_module 始终从这里读取外部存储器。
+reload 稳定性：ModuleManager.load_modules() 只 importlib.reload app.modules 的【顶层】子包
+（即 app.modules.filemanager 的 __init__），不递归重载本子模块，也不重载 storages 子包
+（内建存储类身份稳定）。故本模块级索引不被重置：外部插件运行期注册的存储挺过 reload，
+内建只扫一次。注册状态不挂在（可能被 reload 重建的）FileManagerModule 类上，而由本稳定模块持有。
+
+线程安全：插件启停（PluginManager 线程）与 ModuleManager.load_modules（init_module→ensure_builtins）
+可能并发；_REGISTRY/_builtins_loaded 由 _lock 保护，避免迭代时被并发写改坏（dict changed size）。
 """
-from typing import Dict, List, Optional
+import threading
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
-# {owner: [storage_class, ...]}
-_EXTERNAL_STORAGES: Dict[str, List[type]] = {}
+from app.core.module_loader import ModuleHelper
 
 
-def register(storage_class: type, owner: str) -> bool:
-    """记账一个外部存储器类（按 owner）。幂等：同 owner 重复注册不产生重复记录。"""
+class _Entry(NamedTuple):
+    cls: type
+    owner: Optional[str]  # None=内建，其余=插件 owner
+
+
+# {schema.value: _Entry}
+_REGISTRY: Dict[str, _Entry] = {}
+# 内建是否已扫描入索引（仅成功扫描后才置位，失败可重试）
+_builtins_loaded: bool = False
+# 保护 _REGISTRY 与 _builtins_loaded 的并发读写
+_lock = threading.Lock()
+
+
+def _schema_value(storage_class: type) -> Optional[str]:
+    """取存储器类的 schema.value（路由身份），缺失返回 None。"""
+    return getattr(getattr(storage_class, "schema", None), "value", None)
+
+
+def ensure_builtins() -> None:
+    """
+    首次使用时扫描内建存储包并以 owner=None 入索引（幂等，仅一次）。
+    内建存储类身份稳定（storages 子包不被 reload），故只扫一次即可长期缓存。
+
+    扫描置于锁外（ModuleHelper.load 会 import/reload，较慢且不应持锁）；插入在锁内双检。
+    仅在扫描+插入成功后才置 _builtins_loaded=True——若扫描抛异常，标志位保持 False、下次可重试，
+    不会把内建永久标记为「已加载但为空」而使储存静默失效。
+    ensure_builtins 直接用 setdefault 入索引、不回调 register，避免与 register→ensure_builtins 互递归。
+    """
+    global _builtins_loaded
+    if _builtins_loaded:
+        return
+    scanned = ModuleHelper.load(
+        "app.modules.filemanager.storages",
+        filter_func=lambda _, obj: hasattr(obj, "schema") and obj.schema)
+    with _lock:
+        if _builtins_loaded:  # 双检：并发下另一线程可能已完成
+            return
+        for cls in scanned:
+            value = _schema_value(cls)
+            if value:
+                _REGISTRY.setdefault(value, _Entry(cls, None))
+        _builtins_loaded = True
+
+
+def register(storage_class: type, owner: str) -> Tuple[bool, str]:
+    """
+    注册外部(插件)存储器类。schema.value 碰撞检测对齐 register_module 命名冲突：
+    与内建(owner=None)或【其它】owner 占用同一 schema.value 即拒，同 owner 幂等放行。
+    要求 storage_class 已通过 StorageBase 契约校验（由 FileManagerModule 负责）。
+
+    :return: (是否接受, 失败原因)
+    """
     if not owner or not isinstance(storage_class, type):
-        return False
-    _EXTERNAL_STORAGES.setdefault(owner, [])
-    if storage_class not in _EXTERNAL_STORAGES[owner]:
-        _EXTERNAL_STORAGES[owner].append(storage_class)
-    return True
+        return False, "非法入参（owner 为空或非类对象）"
+    value = _schema_value(storage_class)
+    if not value:
+        return False, "缺少 schema.value"
+    ensure_builtins()
+    with _lock:
+        existing = _REGISTRY.get(value)
+        if existing is not None and existing.owner != owner:
+            where = "内建存储" if existing.owner is None else f"owner={existing.owner}"
+            return False, f"schema.value='{value}' 已被{where}占用"
+        _REGISTRY[value] = _Entry(storage_class, owner)
+    return True, ""
 
 
 def unregister(owner: str) -> bool:
-    """移除某来源(owner)的全部外部存储器记账。返回是否确有移除。"""
+    """移除某来源(owner)注册的全部外部存储器。返回是否确有移除。内建(owner=None)不受影响。"""
     if not owner:
         return False
-    return _EXTERNAL_STORAGES.pop(owner, None) is not None
+    with _lock:
+        removed = [v for v, e in _REGISTRY.items() if e.owner == owner]
+        for v in removed:
+            _REGISTRY.pop(v, None)
+    return bool(removed)
+
+
+def get_class(schema_value: str) -> Optional[type]:
+    """按 schema.value 取存储器类（路由）。O(1)。"""
+    ensure_builtins()
+    with _lock:
+        entry = _REGISTRY.get(schema_value)
+    return entry.cls if entry else None
+
+
+def supported_values() -> Set[str]:
+    """当前支持的全部 schema.value 集合（内建+外部）。"""
+    ensure_builtins()
+    with _lock:
+        return set(_REGISTRY.keys())
+
+
+def all_classes() -> List[type]:
+    """全部存储器类（内建+外部）。"""
+    ensure_builtins()
+    with _lock:
+        return [e.cls for e in _REGISTRY.values()]
+
+
+def external_classes() -> List[type]:
+    """仅外部(插件)注册的存储器类。"""
+    ensure_builtins()
+    with _lock:
+        return [e.cls for e in _REGISTRY.values() if e.owner is not None]
 
 
 def all_storages() -> List[type]:
-    """返回所有外部存储器类（跨 owner 展平）。"""
-    return [cls for classes in _EXTERNAL_STORAGES.values() for cls in classes]
-
-
-def schema_owner(schema_value: str, exclude_owner: Optional[str] = None) -> Optional[str]:
-    """
-    返回声明了该 schema.value（存储路由身份）的外部 owner；无则 None。
-    exclude_owner 用于排除某来源（如注册自检时排除自身 owner，避免幂等重注册误判冲突）。
-    """
-    for owner, classes in _EXTERNAL_STORAGES.items():
-        if exclude_owner is not None and owner == exclude_owner:
-            continue
-        for cls in classes:
-            if getattr(getattr(cls, "schema", None), "value", None) == schema_value:
-                return owner
-    return None
+    """[兼容别名] 仅外部(插件)注册的存储器类，等价 external_classes()。"""
+    return external_classes()

--- a/tests/test_storage_registration.py
+++ b/tests/test_storage_registration.py
@@ -59,6 +59,11 @@ class _DupLocalStorage(LocalStorage):
     pass
 
 
+class _RegGateStorage(LocalStorage):
+    """TestRegisterStorageGate 专用、独立 schema.value，避免与碰撞测试争用同一索引键。"""
+    schema = _FakeSchema("reggate")
+
+
 class TestVerifyStorageContract(TestCase):
     def test_valid_storage_passes(self):
         ok, reasons = FileManagerModule.verify_storage_contract(LocalStorage)
@@ -94,10 +99,10 @@ class TestRegisterStorageGate(TestCase):
         FileManagerModule.unregister_storages(self.owner)
 
     def test_valid_storage_registers(self):
-        # 用非内建 schema.value 的插件存储（直接注册内建 LocalStorage 会被碰撞检测正确拒绝）
-        accepted = FileManagerModule.register_storage(_PluginCloudStorage, self.owner)
+        # 用非内建、且专属本类的 schema.value 插件存储（避免与碰撞测试争用 'testcloud' 键）
+        accepted = FileManagerModule.register_storage(_RegGateStorage, self.owner)
         self.assertTrue(accepted)
-        self.assertIn(_PluginCloudStorage, storage_registry.all_storages())
+        self.assertIn(_RegGateStorage, storage_registry.all_storages())
 
     def test_invalid_storage_rejected_not_in_registry(self):
         accepted = FileManagerModule.register_storage(_IncompleteStorage, self.owner)


### PR DESCRIPTION
## 背景

储存层此前把「有哪些存储」散成 **4 份重叠状态**，靠 `init_module` 每次全量重扫+合并对齐，是「感觉好复杂」的根源（详见架构评估）：
- `FileManagerModule._storage_schemas`（后端类列表，实例态）
- `FileManagerModule._support_storages`（schema.value 字符串列表，实例态）
- `storage_registry._EXTERNAL_STORAGES`（owner→类，模块级）
- 内建包扫描结果

且 `register_storage` 的碰撞检测要从这几处重建「已占用 schema.value」、`_refresh_running_instance` 每次注册全量重跑 `init_module`。

## 改动：收敛为单一事实源

`storage_registry._REGISTRY = {schema.value: (cls, owner)}`（内建 owner=None + 外部插件），成为**唯一**存储索引：

**`storage_registry.py`（重写）**
- `ensure_builtins()`：扫描内建包**仅一次**（扫描置锁外、双检后置位、失败可重试——避免永久空载）。
- `register()`：**内置** schema.value 碰撞检测（与内建/他 owner 冲突即拒、同 owner 幂等），返回 `(bool, reason)`。
- `get_class()` **O(1)** 路由；`supported_values()`/`all_classes()`/`external_classes()`；`all_storages()` 保留为外部别名（测试兼容）。
- `threading.Lock` 保护并发（插件启停 vs init_module）；移除 `schema_owner()`。

**`FileManagerModule`**
- `_storage_schemas`/`_support_storages` 改为**只读属性**直读索引（14 个成员资格守卫**零改动**，运行实例即时可见新注册，无需刷新）。
- `init_module()` 缩为 `ensure_builtins()`；`__get_storage_oper()` 走 `get_class()`（**保留**每次新建实例 + `_func` 可选方法门控 + 未命中返回 None）。
- `register_storage` 把碰撞委托索引；**删除** `_builtin_storage_values()`、`_refresh_running_instance()`。

**后端 `StorageBase` + 6 个实现：零改动。**

## 收益
- 路由 / 碰撞 / 注册 / 卸载 全部降为 dict 操作。
- 消除 4 表同步、全量重扫、碰撞重建。
- reload 稳定性、O(1) 路由、注册即时可见（只读属性）。

## 测试
- `tests/test_storage_registration.py` 更新（注册用独立 schema.value 隔离、碰撞用例保留）；`test_filemanager_external_storage.py`（merge/unregister/builtin 稳定/plugin_manager 接线）、`test_storage_service.py`、transfer/scrape/SPI 回归**全过**。
- code-reviewer **APPROVE**（核心设计 sound）；修复 2 HIGH（`ensure_builtins` 扫描后置位防永久空载、测试独立键消除顺序依赖）+ 1 MEDIUM（加锁）。
- 注：本机 python3.11 下 `storages/smb.py` f-string 反斜杠为 3.12+ 特性，致 `test_builtin_storages_unaffected` 缺 `smb`——**预存环境不兼容、与本 PR 无关**（CI 为 3.12；stash 本改动后该测试同样失败）。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 插件 `provides_storages` 注册的存储器即时参与路由、reload 后仍在
- [ ] 内建存储路由（list/upload/transfer 等）行为不变