### PR TITLE
test: 守护 SSO 插件扩展面防回归

### DIFF
--- a/tests/test_auth_bridge_dedb.py
+++ b/tests/test_auth_bridge_dedb.py
@@ -49,3 +49,27 @@ def test_ticket_roundtrip_and_one_time():
     data = ab.consume_plugin_auth_ticket(ticket)
     assert data and data["user_id"] == 7 and data["provider_id"] == "probe"
     assert ab.consume_plugin_auth_ticket(ticket) is None  # 一次性票据
+
+
+def test_ticket_expired_and_unknown_rejected():
+    """SSO 现有面防回归：过期 / 未知 / 空票据一律拒绝。"""
+    import time
+    import app.core.auth_bridge as ab
+
+    assert ab.consume_plugin_auth_ticket("nope") is None
+    assert ab.consume_plugin_auth_ticket("") is None
+    assert ab.consume_plugin_auth_ticket(None) is None
+    ticket = ab.create_plugin_auth_ticket(user_id=3, provider_id="probe")
+    store = ab.AuthTicketStore()
+    # 把签发时间推到远超 TTL 之前，验证过期分支
+    store._tickets[ticket]["created_at"] = time.time() - (store._ttl_seconds + 100)
+    assert ab.consume_plugin_auth_ticket(ticket) is None
+
+
+def test_ticket_user_id_coerced_to_int():
+    """SSO 现有面防回归：user_id 入库归一化为 int（前端拿到稳定类型）。"""
+    import app.core.auth_bridge as ab
+
+    ticket = ab.create_plugin_auth_ticket(user_id="11", provider_id="probe")
+    data = ab.consume_plugin_auth_ticket(ticket)
+    assert data["user_id"] == 11 and isinstance(data["user_id"], int)

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -42,6 +42,43 @@ class _DisabledPlugin:
         return [{"cmd": "/y"}]
 
 
+class _AuthPlugin:
+    """声明登录入口（SSO）的插件替身。"""
+
+    plugin_name = "假冒 SSO"
+
+    def __init__(self, enabled=True, providers=None, raise_on_call=False):
+        self._enabled = enabled
+        self._providers = [{"icon": "mdi-login"}] if providers is None else providers
+        self._raise = raise_on_call
+
+    def get_state(self):
+        return self._enabled
+
+    def get_render_mode(self):
+        return "vuetify", None
+
+    def get_auth_providers(self):
+        if self._raise:
+            raise RuntimeError("插件内部异常")
+        return [dict(p) for p in self._providers]
+
+
+class _PassAuthPlugin:
+    """get_auth_providers 仅占位（pass 体）：应被 check_method 判为未实现而跳过。"""
+
+    plugin_name = "占位入口"
+
+    def get_state(self):
+        return True
+
+    def get_render_mode(self):
+        return "vuetify", None
+
+    def get_auth_providers(self):
+        pass
+
+
 # ---- (a) 结构契约：12 门面委托、12 函数就位 ----
 
 def test_facades_and_functions_present():
@@ -77,3 +114,32 @@ def test_get_plugin_apis_prefixes_path():
 def test_disabled_plugin_skipped_and_pid_filter():
     assert plugin_metadata.get_plugin_commands({"Off": _DisabledPlugin()}, None) == []  # get_state=False 跳过
     assert plugin_metadata.get_plugin_commands({"FakeP": _FakePlugin()}, "OTHER") == []  # pid 不匹配
+
+
+# ---- (c) SSO 扩展面防回归：get_plugin_auth_providers 富化与跳过 ----
+
+def test_auth_providers_enriched():
+    providers = plugin_metadata.get_plugin_auth_providers({"ghsso": _AuthPlugin(providers=[{"icon": "gh"}])})
+    assert len(providers) == 1
+    p = providers[0]
+    assert p["type"] == "plugin" and p["plugin_id"] == "ghsso"
+    assert p["id"] == "plugin:ghsso" and p["name"] == "假冒 SSO" and p["enabled"] is True  # 默认值注入
+    assert p["icon"] == "gh"                                                              # 原字段保留
+
+
+def test_auth_providers_preserve_explicit_fields():
+    providers = plugin_metadata.get_plugin_auth_providers(
+        {"ghsso": _AuthPlugin(providers=[{"id": "github", "name": "GitHub", "enabled": False}])})
+    p = providers[0]
+    assert p["id"] == "github" and p["name"] == "GitHub" and p["enabled"] is False  # 显式字段不被默认覆盖
+    assert p["type"] == "plugin" and p["plugin_id"] == "ghsso"                       # type/plugin_id 始终强制
+
+
+def test_auth_providers_skip_disabled_nohook_and_failing():
+    assert plugin_metadata.get_plugin_auth_providers({"off": _AuthPlugin(enabled=False)}) == []  # 未启用
+    assert plugin_metadata.get_plugin_auth_providers({"nohook": _FakePlugin()}) == []            # 无 get_auth_providers
+    assert plugin_metadata.get_plugin_auth_providers({"ph": _PassAuthPlugin()}) == []            # pass 体被 check_method 跳过
+    # 抛异常的插件被吞，不影响其它插件
+    providers = plugin_metadata.get_plugin_auth_providers(
+        {"bad": _AuthPlugin(raise_on_call=True), "good": _AuthPlugin(providers=[{"id": "ok"}])})
+    assert [p["id"] for p in providers] == ["ok"]


### PR DESCRIPTION
## 背景

调研「认证器能否像数据源/发现一样靠单实例插件扩展（GitHub/微信/飞书 SSO）」后确认：**SSO 走现有面已可行**——`get_auth_providers()` 声明入口 + 插件自管 OAuth 端点 + `auth_bridge` 一次性票据，**零碰密码登录链**。且 `.gitignore` 排除 `app/plugins/**` → 插件 external-by-design、SSO 需主仓库零改动。

该现有面的**核心半套**（票据往返、提供方聚合）是核心代码，却缺行为覆盖——未来重构可能静默打断 SSO 插件。本 PR 补防回归守卫，**不依赖任何外部插件**。

## 改动（纯增量测试）

**`tests/test_plugin_metadata.py`** — 新增 `get_plugin_auth_providers` 聚合行为测试：
- 富化 descriptor（强制 `type=plugin`/`plugin_id`，默认注入 `id`/`name`/`enabled`）；
- 显式字段不被默认覆盖；
- 跳过未启用 / 无钩子 / `pass` 体（check_method）/ 抛异常的插件。

**`tests/test_auth_bridge_dedb.py`** — 补 `auth_bridge` 票据缺口（往返+单次有效已覆盖）：
- 过期票据拒绝、未知/空票据拒绝、`user_id` int 归一化。

## 测试

```
pytest tests/test_plugin_metadata.py tests/test_auth_bridge_dedb.py  →  14 passed
```

无生产代码改动；不引入对被 gitignore 的 SSO 插件的依赖（故核心 CI 不受其缺席影响）。