### PR TITLE
refactor: 注册机制去重（抽通用实现，净减 230 行）

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -253,98 +253,68 @@ class ModuleManager(metaclass=Singleton):
         return (not reasons), reasons
 
     @staticmethod
-    def verify_data_source_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    def _verify_typed_contract(module_cls: type, expected_type: ModuleType,
+                               required_methods: Tuple[str, ...] = (),
+                               method_label: str = "") -> Tuple[bool, List[str]]:
         """
-        校验数据源（媒体识别/信息源，MediaRecognize 域）契约：在 _ModuleBase 基类契约之上，
-        要求 get_type()==ModuleType.MediaRecognize。识别能力方法（recognize_media /
-        search_medias / obtain_images 等）由框架按方法名分发、按需实现，故不在此强制
-        （避免误拒 thetvdb 这类仅实现部分/其它方法的真实源）。返回 (是否通过, 失败原因列表)。
+        域契约通用校验（各 verify_*_contract 的共用实现）：在 _ModuleBase 基类契约之上，要求
+        get_type()==expected_type，并要求 required_methods 全部可调用。能力方法按需实现的域
+        传空 required_methods 即可。返回 (是否通过, 失败原因列表)。
         """
         ok, reasons = ModuleManager.verify_module_contract(module_cls)
         reasons = list(reasons)
-        # 数据源须声明为 MediaRecognize 类型
         _get_type = getattr(module_cls, "get_type", None)
         if not callable(_get_type):
             reasons.append("缺少 get_type")
         else:
             try:
-                if _get_type() != ModuleType.MediaRecognize:
-                    reasons.append(f"get_type 须为 ModuleType.MediaRecognize（实际 {_get_type()}）")
+                if _get_type() != expected_type:
+                    reasons.append(f"get_type 须为 {expected_type}（实际 {_get_type()}）")
             except Exception as err:
                 reasons.append(f"get_type 调用失败：{err}")
+        for _name in required_methods:
+            if not callable(getattr(module_cls, _name, None)):
+                reasons.append(f"缺少{method_label}方法：{_name}")
         return (not reasons), reasons
+
+    @staticmethod
+    def verify_data_source_contract(module_cls: type) -> Tuple[bool, List[str]]:
+        """
+        校验数据源（媒体识别/信息源，MediaRecognize 域）契约：基类契约 + get_type==MediaRecognize。
+        识别能力方法（recognize_media/search_medias/obtain_images 等）按方法名分发、按需实现，
+        故不强制（避免误拒 thetvdb 这类仅实现部分/其它方法的真实源）。
+        """
+        return ModuleManager._verify_typed_contract(module_cls, ModuleType.MediaRecognize)
 
     @staticmethod
     def verify_downloader_contract(module_cls: type) -> Tuple[bool, List[str]]:
         """
-        校验下载器（Downloader 域）契约：在 _ModuleBase 基类契约之上，要求
-        get_type()==ModuleType.Downloader 且实现下载器核心操作（download/list_torrents/
-        remove_torrents）。完整 IDownloader 操作面（start/stop/torrent_files/downloader_info 等）
-        由 run_module 按方法名分发、按需实现。供 provides_downloaders() 注册前严格校验。
-        返回 (是否通过, 失败原因列表)。
+        校验下载器（Downloader 域）契约：基类契约 + get_type==Downloader + 核心操作
+        download/list_torrents/remove_torrents。完整 IDownloader 面（start/stop/torrent_files 等）
+        按方法名分发、按需实现。供 provides_downloaders() 注册前严格校验。
         """
-        ok, reasons = ModuleManager.verify_module_contract(module_cls)
-        reasons = list(reasons)
-        _get_type = getattr(module_cls, "get_type", None)
-        if not callable(_get_type):
-            reasons.append("缺少 get_type")
-        else:
-            try:
-                if _get_type() != ModuleType.Downloader:
-                    reasons.append(f"get_type 须为 ModuleType.Downloader（实际 {_get_type()}）")
-            except Exception as err:
-                reasons.append(f"get_type 调用失败：{err}")
-        for _name in ("download", "list_torrents", "remove_torrents"):
-            if not callable(getattr(module_cls, _name, None)):
-                reasons.append(f"缺少下载器方法：{_name}")
-        return (not reasons), reasons
+        return ModuleManager._verify_typed_contract(
+            module_cls, ModuleType.Downloader,
+            ("download", "list_torrents", "remove_torrents"), "下载器")
 
     @staticmethod
     def verify_notification_contract(module_cls: type) -> Tuple[bool, List[str]]:
         """
-        校验消息渠道（Notification 域）契约：在 _ModuleBase 基类契约之上，要求
-        get_type()==ModuleType.Notification 且实现消息发送核心方法 post_message。
-        其余消息能力方法（post_medias/post_torrents/delete_message/register_commands 等）
-        由 run_module 按方法名分发、按需实现。供 provides_notifications() 注册前严格校验。
-        返回 (是否通过, 失败原因列表)。
+        校验消息渠道（Notification 域）契约：基类契约 + get_type==Notification + 核心方法 post_message。
+        其余消息能力方法（post_medias/post_torrents/delete_message 等）按方法名分发、按需实现。
+        供 provides_notifications() 注册前严格校验。
         """
-        ok, reasons = ModuleManager.verify_module_contract(module_cls)
-        reasons = list(reasons)
-        _get_type = getattr(module_cls, "get_type", None)
-        if not callable(_get_type):
-            reasons.append("缺少 get_type")
-        else:
-            try:
-                if _get_type() != ModuleType.Notification:
-                    reasons.append(f"get_type 须为 ModuleType.Notification（实际 {_get_type()}）")
-            except Exception as err:
-                reasons.append(f"get_type 调用失败：{err}")
-        if not callable(getattr(module_cls, "post_message", None)):
-            reasons.append("缺少消息渠道方法：post_message")
-        return (not reasons), reasons
+        return ModuleManager._verify_typed_contract(
+            module_cls, ModuleType.Notification, ("post_message",), "消息渠道")
 
     @staticmethod
     def verify_mediaserver_contract(module_cls: type) -> Tuple[bool, List[str]]:
         """
-        校验媒体服务器（MediaServer 域）契约：在 _ModuleBase 基类契约之上，要求
-        get_type()==ModuleType.MediaServer。媒体服务器能力方法（mediaserver_librarys /
-        media_statistic / mediaserver_playing / mediaserver_items 等）由 run_module 按方法名
-        分发、按需实现，各后端（emby/jellyfin/plex/trimemedia/ugreen/zspace）实现的子集不同，
-        故不在此强制（避免误拒仅实现部分方法的真实媒体服务器）。供 provides_mediaservers()
-        注册前严格校验。返回 (是否通过, 失败原因列表)。
+        校验媒体服务器（MediaServer 域）契约：基类契约 + get_type==MediaServer。能力方法
+        （mediaserver_librarys/media_statistic 等）各后端实现子集不同，按方法名分发、按需实现，
+        故不强制。供 provides_mediaservers() 注册前严格校验。
         """
-        ok, reasons = ModuleManager.verify_module_contract(module_cls)
-        reasons = list(reasons)
-        _get_type = getattr(module_cls, "get_type", None)
-        if not callable(_get_type):
-            reasons.append("缺少 get_type")
-        else:
-            try:
-                if _get_type() != ModuleType.MediaServer:
-                    reasons.append(f"get_type 须为 ModuleType.MediaServer（实际 {_get_type()}）")
-            except Exception as err:
-                reasons.append(f"get_type 调用失败：{err}")
-        return (not reasons), reasons
+        return ModuleManager._verify_typed_contract(module_cls, ModuleType.MediaServer)
 
     def register_module(self, module_cls: type, owner: str) -> bool:
         """

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -649,70 +649,33 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                             getattr(caps, "channel", None), caps, owner=plugin_id)
                     except Exception as err:
                         logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
-        # 注册插件经 provides_data_sources 声明新增的数据源（媒体识别/信息源，MediaRecognize 域），
-        # 经数据源契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 recognize_media 识别流水线。
-        provided_data_sources = plugin_metadata.get_plugin_provided_data_sources(self._running_plugins, pid)
-        for plugin_id, source_classes in provided_data_sources.items():
-            for source_cls in source_classes:
-                _ds_ok, _ds_reasons = ModuleManager.verify_data_source_contract(source_cls)
-                if not _ds_ok:
-                    logger.warning(f"插件 {plugin_id} 数据源 "
-                                   f"{getattr(source_cls, '__name__', source_cls)} 未通过数据源契约校验，拒绝注册："
-                                   f"{'；'.join(_ds_reasons)}")
+        # 注册插件经 provides_* 声明新增的各契约域模块（数据源/下载器/消息渠道/媒体服务器）：
+        # 经各自契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 chain 分发。
+        for _get_provided, _verify, _label in (
+            (plugin_metadata.get_plugin_provided_data_sources, ModuleManager.verify_data_source_contract, "数据源"),
+            (plugin_metadata.get_plugin_provided_downloaders, ModuleManager.verify_downloader_contract, "下载器"),
+            (plugin_metadata.get_plugin_provided_notifications, ModuleManager.verify_notification_contract, "消息渠道"),
+            (plugin_metadata.get_plugin_provided_mediaservers, ModuleManager.verify_mediaserver_contract, "媒体服务器"),
+        ):
+            self._register_contract_domain(pid, _get_provided, _verify, _label)
+
+    def _register_contract_domain(self, pid, get_provided, verify_contract, label: str):
+        """
+        注册某契约域插件类的共用实现（数据源/下载器/消息渠道/媒体服务器）：聚合插件声明的类 →
+        经域契约校验（不通过仅警告拒绝、不影响其它）→ register_module(owner=plugin_id)。
+        """
+        for plugin_id, classes in get_provided(self._running_plugins, pid).items():
+            for cls in classes:
+                _name = getattr(cls, "__name__", cls)
+                ok, reasons = verify_contract(cls)
+                if not ok:
+                    logger.warning(f"插件 {plugin_id} {label} {_name} 未通过{label}契约校验，拒绝注册："
+                                   f"{'；'.join(reasons)}")
                     continue
                 try:
-                    ModuleManager().register_module(source_cls, owner=plugin_id)
+                    ModuleManager().register_module(cls, owner=plugin_id)
                 except Exception as err:
-                    logger.error(f"注册插件 {plugin_id} 数据源 "
-                                 f"{getattr(source_cls, '__name__', source_cls)} 出错：{str(err)}")
-        # 注册插件经 provides_downloaders 声明新增的下载器（Downloader 域），
-        # 经下载器契约校验通过后注册到 ModuleManager（owner=plugin_id），参与下载器分发。
-        provided_downloaders = plugin_metadata.get_plugin_provided_downloaders(self._running_plugins, pid)
-        for plugin_id, downloader_classes in provided_downloaders.items():
-            for downloader_cls in downloader_classes:
-                _dl_ok, _dl_reasons = ModuleManager.verify_downloader_contract(downloader_cls)
-                if not _dl_ok:
-                    logger.warning(f"插件 {plugin_id} 下载器 "
-                                   f"{getattr(downloader_cls, '__name__', downloader_cls)} 未通过下载器契约校验，拒绝注册："
-                                   f"{'；'.join(_dl_reasons)}")
-                    continue
-                try:
-                    ModuleManager().register_module(downloader_cls, owner=plugin_id)
-                except Exception as err:
-                    logger.error(f"注册插件 {plugin_id} 下载器 "
-                                 f"{getattr(downloader_cls, '__name__', downloader_cls)} 出错：{str(err)}")
-        # 注册插件经 provides_notifications 声明新增的消息渠道（Notification 域），
-        # 经消息渠道契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 post_message 消息分发。
-        provided_notifications = plugin_metadata.get_plugin_provided_notifications(self._running_plugins, pid)
-        for plugin_id, notification_classes in provided_notifications.items():
-            for notification_cls in notification_classes:
-                _nf_ok, _nf_reasons = ModuleManager.verify_notification_contract(notification_cls)
-                if not _nf_ok:
-                    logger.warning(f"插件 {plugin_id} 消息渠道 "
-                                   f"{getattr(notification_cls, '__name__', notification_cls)} 未通过消息渠道契约校验，拒绝注册："
-                                   f"{'；'.join(_nf_reasons)}")
-                    continue
-                try:
-                    ModuleManager().register_module(notification_cls, owner=plugin_id)
-                except Exception as err:
-                    logger.error(f"注册插件 {plugin_id} 消息渠道 "
-                                 f"{getattr(notification_cls, '__name__', notification_cls)} 出错：{str(err)}")
-        # 注册插件经 provides_mediaservers 声明新增的媒体服务器（MediaServer 域），
-        # 经媒体服务器契约校验通过后注册到 ModuleManager（owner=plugin_id），参与媒体库分发。
-        provided_mediaservers = plugin_metadata.get_plugin_provided_mediaservers(self._running_plugins, pid)
-        for plugin_id, mediaserver_classes in provided_mediaservers.items():
-            for mediaserver_cls in mediaserver_classes:
-                _ms_ok, _ms_reasons = ModuleManager.verify_mediaserver_contract(mediaserver_cls)
-                if not _ms_ok:
-                    logger.warning(f"插件 {plugin_id} 媒体服务器 "
-                                   f"{getattr(mediaserver_cls, '__name__', mediaserver_cls)} 未通过媒体服务器契约校验，拒绝注册："
-                                   f"{'；'.join(_ms_reasons)}")
-                    continue
-                try:
-                    ModuleManager().register_module(mediaserver_cls, owner=plugin_id)
-                except Exception as err:
-                    logger.error(f"注册插件 {plugin_id} 媒体服务器 "
-                                 f"{getattr(mediaserver_cls, '__name__', mediaserver_cls)} 出错：{str(err)}")
+                    logger.error(f"注册插件 {plugin_id} {label} {_name} 出错：{str(err)}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -143,232 +143,69 @@ def get_plugin_modules(running_plugins, pid: Optional[str] = None) -> Dict[tuple
                 logger.error(f"获取插件 {plugin_id} 模块出错：{str(e)}")
     return ret_modules
 
-def get_plugin_provided_modules(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+def _get_plugin_provided(running_plugins, hook_name: str, err_label: str,
+                         pid: Optional[str] = None) -> Dict[str, List[Any]]:
     """
-    聚合插件经 provides_modules() 声明【新增】的系统模块类，按 plugin_id(owner) 归集。
-    供 PluginManager 启停时统一向 ModuleManager 注册/卸载（owner=plugin_id）。
+    聚合插件经某 provides_* 钩子声明【新增】的对象（模块类或数据对象），按 plugin_id(owner) 归集。
+    各 get_plugin_provided_* 的共用实现：快照运行态插件、按 pid 过滤、仅取已启用(get_state)插件、
+    调用钩子收集非空结果。hook_name 为钩子方法名，err_label 用于异常日志。
     {
-        plugin_id: [module_cls, ...]
+        plugin_id: [item, ...]
     }
     """
-    ret_modules: Dict[str, List[type]] = {}
+    ret: Dict[str, List[Any]] = {}
     # 创建字典快照避免并发修改
     running_plugins_snapshot = dict(running_plugins)
     for plugin_id, plugin in running_plugins_snapshot.items():
         if pid and pid != plugin_id:
             continue
-        if hasattr(plugin, "provides_modules") and ObjectUtils.check_method(plugin.provides_modules):
+        hook = getattr(plugin, hook_name, None)
+        if hook is not None and ObjectUtils.check_method(hook):
             try:
                 if not plugin.get_state():
                     continue
-                modules = plugin.provides_modules() or []
-                if modules:
-                    ret_modules[plugin_id] = list(modules)
+                items = hook() or []
+                if items:
+                    ret[plugin_id] = list(items)
             except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册模块出错：{str(e)}")
-    return ret_modules
+                logger.error(f"获取插件 {plugin_id} {err_label}出错：{str(e)}")
+    return ret
+
+def get_plugin_provided_modules(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
+    """聚合插件经 provides_modules() 声明【新增】的系统模块类，按 plugin_id 归集（供 ModuleManager 注册/卸载）。"""
+    return _get_plugin_provided(running_plugins, "provides_modules", "注册模块", pid)
 
 def get_plugin_provided_data_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
-    """
-    聚合插件经 provides_data_sources() 声明【新增】的数据源（MediaRecognize 域）类，
-    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [source_cls, ...]
-    }
-    """
-    ret_sources: Dict[str, List[type]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_data_sources") and ObjectUtils.check_method(plugin.provides_data_sources):
-            try:
-                if not plugin.get_state():
-                    continue
-                sources = plugin.provides_data_sources() or []
-                if sources:
-                    ret_sources[plugin_id] = list(sources)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册数据源出错：{str(e)}")
-    return ret_sources
+    """聚合插件经 provides_data_sources() 声明【新增】的数据源（MediaRecognize 域）类，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_data_sources", "注册数据源", pid)
 
 def get_plugin_provided_downloaders(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
-    """
-    聚合插件经 provides_downloaders() 声明【新增】的下载器（Downloader 域）类，
-    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [downloader_cls, ...]
-    }
-    """
-    ret_downloaders: Dict[str, List[type]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_downloaders") and ObjectUtils.check_method(plugin.provides_downloaders):
-            try:
-                if not plugin.get_state():
-                    continue
-                downloaders = plugin.provides_downloaders() or []
-                if downloaders:
-                    ret_downloaders[plugin_id] = list(downloaders)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册下载器出错：{str(e)}")
-    return ret_downloaders
+    """聚合插件经 provides_downloaders() 声明【新增】的下载器（Downloader 域）类，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_downloaders", "注册下载器", pid)
 
 def get_plugin_provided_notifications(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
-    """
-    聚合插件经 provides_notifications() 声明【新增】的消息渠道（Notification 域）类，
-    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [notification_cls, ...]
-    }
-    """
-    ret_notifications: Dict[str, List[type]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_notifications") and ObjectUtils.check_method(plugin.provides_notifications):
-            try:
-                if not plugin.get_state():
-                    continue
-                notifications = plugin.provides_notifications() or []
-                if notifications:
-                    ret_notifications[plugin_id] = list(notifications)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册消息渠道出错：{str(e)}")
-    return ret_notifications
+    """聚合插件经 provides_notifications() 声明【新增】的消息渠道（Notification 域）类，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_notifications", "注册消息渠道", pid)
 
 def get_plugin_provided_mediaservers(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
-    """
-    聚合插件经 provides_mediaservers() 声明【新增】的媒体服务器（MediaServer 域）类，
-    按 plugin_id(owner) 归集。供 PluginManager 启停时经 ModuleManager 注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [mediaserver_cls, ...]
-    }
-    """
-    ret_mediaservers: Dict[str, List[type]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_mediaservers") and ObjectUtils.check_method(plugin.provides_mediaservers):
-            try:
-                if not plugin.get_state():
-                    continue
-                mediaservers = plugin.provides_mediaservers() or []
-                if mediaservers:
-                    ret_mediaservers[plugin_id] = list(mediaservers)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册媒体服务器出错：{str(e)}")
-    return ret_mediaservers
+    """聚合插件经 provides_mediaservers() 声明【新增】的媒体服务器（MediaServer 域）类，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_mediaservers", "注册媒体服务器", pid)
 
 def get_plugin_provided_discover_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
-    """
-    聚合插件经 provides_discover_sources() 声明【新增】的探索数据源（DiscoverMediaSource 数据对象），
-    按 plugin_id 归集。供 /api/discover/source 端点与事件扩展去重合并后供前端枚举。
-    {
-        plugin_id: [DiscoverMediaSource, ...]
-    }
-    """
-    ret_sources: Dict[str, List[Any]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_discover_sources") \
-                and ObjectUtils.check_method(plugin.provides_discover_sources):
-            try:
-                if not plugin.get_state():
-                    continue
-                sources = plugin.provides_discover_sources() or []
-                if sources:
-                    ret_sources[plugin_id] = list(sources)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册探索数据源出错：{str(e)}")
-    return ret_sources
+    """聚合插件经 provides_discover_sources() 声明【新增】的探索数据源（DiscoverMediaSource），按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_discover_sources", "注册探索数据源", pid)
 
 def get_plugin_provided_recommend_sources(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
-    """
-    聚合插件经 provides_recommend_sources() 声明【新增】的推荐数据源（RecommendMediaSource 数据对象），
-    按 plugin_id 归集。供 /api/recommend/source 端点与事件扩展去重合并后供前端枚举。
-    {
-        plugin_id: [RecommendMediaSource, ...]
-    }
-    """
-    ret_sources: Dict[str, List[Any]] = {}
-    # 创建字典快照避免并发修改
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_recommend_sources") \
-                and ObjectUtils.check_method(plugin.provides_recommend_sources):
-            try:
-                if not plugin.get_state():
-                    continue
-                sources = plugin.provides_recommend_sources() or []
-                if sources:
-                    ret_sources[plugin_id] = list(sources)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册推荐数据源出错：{str(e)}")
-    return ret_sources
+    """聚合插件经 provides_recommend_sources() 声明【新增】的推荐数据源（RecommendMediaSource），按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_recommend_sources", "注册推荐数据源", pid)
 
 def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> Dict[str, List[type]]:
-    """
-    聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id(owner) 归集。
-    供 PluginManager 启停时统一向 FileManager 注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [storage_cls, ...]
-    }
-    """
-    ret_storages: Dict[str, List[type]] = {}
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_storages") and ObjectUtils.check_method(plugin.provides_storages):
-            try:
-                if not plugin.get_state():
-                    continue
-                storages = plugin.provides_storages() or []
-                if storages:
-                    ret_storages[plugin_id] = list(storages)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册存储器出错：{str(e)}")
-    return ret_storages
+    """聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id 归集（供 FileManager 注册/卸载）。"""
+    return _get_plugin_provided(running_plugins, "provides_storages", "注册存储器", pid)
 
 def get_plugin_provided_channel_capabilities(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
-    """
-    聚合插件经 provides_channel_capabilities() 声明【新增】的消息渠道能力矩阵，
-    按 plugin_id(owner) 归集。供 PluginManager 启停时统一向 ChannelCapabilityManager
-    注册/卸载（owner=plugin_id）。
-    {
-        plugin_id: [ChannelCapabilities, ...]
-    }
-    """
-    ret_caps: Dict[str, List[Any]] = {}
-    running_plugins_snapshot = dict(running_plugins)
-    for plugin_id, plugin in running_plugins_snapshot.items():
-        if pid and pid != plugin_id:
-            continue
-        if hasattr(plugin, "provides_channel_capabilities") \
-                and ObjectUtils.check_method(plugin.provides_channel_capabilities):
-            try:
-                if not plugin.get_state():
-                    continue
-                caps = plugin.provides_channel_capabilities() or []
-                if caps:
-                    ret_caps[plugin_id] = list(caps)
-            except Exception as e:
-                logger.error(f"获取插件 {plugin_id} 注册渠道能力出错：{str(e)}")
-    return ret_caps
+    """聚合插件经 provides_channel_capabilities() 声明【新增】的消息渠道能力矩阵，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_channel_capabilities", "注册渠道能力", pid)
 
 def get_plugin_actions(running_plugins, pid: Optional[str] = None) -> List[Dict[str, Any]]:
     """


### PR DESCRIPTION
## 背景

本会话陆续为多个域加开放注册（#61/#62/#65/#68）后，注册机制里堆了**大量近乎复制**的代码。本 PR 把三处重复抽成参数化通用实现——**公开 API 签名与行为完全不变**，仅内部收敛。

## 改动（净减 230 行：+93 / -323）

| 文件 | 重复 | 抽取 |
|---|---|---|
| `app/core/module.py` | 4 个 `verify_*_contract`（data_source/downloader/notification/mediaserver）结构全同 | `_verify_typed_contract(expected_type, required_methods, label)`，4 个公开方法 → 薄壳 |
| `app/helper/plugin_metadata.py` | **9 个** `get_plugin_provided_*` 几乎逐行相同 | `_get_plugin_provided(hook_name, err_label)`，9 个公开函数 → 一行薄壳 |
| `app/helper/plugin_manager.py` | `_register_plugin_modules` 的 4 个契约域注册块结构全同 | `_register_contract_domain(get_provided, verify, label)` + 数据驱动循环 |

## 行为保真
- **reason 字符串保留**：`f"get_type 须为 {expected_type}…"` 的 `str(ModuleType.X)` 等于原硬编码 `"ModuleType.X"`，测试所验子串（类型名/方法名）不变。
- **日志文案保留**：聚合器异常日志 `err_label`、注册 warning/error 的 `label` 拼接逐字等于原逐块文案。
- **公开 API 不变**：`verify_*_contract` / `get_plugin_provided_*` 签名与返回值不变（被 plugin_manager / 端点 / 测试消费）。

## 测试
- 全量注册测试 **82 passed**（data_source/downloader/notification/mediaserver/metadata/discover_recommend/storage 注册 + plugin_metadata/spi_aggregator/module_external/module_registration_validation），行为零变化。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 插件经各 provides_* 注册/拒绝行为与重构前一致