### PR TITLE
refactor: 认证编排清理（UserChain.user_authenticate，A 档）

### DIFF
--- a/app/chain/user.py
+++ b/app/chain/user.py
@@ -1,5 +1,5 @@
 import secrets
-from typing import Optional, Tuple, Union
+from typing import NamedTuple, Optional, Tuple, Union
 
 from app.chain import ChainBase
 from app.core.config import settings
@@ -12,6 +12,13 @@ from app.schemas.types import ChainEventType
 from app.utils.otp import OtpUtils
 
 PASSWORD_INVALID_CREDENTIALS_MESSAGE = "用户名或密码或二次校验码不正确"
+
+
+class _AuthOutcome(NamedTuple):
+    """user_authenticate 内部编排结果：user 非空表示已认证成功；apply_mfa 指明是否需走 MFA。"""
+    user: Optional[User]
+    error: Optional[str]
+    apply_mfa: bool
 
 
 class UserChain(ChainBase):
@@ -47,49 +54,52 @@ class UserChain(ChainBase):
             grant_type=grant_type
         )
         logger.debug(f"认证类型：{grant_type}，开始准备对用户 {username} 进行身份校验")
-        if credentials.grant_type == "password":
-            # Password 认证
+        # 1) 按 grant_type 解析出已认证用户（本地密码 → 辅助认证），并指明是否需走 MFA
+        outcome = self._resolve_user(credentials)
+        # 用 is None 而非真值判断：成功与否由 user 是否为 None 决定，避免未来 User 真值被覆写时误判
+        if outcome.user is None:
+            return False, outcome.error
+        # 2) MFA 二次验证：仅 password grant 校验（authorization_code 等不校验，保持原行为）
+        if outcome.apply_mfa:
+            mfa_result = self._verify_mfa(outcome.user, credentials.mfa_code)
+            if mfa_result == "MFA_REQUIRED":
+                return False, "MFA_REQUIRED"
+            if not mfa_result:
+                return False, PASSWORD_INVALID_CREDENTIALS_MESSAGE
+        logger.info(f"用户 {username} 认证成功")
+        return True, outcome.user
+
+    def _resolve_user(self, credentials: AuthCredentials) -> _AuthOutcome:
+        """
+        按 grant_type 解析出已认证用户（不含 MFA），是 user_authenticate 的编排子步骤：
+        - "password"：先本地密码，失败再辅助认证（若启用）；两条路得到的用户都需后续 MFA。
+        - "authorization_code"：仅辅助认证（若启用），不走 MFA。
+        - 其它：不支持。
+        返回 _AuthOutcome(user, error, apply_mfa)：user 非空表示成功，否则 error 为失败信息。
+        """
+        grant_type = credentials.grant_type
+        if grant_type == "password":
             success, user_or_message = self.password_authenticate(credentials=credentials)
             if success:
-                # 如果用户启用了二次验证码，则进一步验证
-                mfa_result = self._verify_mfa(user_or_message, credentials.mfa_code)
-                if mfa_result == "MFA_REQUIRED":
-                    return False, "MFA_REQUIRED"
-                elif not mfa_result:
-                    return False, PASSWORD_INVALID_CREDENTIALS_MESSAGE
-                logger.info(f"用户 {username} 通过密码认证成功")
-                return True, user_or_message
-            else:
-                # 用户不存在或密码错误，考虑辅助认证
-                if settings.AUXILIARY_AUTH_ENABLE:
-                    logger.warning("密码认证失败，尝试通过外部服务进行辅助认证 ...")
-                    aux_success, aux_user_or_message = self.auxiliary_authenticate(credentials=credentials)
-                    if aux_success:
-                        # 辅助认证成功后再验证二次验证码
-                        mfa_result = self._verify_mfa(aux_user_or_message, credentials.mfa_code)
-                        if mfa_result == "MFA_REQUIRED":
-                            return False, "MFA_REQUIRED"
-                        elif not mfa_result:
-                            return False, PASSWORD_INVALID_CREDENTIALS_MESSAGE
-                        return True, aux_user_or_message
-                    else:
-                        return False, PASSWORD_INVALID_CREDENTIALS_MESSAGE
-                else:
-                    logger.debug(f"辅助认证未启用，用户 {username} 认证失败")
-                    return False, PASSWORD_INVALID_CREDENTIALS_MESSAGE
-        elif credentials.grant_type == "authorization_code":
-            # 处理其他认证类型的分支
-            if settings.AUXILIARY_AUTH_ENABLE:
-                aux_success, aux_user_or_message = self.auxiliary_authenticate(credentials=credentials)
-                if aux_success:
-                    return True, aux_user_or_message
-                else:
-                    return False, "认证失败"
-            else:
-                return False, "认证失败"
-        else:
-            logger.debug(f"辅助认证未启用，认证类型 {grant_type} 未实现")
-            return False, "不支持的认证类型"
+                return _AuthOutcome(user_or_message, None, apply_mfa=True)
+            # 用户不存在或密码错误 → 辅助认证兜底
+            if not settings.AUXILIARY_AUTH_ENABLE:
+                logger.debug(f"辅助认证未启用，用户 {credentials.username} 认证失败")
+                return _AuthOutcome(None, PASSWORD_INVALID_CREDENTIALS_MESSAGE, apply_mfa=False)
+            logger.warning("密码认证失败，尝试通过外部服务进行辅助认证 ...")
+            aux_success, aux_user_or_message = self.auxiliary_authenticate(credentials=credentials)
+            if aux_success:
+                return _AuthOutcome(aux_user_or_message, None, apply_mfa=True)
+            return _AuthOutcome(None, PASSWORD_INVALID_CREDENTIALS_MESSAGE, apply_mfa=False)
+        if grant_type == "authorization_code":
+            if not settings.AUXILIARY_AUTH_ENABLE:
+                return _AuthOutcome(None, "认证失败", apply_mfa=False)
+            aux_success, aux_user_or_message = self.auxiliary_authenticate(credentials=credentials)
+            if aux_success:
+                return _AuthOutcome(aux_user_or_message, None, apply_mfa=False)
+            return _AuthOutcome(None, "认证失败", apply_mfa=False)
+        logger.debug(f"不支持的认证类型：{grant_type}")
+        return _AuthOutcome(None, "不支持的认证类型", apply_mfa=False)
 
     @staticmethod
     def password_authenticate(credentials: AuthCredentials) -> Tuple[bool, Union[User, str]]:

--- a/tests/test_user_authenticate_orchestration.py
+++ b/tests/test_user_authenticate_orchestration.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+UserChain.user_authenticate 编排回归：锁住对外返回契约（login.py 依赖），护住 A 档内部清理。
+
+外部契约（app/api/endpoints/login.py:29）：
+  - 成功 → (True, User)
+  - 需要二次验证 → (False, "MFA_REQUIRED")
+  - 失败 → (False, <错误串>)
+
+关键不变量：
+  - grant_type=="password" 走 MFA（password-success 与 aux-success 两条子路均校验 MFA）；
+  - grant_type=="authorization_code" **不走 MFA**（即便 _verify_mfa 会要求，也直接放行）；
+  - 各失败串与现行一致。
+
+测试以 mock 替换 password_authenticate / auxiliary_authenticate / _verify_mfa 与 settings，
+只验证编排（不触真实 DB/模块/事件）。
+"""
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.chain.user import UserChain, PASSWORD_INVALID_CREDENTIALS_MESSAGE
+
+
+class _FakeUser:
+    def __init__(self, name="u"):
+        self.name = name
+        self.id = 1
+        self.is_superuser = False
+
+
+class _FalsyUser(_FakeUser):
+    """真值为 False 的用户：成功门用 is None 而非真值判断，故仍应判为认证成功。"""
+    def __bool__(self):
+        return False
+
+
+def _authenticate(*, grant_type="password", pw=(False, "x"), aux=(False, "x"),
+                  mfa=True, aux_enable=False, mfa_code=None):
+    """以受控 mock 跑 user_authenticate，返回其对外结果。"""
+    chain = UserChain.__new__(UserChain)  # 绕过 __init__，避免初始化真实依赖
+    # AuthCredentials 对 authorization_code 要求必填 code
+    code = "authcode" if grant_type == "authorization_code" else None
+    with patch.object(UserChain, "password_authenticate", staticmethod(lambda credentials: pw)), \
+            patch.object(UserChain, "auxiliary_authenticate", lambda self, credentials: aux), \
+            patch.object(UserChain, "_verify_mfa", staticmethod(lambda user, code: mfa)), \
+            patch("app.chain.user.settings") as s:
+        s.AUXILIARY_AUTH_ENABLE = aux_enable
+        return chain.user_authenticate(username="u", password="p", mfa_code=mfa_code,
+                                       code=code, grant_type=grant_type)
+
+
+class UserAuthenticateOrchestrationTest(TestCase):
+
+    # ---- password grant：本地密码 ----
+    def test_password_success_no_mfa(self):
+        user = _FakeUser()
+        self.assertEqual(_authenticate(pw=(True, user), mfa=True), (True, user))
+
+    def test_falsy_user_still_authenticated(self):
+        # 成功门用 is None：真值为 False 的合法用户也应判为成功（不被误拒）
+        user = _FalsyUser()
+        success, returned = _authenticate(pw=(True, user), mfa=True)
+        self.assertTrue(success)
+        self.assertIs(returned, user)
+
+    def test_password_success_mfa_required(self):
+        user = _FakeUser()
+        self.assertEqual(_authenticate(pw=(True, user), mfa="MFA_REQUIRED"), (False, "MFA_REQUIRED"))
+
+    def test_password_success_mfa_failed(self):
+        user = _FakeUser()
+        self.assertEqual(_authenticate(pw=(True, user), mfa=False),
+                         (False, PASSWORD_INVALID_CREDENTIALS_MESSAGE))
+
+    # ---- password grant：本地失败 → 辅助认证 ----
+    def test_password_fail_aux_disabled(self):
+        self.assertEqual(_authenticate(pw=(False, "x"), aux_enable=False),
+                         (False, PASSWORD_INVALID_CREDENTIALS_MESSAGE))
+
+    def test_password_fail_aux_success_with_mfa(self):
+        # 辅助认证成功的用户在 password grant 下仍需过 MFA
+        aux_user = _FakeUser("aux")
+        self.assertEqual(_authenticate(pw=(False, "x"), aux=(True, aux_user), aux_enable=True, mfa=True),
+                         (True, aux_user))
+
+    def test_password_fail_aux_success_mfa_required(self):
+        aux_user = _FakeUser("aux")
+        self.assertEqual(_authenticate(pw=(False, "x"), aux=(True, aux_user), aux_enable=True, mfa="MFA_REQUIRED"),
+                         (False, "MFA_REQUIRED"))
+
+    def test_password_fail_aux_failed(self):
+        self.assertEqual(_authenticate(pw=(False, "x"), aux=(False, "x"), aux_enable=True),
+                         (False, PASSWORD_INVALID_CREDENTIALS_MESSAGE))
+
+    # ---- authorization_code grant：不走 MFA ----
+    def test_authorization_code_aux_success_skips_mfa(self):
+        # 关键不变量：authorization_code 即便 _verify_mfa 会要求 MFA，也直接放行
+        aux_user = _FakeUser("oauth")
+        self.assertEqual(
+            _authenticate(grant_type="authorization_code", aux=(True, aux_user),
+                          aux_enable=True, mfa="MFA_REQUIRED"),
+            (True, aux_user))
+
+    def test_authorization_code_aux_disabled(self):
+        self.assertEqual(_authenticate(grant_type="authorization_code", aux_enable=False),
+                         (False, "认证失败"))
+
+    def test_authorization_code_aux_failed(self):
+        self.assertEqual(_authenticate(grant_type="authorization_code", aux=(False, "x"), aux_enable=True),
+                         (False, "认证失败"))
+
+    # ---- 不支持的类型 ----
+    def test_unsupported_grant_type(self):
+        self.assertEqual(_authenticate(grant_type="client_credentials"),
+                         (False, "不支持的认证类型"))


### PR DESCRIPTION
## 背景

`UserChain.user_authenticate` 的编排是过程式 if/elif 阶梯：嵌套 `AUXILIARY_AUTH_ENABLE` 开关、**MFA 校验在 password-success 与 aux-success 两处各写一份**、union 元组 + `"MFA_REQUIRED"` 魔法字符串返回。本 PR 做**保守的内部清理（A 档）**——**对外行为零变化**，机制（媒服 SSO / 插件事件）一概不动。

## 改动（仅 `app/chain/user.py` + 回归测试）

- 抽 **`_resolve_user(credentials) -> _AuthOutcome(user, error, apply_mfa)`**：把 grant_type 阶梯（本地密码 → 辅助认证）收敛为单一解析步骤。
- **MFA 校验去重**：原两份合一，`user_authenticate` 在解析出用户后按 `apply_mfa` 统一校验一次。
- 引入内部 `_AuthOutcome` NamedTuple；**对外返回契约不变**（`(True, User)` / `(False, "MFA_REQUIRED")` / `(False, <err>)`，login.py 消费方零改动）。

## 关键不变量（全部保留，安全审查逐条核对）
- `grant_type=="password"` **走 MFA**；`grant_type=="authorization_code"` **不走 MFA**（原 OAuth 路径无 MFA，重构后 `apply_mfa=False` 如实复刻——既未新增也未跳过）。
- MFA 同时作用于「本地密码成功」与「辅助认证成功」的用户（password grant）。
- 各失败串一致（密码域 `PASSWORD_INVALID_CREDENTIALS_MESSAGE` / OAuth `"认证失败"` / 未知 `"不支持的认证类型"` / `"MFA_REQUIRED"`）。
- `password_authenticate` / `auxiliary_authenticate` / `_verify_mfa` 方法体**零改动**。

## 测试（先写后测，护住行为）
- 新增 `tests/test_user_authenticate_orchestration.py`：**先对未重构旧码跑通 11 例**（捕获现行行为，含 authorization_code 跳过 MFA），**重构后 12 例仍全过**（证明零变化）。认证回归 **35 passed**。

## security-reviewer（0 Critical，不变量全 PRESERVED）
采纳修正：
- 成功门 `if not outcome.user` → **`if outcome.user is None`**（防 User 真值被覆写时误拒；补「假值 `__bool__` 用户」用例锁定）。
- 失败 outcome 的 `apply_mfa` 死值 `True` → `False`（去误导）。
- 未知 grant 的日志文案纠正（原 "辅助认证未启用…" 与实情不符）。
- 边界改善：`auxiliary_authenticate` 竞态返回 `(True, None)` 时，重构后由 `is None` 门拦为 `(False, None)`，比旧码（会带 None 用户继续）更安全。

## Test Plan
- [ ] CI（python 3.12）全量套件通过
- [ ] 密码登录 / MFA / 媒服 SSO 辅助认证 / OAuth code 行为与重构前一致