### PR TITLE
feat: 媒体服务器域升级为门面+后端模式（MediaServerManager）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -17,6 +17,7 @@ from app.core.event import EventManager
 from app.core.meta import MetaBase
 from app.core.module import ModuleManager
 from app.helper.downloader_manager import DownloaderManager
+from app.helper.mediaserver_manager import MediaServerManager
 from app.helper.plugin_manager import PluginManager
 from app.db.message_oper import MessageOper
 from app.db.user_oper import UserOper
@@ -62,6 +63,7 @@ class ChainBase(metaclass=ABCMeta):
         *,
         modulemanager=None,
         downloadermanager=None,
+        mediaservermanager=None,
         eventmanager=None,
         messageoper=None,
         messagehelper=None,
@@ -81,6 +83,8 @@ class ChainBase(metaclass=ABCMeta):
         self.modulemanager = modulemanager or ModuleManager()
         # 下载器（Downloader 域）门面：下载器相关包装方法经此分发，取代 run_module 字符串 ABI。
         self.downloadermanager = downloadermanager or DownloaderManager()
+        # 媒体服务器（MediaServer 域）门面：媒服相关包装方法经此分发，取代 run_module 字符串 ABI。
+        self.mediaservermanager = mediaservermanager or MediaServerManager()
         self.eventmanager = eventmanager or EventManager()
         self.messageoper = messageoper or MessageOper()
         self.messagehelper = messagehelper or MessageHelper()
@@ -1453,8 +1457,8 @@ class ChainBase(metaclass=ABCMeta):
         :param server:  媒体服务器
         :return: 如不存在返回None，存在时返回信息，包括每季已存在所有集{type: movie/tv, seasons: {season: [episodes]}}
         """
-        return self.run_module(
-            "media_exists", mediainfo=mediainfo, itemid=itemid, server=server
+        return self.mediaservermanager.media_exists(
+            mediainfo=mediainfo, itemid=itemid, server=server
         )
 
     def media_files(self, mediainfo: MediaInfo) -> Optional[List[FileItem]]:

--- a/app/chain/dashboard.py
+++ b/app/chain/dashboard.py
@@ -12,7 +12,7 @@ class DashboardChain(ChainBase):
         """
         媒体数量统计
         """
-        return self.run_module("media_statistic", server=server)
+        return self.mediaservermanager.media_statistic(server=server)
 
     def downloader_info(self, downloader: Optional[str] = None) -> Optional[List[schemas.DownloaderInfo]]:
         """

--- a/app/chain/mediaserver.py
+++ b/app/chain/mediaserver.py
@@ -59,8 +59,7 @@ class MediaServerChain(ChainBase):
         获取媒体服务器所有媒体库
         """
         return self._sign_library_images(
-            self.run_module(
-                "mediaserver_librarys",
+            self.mediaservermanager.mediaserver_librarys(
                 server=server,
                 username=username,
                 hidden=hidden,
@@ -86,40 +85,22 @@ class MediaServerChain(ChainBase):
         - 如果未来评估结果显示，不分页场景下的内存消耗远大于分页处理时的网络请求开销，可以考虑在此方法中实现自分页的处理
         - 即通过 `while` 循环在上层进行分页控制，逐步获取所有数据，避免内存爆炸，当前该逻辑由具体实例来实现不分页的处理
         - Plex 实际上已默认支持内部分页处理，Jellyfin 与 Emby 获取数据时存在内部过滤场景，如排除合集等，分页数据可能是错误的
-        if limit is not None and limit != -1:
-            yield from self.run_module("mediaserver_items", server=server, library_id=library_id,
-                                   start_index=start_index, limit=limit)
-        else:
-            # 自分页逻辑，通过循环逐步获取所有数据
-            page_size = 10
-            while True:
-                data_generator = self.run_module("mediaserver_items", server=server, library_id=library_id,
-                                                 start_index=start_index, limit=page_size)
-                if not data_generator:
-                    break
-                count = 0
-                for item in data_generator:
-                    if item:
-                        count += 1
-                        yield item
-                if count < page_size:
-                    break
-                start_index += page_size
+        - 自分页（while 循环逐步取数）为评估后未采用的备选方案，当前不分页逻辑由各后端实例自行实现
         """
-        yield from self.run_module("mediaserver_items", server=server, library_id=library_id,
-                                   start_index=start_index, limit=limit)
+        yield from self.mediaservermanager.mediaserver_items(server=server, library_id=library_id,
+                                                              start_index=start_index, limit=limit)
 
     def iteminfo(self, server: str, item_id: Union[str, int]) -> MediaServerItem:
         """
         获取媒体服务器项目信息
         """
-        return self.run_module("mediaserver_iteminfo", server=server, item_id=item_id)
+        return self.mediaservermanager.mediaserver_iteminfo(server=server, item_id=item_id)
 
     def episodes(self, server: str, item_id: Union[str, int]) -> List[MediaServerSeasonInfo]:
         """
         获取媒体服务器剧集信息
         """
-        return self.run_module("mediaserver_tv_episodes", server=server, item_id=item_id)
+        return self.mediaservermanager.mediaserver_tv_episodes(server=server, item_id=item_id)
 
     def playing(self, server: str, count: Optional[int] = 20,
                 username: Optional[str] = None) -> List[MediaServerPlayItem]:
@@ -127,8 +108,7 @@ class MediaServerChain(ChainBase):
         获取媒体服务器正在播放信息
         """
         return self._sign_play_item_images(
-            self.run_module(
-                "mediaserver_playing",
+            self.mediaservermanager.mediaserver_playing(
                 count=count,
                 server=server,
                 username=username,
@@ -141,8 +121,7 @@ class MediaServerChain(ChainBase):
         获取媒体服务器最新入库条目
         """
         return self._sign_play_item_images(
-            self.run_module(
-                "mediaserver_latest",
+            self.mediaservermanager.mediaserver_latest(
                 count=count,
                 server=server,
                 username=username,
@@ -154,8 +133,7 @@ class MediaServerChain(ChainBase):
         """
         获取最新最新入库条目海报作为壁纸，缓存1小时
         """
-        wallpapers = self.run_module(
-            "mediaserver_latest_images",
+        wallpapers = self.mediaservermanager.mediaserver_latest_images(
             server=server,
             count=count,
             remote=remote,
@@ -179,7 +157,7 @@ class MediaServerChain(ChainBase):
         """
         获取播放地址
         """
-        return self.run_module("mediaserver_play_url", server=server, item_id=item_id)
+        return self.mediaservermanager.mediaserver_play_url(server=server, item_id=item_id)
 
     def get_image_cookies(
         self, server: Optional[str], image_url: str
@@ -187,8 +165,8 @@ class MediaServerChain(ChainBase):
         """
         获取图片的Cookies
         """
-        return self.run_module(
-            "mediaserver_image_cookies", server=server, image_url=image_url
+        return self.mediaservermanager.mediaserver_image_cookies(
+            server=server, image_url=image_url
         )
 
     def sync(self):

--- a/app/helper/downloader_manager.py
+++ b/app/helper/downloader_manager.py
@@ -7,6 +7,7 @@ from app.core.module import ModuleManager
 from app.helper.message import MessageHelper
 from app.log import logger
 from app.schemas import DownloaderTorrent, DownloaderFile, DownloaderInfo
+from app.schemas.exception import RateLimitExceededException
 from app.schemas.types import EventType, TorrentStatus
 from app.utils.object import ObjectUtils
 from app.utils.singleton import Singleton
@@ -74,6 +75,17 @@ class DownloaderManager(metaclass=Singleton):
             },
         )
 
+    @staticmethod
+    def _handle_rate_limit_error(err: RateLimitExceededException, module_id: str,
+                                 method: str, raise_exception: bool) -> None:
+        """
+        本地限流跳过（复刻 ChainBase.__handle_rate_limit_error）：raise_exception 为真则抛出；
+        否则仅 INFO 记录、不进系统错误告警（预期的限流状态不应触发 SystemError 事件/消息）。
+        """
+        if raise_exception:
+            raise err
+        logger.info(f"模块 {module_id}.{method} 已限流，跳过执行：{str(err)}")
+
     def _dispatch(self, method: str, *args, **kwargs) -> Any:
         """
         将下载器方法按方法名分发到所有 Downloader 后端模块并合并结果。
@@ -111,6 +123,9 @@ class DownloaderManager(metaclass=Singleton):
                         result.extend(temp)
                 else:
                     break
+            except RateLimitExceededException as err:
+                # 限流先于通用异常处理（与 __execute_system_modules 一致）：安静跳过、不告警。
+                self._handle_rate_limit_error(err, module_id, method, raise_exception)
             except Exception as err:
                 self._handle_error(err, module_id, module_name, method, raise_exception)
         return result

--- a/app/helper/mediaserver_manager.py
+++ b/app/helper/mediaserver_manager.py
@@ -1,0 +1,214 @@
+import traceback
+from typing import Any, Generator, List, Optional, Union, TYPE_CHECKING
+
+from app.core.event import eventmanager
+from app.core.module import ModuleManager
+from app.helper.message import MessageHelper
+from app.log import logger
+from app.schemas import (ExistMediaInfo, MediaServerItem, MediaServerLibrary,
+                         MediaServerPlayItem, MediaServerSeasonInfo, Statistic)
+from app.schemas.exception import RateLimitExceededException
+from app.schemas.types import EventType
+from app.utils.object import ObjectUtils
+from app.utils.singleton import Singleton
+
+if TYPE_CHECKING:
+    from app.core.context import MediaInfo
+
+
+class MediaServerManager(metaclass=Singleton):
+    """
+    媒体服务器（MediaServer 域）门面。
+
+    对照下载器域的 DownloaderManager / 存储域的 FileManager：把"媒体服务器"领域升级为
+    "门面 + 后端"模式——对外提供一组类型化、可发现的统一方法（实现 app.modules.IMediaServer
+    契约的对外面），对内按方法名分发到所有 ModuleType.MediaServer 后端模块（内建 Emby/Jellyfin/
+    Plex/TrimeMedia/Ugreen/ZSpace 以及插件经 provides_mediaservers() 注册的媒体服务器），并按与
+    ChainBase.run_module 完全一致的合并语义（列表 extend / 非列表取首个非 None）汇总结果。
+
+    设计要点：
+    - **行为等价**：_dispatch 忠实复刻 ChainBase.__execute_system_modules 的分发与合并（含
+      check_signature 分支、异常逐后端续跑、SystemError 事件与消息上报），调用的是与 run_module
+      同一批后端模块方法（后端方法体零改动），故对真实媒体服务器的行为不变；唯一被收敛的是
+      "字符串 ABI 分发"这一隐式面，被显式、类型化的门面取代。等价性测试见 tests/test_mediaserver_facade.py。
+    - **签名漂移收敛**：各后端 mediaserver_* 的 server 必填性 / username 形参 / **kwargs 存在差异；
+      门面统一为最宽松 canonical 签名并按 kwarg 分发——后端要么声明该形参、要么有 **kwargs 吸收，
+      故与 run_module 一样对全部后端兼容（详见 app.modules.IMediaServer）。
+    - **v2 兼容路径保留**：内建媒体服务器仍作为 _ModuleBase 模块注册，run_module("mediaserver_librarys")
+      等字符串分发仍可用（标记为 v2 兼容路径、计划后续废弃）。门面不替换该路径，只作为新代码的
+      首选入口叠加其上。
+    - **后端发现**：每次分发实时查询 ModuleManager().get_running_modules(method)，自动纳入运行期
+      注册/卸载的插件媒体服务器，无需门面侧维护后端清单。
+    """
+
+    def __init__(self):
+        self._modulemanager = ModuleManager()
+        self._messagehelper = MessageHelper()
+
+    @staticmethod
+    def _is_valid_empty(ret: Any) -> bool:
+        """
+        判断结果是否为空（与 ChainBase.__is_valid_empty 同义）：元组要求全 None，否则判 is None。
+        """
+        if isinstance(ret, tuple):
+            return all(value is None for value in ret)
+        return ret is None
+
+    def _handle_error(self, err: Exception, module_id: str, module_name: str,
+                      method: str, raise_exception: bool) -> None:
+        """
+        后端方法执行出错处理（复刻 ChainBase.__handle_system_error 的对外可见行为）：
+        raise_exception 为真则抛出；否则记录日志 + 推送系统错误消息 + 发送 SystemError 事件后续跑。
+        """
+        if raise_exception:
+            raise err
+        logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{module_name}发生了错误", message=str(err), role="system")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "module",
+                "module_id": module_id,
+                "module_name": module_name,
+                "module_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    @staticmethod
+    def _handle_rate_limit_error(err: RateLimitExceededException, module_id: str,
+                                 method: str, raise_exception: bool) -> None:
+        """
+        本地限流跳过（复刻 ChainBase.__handle_rate_limit_error）：raise_exception 为真则抛出；
+        否则仅 INFO 记录、不进系统错误告警（预期的限流状态不应触发 SystemError 事件/消息）。
+        """
+        if raise_exception:
+            raise err
+        logger.info(f"模块 {module_id}.{method} 已限流，跳过执行：{str(err)}")
+
+    def _dispatch(self, method: str, *args, **kwargs) -> Any:
+        """
+        将媒体服务器方法按方法名分发到所有 MediaServer 后端模块并合并结果。
+
+        合并语义与 ChainBase.__execute_system_modules 严格一致：按 get_priority() 升序遍历后端，
+        - 结果为空（None/全 None 元组）→ 取该后端返回值；
+        - 结果与方法签名一致（check_signature）→ 透传；
+        - 结果为列表 → 合并后续后端的列表结果；
+        - 否则（非空非列表，如 str/dict/生成器）→ 短路停止。
+        单后端异常逐个捕获续跑，不影响其它后端；raise_exception=True 时透传首个异常。
+        """
+        # pop 而非 get：raise_exception 是分发器控制位，不应透传给不接受该参数的后端 func。
+        raise_exception = bool(kwargs.pop("raise_exception", False))
+        result: Any = None
+        for module in sorted(
+                self._modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            try:
+                func = getattr(module, method)
+                if self._is_valid_empty(result):
+                    result = func(*args, **kwargs)
+                elif ObjectUtils.check_signature(func, result):
+                    result = func(result)
+                elif isinstance(result, list):
+                    temp = func(*args, **kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                # 限流先于通用异常处理（与 __execute_system_modules 一致）：安静跳过、不告警。
+                self._handle_rate_limit_error(err, module_id, method, raise_exception)
+            except Exception as err:
+                self._handle_error(err, module_id, module_name, method, raise_exception)
+        return result
+
+    # ------------------------------------------------------------------ #
+    # IMediaServer 对外面：签名与 ChainBase/MediaServerChain 媒服包装方法一致（收敛漂移后的 canonical 形）。
+    # ------------------------------------------------------------------ #
+
+    def media_exists(self, mediainfo: "MediaInfo", itemid: Optional[str] = None,
+                     server: Optional[str] = None) -> Optional[ExistMediaInfo]:
+        """
+        判断媒体是否存在于媒体服务器。
+        """
+        return self._dispatch("media_exists", mediainfo=mediainfo, itemid=itemid, server=server)
+
+    def media_statistic(self, server: Optional[str] = None) -> Optional[List[Statistic]]:
+        """
+        媒体数量统计。
+        """
+        return self._dispatch("media_statistic", server=server)
+
+    def mediaserver_librarys(self, server: Optional[str] = None, username: Optional[str] = None,
+                             hidden: Optional[bool] = False) -> Optional[List[MediaServerLibrary]]:
+        """
+        获取媒体服务器所有媒体库。
+        """
+        return self._dispatch("mediaserver_librarys", server=server, username=username, hidden=hidden)
+
+    def mediaserver_items(self, server: Optional[str] = None, library_id: Union[str, int] = None,
+                          start_index: Optional[int] = 0, limit: Optional[int] = -1) -> Optional[Generator]:
+        """
+        获取媒体服务器项目列表（生成器）。
+        """
+        return self._dispatch("mediaserver_items", server=server, library_id=library_id,
+                              start_index=start_index, limit=limit)
+
+    def mediaserver_iteminfo(self, server: Optional[str] = None,
+                             item_id: Union[str, int] = None) -> Optional[MediaServerItem]:
+        """
+        获取媒体服务器项目信息。
+        """
+        return self._dispatch("mediaserver_iteminfo", server=server, item_id=item_id)
+
+    def mediaserver_tv_episodes(self, server: Optional[str] = None,
+                                item_id: Union[str, int] = None) -> Optional[List[MediaServerSeasonInfo]]:
+        """
+        获取媒体服务器剧集信息。
+        """
+        return self._dispatch("mediaserver_tv_episodes", server=server, item_id=item_id)
+
+    def mediaserver_playing(self, server: Optional[str] = None, count: Optional[int] = 20,
+                            username: Optional[str] = None) -> List[MediaServerPlayItem]:
+        """
+        获取媒体服务器正在播放信息。
+        """
+        return self._dispatch("mediaserver_playing", server=server, count=count, username=username)
+
+    def mediaserver_play_url(self, server: Optional[str] = None,
+                             item_id: Union[str, int] = None) -> Optional[str]:
+        """
+        获取播放地址。
+        """
+        return self._dispatch("mediaserver_play_url", server=server, item_id=item_id)
+
+    def mediaserver_latest(self, server: Optional[str] = None, count: Optional[int] = 20,
+                           username: Optional[str] = None) -> List[MediaServerPlayItem]:
+        """
+        获取媒体服务器最新入库条目。
+        """
+        return self._dispatch("mediaserver_latest", server=server, count=count, username=username)
+
+    def mediaserver_latest_images(self, server: Optional[str] = None, count: Optional[int] = 10,
+                                  username: Optional[str] = None,
+                                  remote: Optional[bool] = False) -> List[str]:
+        """
+        获取最新入库条目海报作为壁纸。
+        """
+        return self._dispatch("mediaserver_latest_images", server=server, count=count,
+                              username=username, remote=remote)
+
+    def mediaserver_image_cookies(self, server: Optional[str] = None,
+                                  image_url: Optional[str] = None) -> Optional[Union[str, dict]]:
+        """
+        获取图片的 Cookies（仅部分后端实现，未实现者不参与分发）。
+        """
+        return self._dispatch("mediaserver_image_cookies", server=server, image_url=image_url)

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABCMeta
 from enum import Enum
 from typing import Generic, Tuple, Union, TypeVar, Type, Dict, List, Set, Optional, Callable, \
-    Protocol, runtime_checkable, TYPE_CHECKING
+    Generator, Protocol, runtime_checkable, TYPE_CHECKING
 from pathlib import Path
 
 from app.helper.service import ServiceConfigHelper
@@ -12,7 +12,10 @@ from app.utils.mixins import ConfigReloadMixin
 
 if TYPE_CHECKING:
     # 仅用于类型注解，避免在早期导入的 app.modules 顶层引入 schemas 重负载/潜在环。
-    from app.schemas import DownloaderTorrent, DownloaderFile, DownloaderInfo
+    from app.core.context import MediaInfo
+    from app.schemas import DownloaderTorrent, DownloaderFile, DownloaderInfo, \
+        MediaServerLibrary, MediaServerItem, MediaServerSeasonInfo, MediaServerPlayItem, \
+        ExistMediaInfo, Statistic
     from app.schemas.types import TorrentStatus
 
 
@@ -497,3 +500,60 @@ class _MediaServerBase(ServiceBase[TService, MediaServerConf]):
         if not self._service_name:
             return {}
         return {conf.name: conf for conf in configs if conf.type == self._service_name and conf.enabled}
+
+
+@runtime_checkable
+class IMediaServer(Protocol):
+    """
+    媒体服务器（MediaServer 域）行为接口契约。
+
+    对照下载器域的 IDownloader / 存储域的 StorageBase：声明门面
+    app.helper.mediaserver_manager.MediaServerManager 统一对外暴露、并按方法名分发到各后端的
+    媒体服务器操作面。采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足
+    契约，无需显式继承，避免与 _ModuleBase(ABCMeta)/ServiceBase(Generic) 的元类冲突，对既有
+    Emby/Jellyfin/Plex/TrimeMedia/Ugreen/ZSpace 模块零改动即结构兼容。
+
+    约定（与 ChainBase/MediaServerChain 媒服包装方法签名一致）：
+    - 多实例路由：server 参数为具体媒体服务器配置名（config_name）；为 None 时由后端广播到其
+      全部启用实例，门面再按"列表 extend / 非列表取首个非 None"跨后端合并。
+    - 签名漂移收敛：各后端 server 必填性 / username 形参 / **kwargs 存在差异（见各模块），门面在此
+      统一为最宽松 canonical 签名（server: Optional[str]）；后端要么声明该形参、要么有 **kwargs
+      吸收（不致 TypeError），故按 kwarg 分发对全部后端兼容、与 run_module 行为完全一致。注意：以
+      **kwargs 吸收某形参的后端（如 Plex/TrimeMedia/Ugreen 对 username）会静默忽略该值——此为既有
+      run_module 行为，门面如实保留、不引入差异。
+    - mediaserver_image_cookies 仅部分后端实现（TrimeMedia/Ugreen），按方法名分发自然只命中实现者
+      （类比下载器域 rtorrent 早期缺方法），未实现者不参与。
+    """
+
+    def media_exists(self, mediainfo: "MediaInfo", itemid: Optional[str] = None,
+                     server: Optional[str] = None) -> "Optional[ExistMediaInfo]": ...
+
+    def media_statistic(self, server: Optional[str] = None) -> "Optional[List[Statistic]]": ...
+
+    def mediaserver_librarys(self, server: Optional[str] = None, username: Optional[str] = None,
+                             hidden: Optional[bool] = False) -> "Optional[List[MediaServerLibrary]]": ...
+
+    def mediaserver_items(self, server: Optional[str] = None, library_id: Union[str, int] = None,
+                          start_index: Optional[int] = 0, limit: Optional[int] = -1) -> Optional[Generator]: ...
+
+    def mediaserver_iteminfo(self, server: Optional[str] = None,
+                             item_id: Union[str, int] = None) -> "Optional[MediaServerItem]": ...
+
+    def mediaserver_tv_episodes(self, server: Optional[str] = None,
+                                item_id: Union[str, int] = None) -> "Optional[List[MediaServerSeasonInfo]]": ...
+
+    def mediaserver_playing(self, server: Optional[str] = None, count: Optional[int] = 20,
+                            username: Optional[str] = None) -> "List[MediaServerPlayItem]": ...
+
+    def mediaserver_play_url(self, server: Optional[str] = None,
+                             item_id: Union[str, int] = None) -> Optional[str]: ...
+
+    def mediaserver_latest(self, server: Optional[str] = None, count: Optional[int] = 20,
+                           username: Optional[str] = None) -> "List[MediaServerPlayItem]": ...
+
+    def mediaserver_latest_images(self, server: Optional[str] = None, count: Optional[int] = 10,
+                                  username: Optional[str] = None,
+                                  remote: Optional[bool] = False) -> List[str]: ...
+
+    def mediaserver_image_cookies(self, server: Optional[str] = None,
+                                  image_url: Optional[str] = None) -> Optional[Union[str, dict]]: ...

--- a/tests/test_mediaserver_facade.py
+++ b/tests/test_mediaserver_facade.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+"""
+媒体服务器门面 MediaServerManager 回归测试。
+
+核心是 **等价性测试**：证明门面 _dispatch 与 ChainBase.run_module 在各返回形态下结果全等——
+门面调用的是与 run_module 同一批后端模块方法，唯一可能分歧的是分发/合并逻辑，本测试以受控
+mock 后端覆盖 None / 列表合并 / 短路 / tuple / dict / 优先级 / 生成器 各分支，锁死"门面 == run_module"。
+另含：公开方法路由、后端异常逐个续跑、raise_exception 透传、内建媒服结构化满足 IMediaServer 契约。
+"""
+from unittest import TestCase
+
+from app.chain import ChainBase
+from app.core.module import ModuleManager
+from app.helper.mediaserver_manager import MediaServerManager
+from app.modules import IMediaServer, _ModuleBase
+from app.schemas.exception import RateLimitExceededException
+from app.schemas.types import ModuleType
+
+
+class _TestChain(ChainBase):
+    """用于对照 run_module 的可实例化 ChainBase 子类。"""
+    pass
+
+
+class _ProbeBackend(_ModuleBase):
+    """
+    受控 mock 媒服后端：以自定义 probe 方法承载各返回形态，priority/name 可配置。
+    probe 对列表返回值每次返回新副本、对生成器每次返回新迭代器，避免 run_module 与门面两次
+    调用相互污染。
+    """
+
+    def __init__(self, name="mock", priority=1, probe_return=None, raises=False,
+                 gen_values=None, rate_limit=False):
+        super().__init__()
+        self._name = name
+        self._priority = priority
+        self._probe_return = probe_return
+        self._raises = raises
+        self._gen_values = gen_values
+        self._rate_limit = rate_limit
+        self.probe_calls = []
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self):
+        pass
+
+    def test(self):
+        return True, ""
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return self._priority
+
+    def get_type(self):
+        return ModuleType.MediaServer
+
+    def probe(self, *args, **kwargs):
+        self.probe_calls.append(kwargs)
+        if self._rate_limit:
+            raise RateLimitExceededException(f"{self._name} rate limited")
+        if self._raises:
+            raise RuntimeError(f"{self._name} boom")
+        if self._gen_values is not None:
+            return (v for v in self._gen_values)
+        ret = self._probe_return
+        return list(ret) if isinstance(ret, list) else ret
+
+
+class _MediaServerBackend(_ModuleBase):
+    """实现真实媒服方法名的 mock 后端，用于验证门面公开方法的路由与传参。"""
+
+    def __init__(self, name="ms"):
+        super().__init__()
+        self._name = name
+        self.calls = {}
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self):
+        pass
+
+    def test(self):
+        return True, ""
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return 1
+
+    def get_type(self):
+        return ModuleType.MediaServer
+
+    def mediaserver_librarys(self, **kwargs):
+        self.calls["mediaserver_librarys"] = kwargs
+        return ["lib"]
+
+    def media_statistic(self, **kwargs):
+        self.calls["media_statistic"] = kwargs
+        return ["stat"]
+
+    def mediaserver_play_url(self, **kwargs):
+        self.calls["mediaserver_play_url"] = kwargs
+        return "http://play"
+
+    def mediaserver_items(self, **kwargs):
+        self.calls["mediaserver_items"] = kwargs
+        return (i for i in ["it1", "it2"])
+
+
+def _patch_running(backends):
+    """把给定后端注入 ModuleManager 单例的 _running_modules，返回 (mgr, 原字典) 以便还原。"""
+    mgr = ModuleManager()
+    orig = mgr._running_modules
+    mgr._running_modules = {b._name: b for b in backends}
+    return mgr, orig
+
+
+class TestDispatchEquivalence(TestCase):
+    """门面 _dispatch 与 ChainBase.run_module 行为等价。"""
+
+    def _both(self, backends, **kwargs):
+        mgr, orig = _patch_running(backends)
+        try:
+            chain = _TestChain()
+            via_run_module = chain.run_module("probe", **kwargs)
+            via_facade = MediaServerManager()._dispatch("probe", **kwargs)
+            return via_run_module, via_facade
+        finally:
+            mgr._running_modules = orig
+
+    def test_all_none(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, None), _ProbeBackend("b", 2, None)])
+        self.assertIsNone(rm)
+        self.assertEqual(rm, fc)
+
+    def test_list_merge_two_backends(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, [1, 2]), _ProbeBackend("b", 2, [3])])
+        self.assertEqual(rm, [1, 2, 3])
+        self.assertEqual(rm, fc)
+
+    def test_list_merge_with_leading_none(self):
+        rm, fc = self._both([
+            _ProbeBackend("a", 1, None),
+            _ProbeBackend("b", 2, [3, 4]),
+            _ProbeBackend("c", 3, [5]),
+        ])
+        self.assertEqual(rm, [3, 4, 5])
+        self.assertEqual(rm, fc)
+
+    def test_str_short_circuit(self):
+        # 首个非空非列表（str，如 play_url）短路，后续不应合并
+        rm, fc = self._both([_ProbeBackend("a", 1, "http://x"), _ProbeBackend("b", 2, [9])])
+        self.assertEqual(rm, "http://x")
+        self.assertEqual(rm, fc)
+
+    def test_tuple_short_circuit(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, ("x", "y")), _ProbeBackend("b", 2, ("z", "w"))])
+        self.assertEqual(rm, ("x", "y"))
+        self.assertEqual(rm, fc)
+
+    def test_all_none_tuple_treated_empty(self):
+        rm, fc = self._both([
+            _ProbeBackend("a", 1, (None, None)),
+            _ProbeBackend("b", 2, ("got", None)),
+        ])
+        self.assertEqual(rm, ("got", None))
+        self.assertEqual(rm, fc)
+
+    def test_dict_result(self):
+        rm, fc = self._both([_ProbeBackend("a", 1, None), _ProbeBackend("b", 2, {"x": True})])
+        self.assertEqual(rm, {"x": True})
+        self.assertEqual(rm, fc)
+
+    def test_priority_ordering(self):
+        rm, fc = self._both([
+            _ProbeBackend("late", 9, [99]),
+            _ProbeBackend("early", 1, [1]),
+        ])
+        self.assertEqual(rm, [1, 99])
+        self.assertEqual(rm, fc)
+
+    def test_generator_leading_none(self):
+        # mediaserver_items 形态：前置 None 后端 + 返回生成器的后端 → 取该生成器（非列表短路）
+        rm, fc = self._both([
+            _ProbeBackend("a", 1, None),
+            _ProbeBackend("b", 2, gen_values=["it1", "it2"]),
+        ])
+        self.assertEqual(list(rm), ["it1", "it2"])
+        self.assertEqual(list(fc), ["it1", "it2"])
+
+
+class TestPublicMethodRouting(TestCase):
+    """门面公开方法路由到正确后端方法并透传参数。"""
+
+    def setUp(self):
+        self.backend = _MediaServerBackend("ms")
+        self.mgr, self.orig = _patch_running([self.backend])
+        self.msm = MediaServerManager()
+
+    def tearDown(self):
+        self.mgr._running_modules = self.orig
+
+    def test_librarys_routes(self):
+        ret = self.msm.mediaserver_librarys(server="emby1", username="u", hidden=True)
+        self.assertEqual(ret, ["lib"])
+        self.assertEqual(self.backend.calls["mediaserver_librarys"]["server"], "emby1")
+        self.assertEqual(self.backend.calls["mediaserver_librarys"]["username"], "u")
+
+    def test_media_statistic_routes(self):
+        ret = self.msm.media_statistic(server="emby1")
+        self.assertEqual(ret, ["stat"])
+        self.assertEqual(self.backend.calls["media_statistic"]["server"], "emby1")
+
+    def test_play_url_routes(self):
+        ret = self.msm.mediaserver_play_url(server="emby1", item_id="123")
+        self.assertEqual(ret, "http://play")
+        self.assertEqual(self.backend.calls["mediaserver_play_url"]["item_id"], "123")
+
+    def test_items_routes_generator(self):
+        ret = self.msm.mediaserver_items(server="emby1", library_id="1")
+        self.assertEqual(list(ret), ["it1", "it2"])
+
+
+class TestErrorHandling(TestCase):
+    """后端异常逐个续跑；raise_exception 透传。"""
+
+    def test_error_continues_to_next_backend(self):
+        backends = [_ProbeBackend("boom", 1, raises=True), _ProbeBackend("ok", 2, "value")]
+        mgr, orig = _patch_running(backends)
+        try:
+            self.assertEqual(MediaServerManager()._dispatch("probe"), "value")
+            self.assertEqual(_TestChain().run_module("probe"), "value")
+        finally:
+            mgr._running_modules = orig
+
+    def test_raise_exception_propagates(self):
+        backends = [_ProbeBackend("boom", 1, raises=True)]
+        mgr, orig = _patch_running(backends)
+        try:
+            with self.assertRaises(RuntimeError):
+                MediaServerManager()._dispatch("probe", raise_exception=True)
+        finally:
+            mgr._running_modules = orig
+
+    def test_rate_limit_skipped_quietly_equivalence(self):
+        # 限流异常应安静跳过（不当系统错误、不中止），续跑到下一后端——与 run_module 完全一致
+        backends = [_ProbeBackend("limited", 1, rate_limit=True), _ProbeBackend("ok", 2, "value")]
+        mgr, orig = _patch_running(backends)
+        try:
+            self.assertEqual(MediaServerManager()._dispatch("probe"), "value")
+            self.assertEqual(_TestChain().run_module("probe"), "value")
+        finally:
+            mgr._running_modules = orig
+
+    def test_rate_limit_raise_exception_propagates(self):
+        backends = [_ProbeBackend("limited", 1, rate_limit=True)]
+        mgr, orig = _patch_running(backends)
+        try:
+            with self.assertRaises(RateLimitExceededException):
+                MediaServerManager()._dispatch("probe", raise_exception=True)
+        finally:
+            mgr._running_modules = orig
+
+
+class TestIMediaServerContract(TestCase):
+    """
+    内建媒服模块对 IMediaServer 契约的符合度。
+
+    IMediaServer 是媒服域的 **最大化** 行为面（11 方法）：门面对外暴露全部，后端按方法名分发、
+    可只实现子集。10 个通用方法所有内建后端必有；mediaserver_image_cookies 仅 TrimeMedia/Ugreen 实现
+    （部分后端，类比下载器域 rtorrent 早期缺方法）。
+    """
+
+    _UNIVERSAL = (
+        "media_exists", "media_statistic", "mediaserver_librarys", "mediaserver_items",
+        "mediaserver_iteminfo", "mediaserver_tv_episodes", "mediaserver_playing",
+        "mediaserver_play_url", "mediaserver_latest", "mediaserver_latest_images",
+    )
+    _FULL = _UNIVERSAL + ("mediaserver_image_cookies",)
+
+    def _builtins(self):
+        from app.modules.emby import EmbyModule
+        from app.modules.jellyfin import JellyfinModule
+        from app.modules.plex import PlexModule
+        from app.modules.trimemedia import TrimeMediaModule
+        from app.modules.ugreen import UgreenModule
+        from app.modules.zspace import ZSpaceModule
+        return [EmbyModule, JellyfinModule, PlexModule, TrimeMediaModule, UgreenModule, ZSpaceModule]
+
+    def test_all_builtins_implement_universal(self):
+        for cls in self._builtins():
+            for name in self._UNIVERSAL:
+                self.assertTrue(callable(getattr(cls, name, None)),
+                                f"{cls.__name__} 缺少媒服通用方法 {name}")
+
+    def test_image_cookies_partial(self):
+        from app.modules.trimemedia import TrimeMediaModule
+        from app.modules.ugreen import UgreenModule
+        from app.modules.emby import EmbyModule
+        self.assertTrue(callable(getattr(TrimeMediaModule, "mediaserver_image_cookies", None)))
+        self.assertTrue(callable(getattr(UgreenModule, "mediaserver_image_cookies", None)))
+        # Emby 不实现该可选方法
+        self.assertFalse(callable(getattr(EmbyModule, "mediaserver_image_cookies", None)))
+
+    def test_facade_exposes_full_face(self):
+        for name in self._FULL:
+            self.assertTrue(callable(getattr(MediaServerManager, name, None)),
+                            f"MediaServerManager 缺少 IMediaServer 方法 {name}")
+
+    def test_full_face_backends_satisfy_protocol(self):
+        # 实现全部 11 方法的后端应结构化满足 IMediaServer（runtime_checkable）
+        from app.modules.trimemedia import TrimeMediaModule
+        from app.modules.ugreen import UgreenModule
+        for cls in (TrimeMediaModule, UgreenModule):
+            self.assertTrue(issubclass(cls, IMediaServer), f"{cls.__name__} 未结构化满足 IMediaServer")

--- a/tests/test_mediaserver_image_signing.py
+++ b/tests/test_mediaserver_image_signing.py
@@ -10,10 +10,17 @@ class MediaServerImageSigningTest(unittest.TestCase):
     @staticmethod
     def _build_chain(result):
         """
-        构造只带 run_module 的 MediaServerChain，避免单测初始化真实模块管理器。
+        构造只带媒服门面的 MediaServerChain，避免单测初始化真实模块管理器。
+        门面化后 MediaServerChain 经 self.mediaservermanager.mediaserver_* 分发（取代 run_module），
+        故此处 mock 门面的各媒服方法统一返回 result。
         """
         chain = MediaServerChain.__new__(MediaServerChain)
-        chain.run_module = Mock(return_value=result)
+        manager = Mock()
+        for name in ("mediaserver_librarys", "mediaserver_latest", "mediaserver_latest_images",
+                     "mediaserver_playing", "mediaserver_items", "mediaserver_iteminfo",
+                     "mediaserver_tv_episodes", "mediaserver_play_url", "mediaserver_image_cookies"):
+            getattr(manager, name).return_value = result
+        chain.mediaservermanager = manager
         return chain
 
     def test_librarys_signs_image_fields(self):


### PR DESCRIPTION
## 背景

继下载器域门面化（#63）之后，媒体服务器是评估中点名的**下一个门面候选**：6 个后端（Emby/Jellyfin/Plex/TrimeMedia/Ugreen/ZSpace）、`_MediaServerBase` 无行为接口、`mediaserver_*` 经 `run_module` 字符串 ABI 分发、且后端**签名漂移**。本 PR 照 DownloaderManager 范式将其升级为「门面 + 可插拔后端」。

## 改动

- **`IMediaServer` Protocol**（`app/modules/__init__.py`）：`runtime_checkable`、**11 方法最大化面**、结构化类型（后端零改动即结构兼容）。
- **`MediaServerManager(Singleton)`**（新 `app/helper/mediaserver_manager.py`）：`_dispatch` **忠实复刻** `ChainBase.__execute_system_modules` 合并语义（`check_signature` / 列表 extend / 短路 / **生成器分发** / 异常逐后端续跑 / SystemError 事件 / **RateLimit 安静跳过**），按 `get_running_modules(method)` 实时发现后端（含插件 `provides_mediaservers` 注册者）。
- **改走门面**：`ChainBase.__init__` 加 `mediaservermanager` DI 注入；`MediaServerChain` 9 方法 + `DashboardChain.media_statistic` + `ChainBase.media_exists` 经门面分发。**v2 `run_module` 路径保留**（叠加层，标废弃）。
- **签名漂移收敛**：各后端 `server` 必填性 / `username` 形参 / `**kwargs` 不一致；门面在**接口层**统一为最宽松 canonical 签名（`server: Optional[str]`），后端要么声明形参、要么 `**kwargs` 吸收，故按 kwarg 分发对全部后端兼容、与 `run_module` **完全一致**（`**kwargs` 吸收方静默忽略该值——既有行为，如实保留）。
- 后端 6 模块**零改动**。

## 等价性

门面调用的是与 `run_module` **同一批后端方法**（方法体零改动），唯一被收敛的是「字符串 ABI 分发」。`tests/test_mediaserver_facade.py` 以**等价性测试**证明门面 `_dispatch == run_module` 在 None / 列表合并 / 短路 / tuple / dict / 优先级 / **生成器** / **限流** 各形态下结果全等。

## code-reviewer

APPROVE（核心 `_dispatch` 与 DownloaderManager 字节级等价、与 `__execute_system_modules` 语义等价）；已修复：
- **HIGH**：两门面 `_dispatch` 补 `RateLimitExceededException` 安静跳过分支（与 `__execute_system_modules` 一致；DownloaderManager 同补保持一致）→ 限流不再误报系统错误。
- **HIGH**：清理 `items()` docstring 内含旧 `run_module` 的过时伪代码（误导）。
- **MEDIUM**：`IMediaServer` docstring 准确说明 `**kwargs` 吸收方静默忽略该值。

## 测试
- 新增 `tests/test_mediaserver_facade.py`（21 例：等价性含生成器/限流 + 路由 + 异常续跑 + IMediaServer 契约）；`test_mediaserver_image_signing.py` mock 目标从 `run_module` 迁到门面。
- 媒服全链路 + 下载器门面 + transfer 回归 **88 passed**。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 插件经 `provides_mediaservers` 注册的媒服即时参与门面分发
- [ ] 内建媒服库/最新/播放/统计/存在性查询行为不变