### PR TITLE
feat: 固化 provides_auth_providers，下沉 SSO 登录框架（消除 G3）

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -1,15 +1,23 @@
-from typing import Any
+from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
 from app import schemas
+from app.core import sso
 from app.core.auth_bridge import build_token_response, consume_plugin_auth_ticket
+from app.core.config import settings
 from app.helper.plugin_manager import PluginManager
+from app.helper.sso import begin_login, complete_login
+from app.log import logger
 from app.db.models.passkey import PassKey
 from app.db.models.user import User
 
 router = APIRouter()
+
+# SSO 端点前缀（auth.router 挂载于 /api/v1/auth）
+_SSO_BASE = "/api/v1/auth/sso"
 
 
 class AuthExchangeRequest(BaseModel):
@@ -39,15 +47,41 @@ def _system_auth_providers() -> list[dict[str, Any]]:
     ]
 
 
+def _registered_sso_providers() -> list[dict[str, Any]]:
+    """
+    由 app.core.sso 注册表（provides_auth_providers）派生登录入口摘要。
+
+    每个注册提供方自动获得 `/auth/sso/{id}/login` 入口（框架统一驱动 OAuth），无需插件再声明端点。
+
+    :return: SSO 认证提供方列表
+    """
+    items: list[dict[str, Any]] = []
+    for provider in sso.all_auth_providers():
+        pid = getattr(provider, "provider_id", None)
+        if not pid:
+            continue
+        items.append({
+            "id": pid,
+            "type": "sso",
+            "name": getattr(provider, "provider_name", pid),
+            "icon": getattr(provider, "provider_icon", ""),
+            "method": "redirect",
+            "login_url": f"{_SSO_BASE}/{pid}/login",
+            "enabled": bool(getattr(provider, "enabled", True)),
+        })
+    return items
+
+
 @router.get("/providers", summary="查询登录认证提供方", response_model=list[dict])
 def auth_providers() -> list[dict[str, Any]]:
     """
-    查询系统和插件提供的登录认证入口。
+    查询系统、插件与注册的 SSO 提供方提供的登录认证入口。
 
     :return: 认证提供方摘要列表
     """
     providers = _system_auth_providers()
     providers.extend(PluginManager().get_plugin_auth_providers())
+    providers.extend(_registered_sso_providers())
     return [provider for provider in providers if provider.get("enabled", True)]
 
 
@@ -68,3 +102,62 @@ def auth_exchange(body: AuthExchangeRequest) -> schemas.Token:
         raise HTTPException(status_code=403, detail="用户不存在或已禁用")
 
     return build_token_response(user)
+
+
+def _sso_redirect_uri(provider_id: str, request: Request) -> str:
+    """构造 OAuth redirect_uri（须与 IdP 注册回调一致）：优先 APP_DOMAIN，否则从请求 Host 推导。"""
+    path = f"{_SSO_BASE}/{provider_id}/callback"
+    domain_url = settings.MP_DOMAIN(path)
+    if domain_url:
+        return domain_url
+    # 兜底：从请求 Host 推导，依赖反代正确校验 Host 头；生产应配置 APP_DOMAIN
+    logger.warning("SSO 未配置 APP_DOMAIN，回退用请求 Host 推导 redirect_uri，存在 Host 头注入风险")
+    return f"{str(request.base_url).rstrip('/')}{path}"
+
+
+def _safe_relative(path: Optional[str]) -> str:
+    """约束跳转为站内相对路径，避免票据被 302 到外部域（票据可兑换 Token）。"""
+    p = (path or "/").strip()
+    if (not p.startswith("/") or p.startswith("//") or "://" in p
+            or "\\" in p or any(c < " " for c in p)):
+        return "/"
+    return p
+
+
+def _sso_redirect_back(success_redirect: str, ticket: Optional[str] = None,
+                       error: Optional[str] = None) -> RedirectResponse:
+    """重定向回前端：成功带 ?ticket=（前端再调 /auth/exchange 换 Token），失败带 ?sso_error=。"""
+    from urllib.parse import urlencode
+    # 保底再过滤一次，确保任何调用方传入的 success_redirect 均为站内相对路径
+    success_redirect = _safe_relative(success_redirect)
+    base = settings.MP_DOMAIN(success_redirect) or success_redirect
+    query = {}
+    if ticket:
+        query["ticket"] = ticket
+    if error:
+        query["sso_error"] = error
+    sep = "&" if "?" in base else "?"
+    url = f"{base}{sep}{urlencode(query)}" if query else base
+    return RedirectResponse(url=url)
+
+
+@router.get("/sso/{provider_id}/login", summary="发起 SSO 登录")
+def sso_login(provider_id: str, request: Request) -> RedirectResponse:
+    """将浏览器重定向到指定 SSO 提供方的 IdP 授权页（框架签发 CSRF state）。"""
+    provider = sso.get_auth_provider(provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="未知的登录提供方")
+    return RedirectResponse(url=begin_login(provider, _sso_redirect_uri(provider_id, request)))
+
+
+@router.get("/sso/{provider_id}/callback", summary="SSO 登录回调")
+def sso_callback(provider_id: str, request: Request, code: str = "", state: str = "") -> RedirectResponse:
+    """处理 IdP 回调：框架统一完成 state 校验 / 换身份 / 用户解析建号 / 铸票，再重定向回前端。"""
+    provider = sso.get_auth_provider(provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="未知的登录提供方")
+    success_redirect = _safe_relative(getattr(provider, "success_redirect", "/"))
+    auto_create = bool(getattr(provider, "auto_create", False))
+    ticket, error = complete_login(provider, code, state,
+                                   _sso_redirect_uri(provider_id, request), auto_create=auto_create)
+    return _sso_redirect_back(success_redirect, ticket=ticket, error=error)

--- a/app/core/sso.py
+++ b/app/core/sso.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""
+SSO（外部 IdP 单点登录）框架能力 —— db-free 核心。
+
+把每个 SSO 插件原本要各自重复实现的样板（G3）下沉为框架能力：
+  - CSRF ``state`` 的签发/单次校验（``SsoStateStore``）；
+  - 登录提供方的注册/路由（``AuthProviderRegistry``，按 ``provider_id`` 单索引、带 owner）；
+  - 提供方契约校验（``verify_auth_provider_contract``）。
+
+插件只需交出 IdP 特定的两件事（见 ``IAuthProvider``）：``authorize_url`` 与 ``fetch_identity``；
+用户解析/建号（碰 db）与 HTTP 端点编排在更上层（helper / api），本模块保持 **db-free**
+（延续 auth_bridge 去 db 的方向，不新增 core→db 边）。
+"""
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any, Dict, List, NamedTuple, Optional, Protocol, Tuple, runtime_checkable
+
+# provider_id 合法字符集：字母数字与连字符，1–32 位。禁用下划线等分隔符——provider_id 会进入本地用户名
+# ``sso_{provider_id}_{外部用户名}`` 与回调 URL 路径片段，禁分隔符可数学上杜绝跨提供方撞名与路径注入。
+_PROVIDER_ID_RE = re.compile(r"^[A-Za-z0-9\-]{1,32}$")
+
+
+@dataclass
+class AuthProviderIdentity:
+    """提供方校验成功后返回的外部身份（与本地用户解耦，由上层映射为本地用户）。"""
+
+    subject: str                                   # IdP 侧稳定用户标识
+    username: str                                  # IdP 侧用户名（上层会加命名空间前缀）
+    avatar: Optional[str] = None
+    display_name: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class IAuthProvider(Protocol):
+    """
+    SSO 登录提供方契约（插件只实现 IdP 特定的最小面）。
+
+    数据属性：
+      - provider_id：唯一标识（如 "github"），用于路由与去重；
+      - provider_name / provider_icon：登录页入口展示。
+    方法：
+      - authorize_url(state, redirect_uri)：构造 IdP 授权页 URL（框架负责签发 state、拼回调）；
+      - fetch_identity(code, redirect_uri)：用授权码换取外部身份，失败返回 None。
+    """
+
+    provider_id: str
+    provider_name: str
+    provider_icon: str
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str: ...
+
+    def fetch_identity(self, code: str, redirect_uri: str) -> Optional[AuthProviderIdentity]: ...
+
+
+def verify_auth_provider_contract(provider: Any) -> Tuple[bool, List[str]]:
+    """
+    校验对象是否满足 ``IAuthProvider`` 契约。返回 (是否通过, 失败原因列表)。
+
+    不依赖 isinstance（runtime_checkable 对数据属性的判定随版本而异），做显式检查以给出清晰原因。
+    """
+    reasons: List[str] = []
+    pid = getattr(provider, "provider_id", None)
+    if not isinstance(pid, str) or not _PROVIDER_ID_RE.match(pid):
+        reasons.append("provider_id 必须为 1–32 位字母、数字或连字符（不含下划线/路径分隔符）")
+    for attr in ("provider_name", "provider_icon"):
+        if not isinstance(getattr(provider, attr, None), str):
+            reasons.append(f"{attr} 必须为字符串")
+    for meth in ("authorize_url", "fetch_identity"):
+        if not callable(getattr(provider, meth, None)):
+            reasons.append(f"须实现 {meth} 方法")
+    return (not reasons), reasons
+
+
+class SsoStateStore:
+    """
+    OAuth ``state`` 短时一次性存储（CSRF 防护）：内存 + 锁 + TTL，签发时写、回调时取（取即销毁）。
+    """
+
+    def __init__(self, ttl_seconds: int = 600) -> None:
+        self._ttl = ttl_seconds
+        self._states: Dict[str, float] = {}
+        self._lock = RLock()
+
+    def issue(self) -> str:
+        """生成并登记一个新 state，返回不可猜测的随机串。"""
+        state = secrets.token_urlsafe(24)
+        now = time.time()
+        with self._lock:
+            self._cleanup(now)
+            self._states[state] = now
+        return state
+
+    def consume(self, state: Optional[str]) -> bool:
+        """取用一个 state：存在且未过期返回 True（并删除），否则 False（单次有效）。"""
+        if not state:
+            return False
+        now = time.time()
+        with self._lock:
+            issued_at = self._states.pop(state, None)
+            self._cleanup(now)
+        return bool(issued_at) and (now - issued_at) <= self._ttl
+
+    def _cleanup(self, now: float) -> None:
+        expired = [s for s, t in self._states.items() if now - t > self._ttl]
+        for s in expired:
+            self._states.pop(s, None)
+
+
+class _Entry(NamedTuple):
+    provider: Any
+    owner: Optional[str]                            # 注册来源插件 id；None 表示内建
+
+
+class AuthProviderRegistry:
+    """
+    SSO 登录提供方注册表：按 ``provider_id`` 单索引（仿 storage_registry），带 owner 以便按插件卸载。
+    """
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, _Entry] = {}
+        self._lock = RLock()
+
+    def register(self, provider: Any, owner: Optional[str]) -> Tuple[bool, str]:
+        """
+        注册一个提供方：先过契约校验，再做 provider_id 碰撞检测（不同 owner 占用同 id 则拒绝）。
+        返回 (是否成功, 失败原因)。同一 owner 重复注册同 id 视为幂等覆盖。
+        """
+        ok, reasons = verify_auth_provider_contract(provider)
+        if not ok:
+            return False, "；".join(reasons)
+        pid = provider.provider_id
+        with self._lock:
+            existing = self._registry.get(pid)
+            if existing is not None and existing.owner != owner:
+                return False, f"provider_id 冲突：{pid} 已由 {existing.owner or '内建'} 注册"
+            self._registry[pid] = _Entry(provider, owner)
+        return True, ""
+
+    def unregister(self, owner: Optional[str]) -> None:
+        """卸载某 owner（插件）注册的全部提供方。"""
+        with self._lock:
+            for pid in [k for k, e in self._registry.items() if e.owner == owner]:
+                self._registry.pop(pid, None)
+
+    def get(self, provider_id: str) -> Optional[Any]:
+        """按 provider_id 取提供方，不存在返回 None。"""
+        with self._lock:
+            entry = self._registry.get(provider_id)
+            return entry.provider if entry else None
+
+    def provider_ids(self) -> List[str]:
+        """已注册的 provider_id 列表。"""
+        with self._lock:
+            return list(self._registry.keys())
+
+    def all(self) -> List[Any]:
+        """已注册的全部提供方对象。"""
+        with self._lock:
+            return [e.provider for e in self._registry.values()]
+
+
+# 模块级单例：state 与提供方注册表均需跨请求/跨插件存活
+_STATE_STORE = SsoStateStore()
+_REGISTRY = AuthProviderRegistry()
+
+
+def issue_state() -> str:
+    """签发一个一次性 CSRF state。"""
+    return _STATE_STORE.issue()
+
+
+def consume_state(state: Optional[str]) -> bool:
+    """校验并消费一个 CSRF state（单次有效）。"""
+    return _STATE_STORE.consume(state)
+
+
+def register_auth_provider(provider: Any, owner: Optional[str]) -> Tuple[bool, str]:
+    """注册一个 SSO 登录提供方（契约校验 + provider_id 碰撞检测）。"""
+    return _REGISTRY.register(provider, owner)
+
+
+def unregister_auth_providers(owner: Optional[str]) -> None:
+    """卸载某 owner（插件）注册的全部提供方。"""
+    _REGISTRY.unregister(owner)
+
+
+def get_auth_provider(provider_id: str) -> Optional[Any]:
+    """按 provider_id 取已注册提供方。"""
+    return _REGISTRY.get(provider_id)
+
+
+def registered_provider_ids() -> List[str]:
+    """已注册的 provider_id 列表。"""
+    return _REGISTRY.provider_ids()
+
+
+def all_auth_providers() -> List[Any]:
+    """已注册的全部提供方对象。"""
+    return _REGISTRY.all()

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -649,6 +649,17 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                             getattr(caps, "channel", None), caps, owner=plugin_id)
                     except Exception as err:
                         logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
+        # 注册插件经 provides_auth_providers 声明的 SSO 登录提供方（按 provider_id 单索引、owner=plugin_id）：
+        # 与各契约域不同，登录提供方不进 ModuleManager/chain，而是注册到 app.core.sso 由 SSO 端点统一驱动。
+        provided_auth = plugin_metadata.get_plugin_provided_auth_providers(self._running_plugins, pid)
+        if provided_auth:
+            from app.core.sso import register_auth_provider
+            for plugin_id, providers in provided_auth.items():
+                for provider in providers:
+                    ok, reason = register_auth_provider(provider, owner=plugin_id)
+                    if not ok:
+                        logger.warning(f"注册插件 {plugin_id} 登录提供方 "
+                                       f"{getattr(provider, 'provider_id', provider)} 失败：{reason}")
         # 注册插件经 provides_* 声明新增的各契约域模块（数据源/下载器/消息渠道/媒体服务器）：
         # 经各自契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 chain 分发。
         for _get_provided, _verify, _label in (
@@ -696,6 +707,11 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 ChannelCapabilityManager.unregister_capabilities(owner=plugin_id)
             except Exception as err:
                 logger.error(f"卸载插件 {plugin_id} 渠道能力出错：{str(err)}")
+            try:
+                from app.core.sso import unregister_auth_providers
+                unregister_auth_providers(owner=plugin_id)
+            except Exception as err:
+                logger.error(f"卸载插件 {plugin_id} 登录提供方出错：{str(err)}")
 
     def sync(self) -> List[str]:
         """

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -203,6 +203,10 @@ def get_plugin_provided_storages(running_plugins, pid: Optional[str] = None) -> 
     """聚合插件经 provides_storages() 声明【新增】的存储器类，按 plugin_id 归集（供 FileManager 注册/卸载）。"""
     return _get_plugin_provided(running_plugins, "provides_storages", "注册存储器", pid)
 
+def get_plugin_provided_auth_providers(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
+    """聚合插件经 provides_auth_providers() 声明【新增】的 SSO 登录提供方实例，按 plugin_id 归集。"""
+    return _get_plugin_provided(running_plugins, "provides_auth_providers", "注册登录提供方", pid)
+
 def get_plugin_provided_channel_capabilities(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
     """聚合插件经 provides_channel_capabilities() 声明【新增】的消息渠道能力矩阵，按 plugin_id 归集。"""
     return _get_plugin_provided(running_plugins, "provides_channel_capabilities", "注册渠道能力", pid)

--- a/app/helper/sso.py
+++ b/app/helper/sso.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+SSO 登录流程编排（helper 层，可碰 db）。
+
+承接 app.core.sso 的 db-free 核心（state/registry/contract），把每个 SSO 插件原本要重复实现的
+「授权码校验 → 外部身份 → 本地用户解析/建号 → 铸票」这套样板（G3）统一在此实现：插件交出的
+IAuthProvider 只负责 IdP 特定的 authorize_url / fetch_identity，其余全由框架代劳。
+"""
+import re
+import secrets
+from typing import Optional, Tuple
+
+from app.core import sso as sso_core
+from app.core.auth_bridge import create_plugin_auth_ticket
+from app.core.security import get_password_hash
+from app.db.user_oper import UserOper
+from app.log import logger
+
+# 授权码合法字符集（边界输入校验，防注入下游/日志）
+_CODE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
+# 外部用户名合法字符集（保守集合：字母数字与 . _ -，最长 64）
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9._\-]{1,64}$")
+# 本地 SSO 用户名前缀（与本地账号命名空间隔离）
+_USERNAME_PREFIX = "sso_"
+
+
+def begin_login(provider, redirect_uri: str) -> str:
+    """签发 CSRF state 并返回 IdP 授权页 URL（框架统一持有 state）。"""
+    state = sso_core.issue_state()
+    return provider.authorize_url(state, redirect_uri)
+
+
+def complete_login(provider, code: Optional[str], state: Optional[str], redirect_uri: str,
+                   *, auto_create: bool = False) -> Tuple[Optional[str], Optional[str]]:
+    """
+    完成回调：校验 state(CSRF) → 校验 code → 换外部身份 → 解析/建本地用户 → 铸票。
+
+    返回 (ticket, error)：成功时 (票据, None)，失败时 (None, 错误码)。错误码语义化（invalid_state /
+    invalid_code / fetch_identity_failed / user_not_provisioned），不泄露内部细节。
+    """
+    provider_id = getattr(provider, "provider_id", "?")
+    # 1) CSRF：state 必须本服务签发、未过期、未用过（取即销毁）
+    if not sso_core.consume_state(state):
+        logger.warning(f"SSO 提供方 {provider_id} 回调 state 校验失败（CSRF 或已过期）")
+        return None, "invalid_state"
+    # 2) 边界校验授权码
+    if not code or not _CODE_RE.match(code):
+        return None, "invalid_code"
+    # 3) 换取外部身份（提供方异常一律安全失败）
+    try:
+        identity = provider.fetch_identity(code, redirect_uri)
+    except Exception as e:
+        logger.error(f"SSO 提供方 {provider_id} 换取身份异常：{str(e)}")
+        return None, "fetch_identity_failed"
+    if not identity or not getattr(identity, "username", None):
+        return None, "fetch_identity_failed"
+    # 4) 解析/建本地用户
+    user = _resolve_user(provider_id, identity, auto_create)
+    if user is None:
+        return None, "user_not_provisioned"
+    # 5) 铸一次性票据（前端再 /auth/exchange 换 Token）
+    ticket = create_plugin_auth_ticket(
+        user_id=user.id,
+        provider_id=provider_id,
+        metadata={"sso_subject": getattr(identity, "subject", None)},
+    )
+    logger.info(f"SSO 提供方 {provider_id} 认证成功，用户：{user.name}，已签发登录票据")
+    return ticket, None
+
+
+def _resolve_user(provider_id: str, identity, auto_create: bool):
+    """
+    将外部身份映射为本地用户。
+
+    安全：用户名 = ``sso_{provider_id}_{外部用户名}``，按提供方+前缀双重命名空间隔离，杜绝与本地账号
+    或跨提供方撞名劫持；首次登录是否建号由 auto_create 门控（默认关），自动建号一律非管理员、随机密码。
+    """
+    raw = getattr(identity, "username", "") or ""
+    if not _USERNAME_RE.match(raw):
+        logger.warning(f"SSO 提供方 {provider_id} 返回非法格式的用户名，已拒绝")
+        return None
+    username = f"{_USERNAME_PREFIX}{provider_id}_{raw}"
+    useroper = UserOper()
+    user = useroper.get_by_name(name=username)
+    if user:
+        if not user.is_active:
+            logger.warning(f"SSO 用户 {username} 已被禁用，拒绝登录")
+            return None
+        return user
+    if not auto_create:
+        logger.info(f"SSO 用户 {username} 不存在且未开启自动建号，拒绝登录")
+        return None
+    useroper.add(
+        name=username,
+        avatar=getattr(identity, "avatar", None),
+        is_active=True,
+        is_superuser=False,
+        hashed_password=get_password_hash(secrets.token_urlsafe(16)),
+    )
+    logger.info(f"SSO 首次登录，已创建本地用户：{username}")
+    return useroper.get_by_name(name=username)

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -311,6 +311,18 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
+    def provides_auth_providers(self) -> List[Any]:
+        """
+        声明本插件向登录页【新增】的 SSO 登录提供方（外部 IdP 单点登录，声明式注册）。
+        返回实现 app.core.sso.IAuthProvider 契约的【实例】列表，每个含 provider_id / provider_name /
+        provider_icon + authorize_url(state, redirect_uri) / fetch_identity(code, redirect_uri)。
+        框架统一负责 CSRF state、回调端点、用户解析/建号与铸票（消除每个 SSO 插件重复的这套样板），
+        插件只实现 IdP 特定的「授权 URL 构造」与「授权码换身份」两件事。默认不新增。
+
+        [GithubAuthProvider(...), FeishuAuthProvider(...), ...]
+        """
+        return []
+
     def get_actions(self) -> List[Dict[str, Any]]:
         """
         获取插件工作流动作

--- a/tests/test_auth_provider_registration.py
+++ b/tests/test_auth_provider_registration.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""
+provides_auth_providers 固化（消除 G3）片 1 回归：db-free 核心 + 注册管线。
+
+锁定：
+  - verify_auth_provider_contract 契约校验（通过 / 各类失败原因）；
+  - AuthProviderRegistry 按 provider_id 单索引、provider_id 碰撞检测、按 owner 卸载；
+  - SsoStateStore CSRF state 单次有效 / 过期 / 拒绝未知空；
+  - _PluginBase.provides_auth_providers 默认 [] + get_plugin_provided_auth_providers 聚合。
+"""
+from unittest import TestCase
+
+from app.core import sso
+from app.core.sso import (
+    AuthProviderIdentity,
+    AuthProviderRegistry,
+    SsoStateStore,
+    verify_auth_provider_contract,
+)
+from app.helper import plugin_metadata
+from app.plugins import _PluginBase
+
+
+class _GoodProvider:
+    provider_id = "github"
+    provider_name = "GitHub"
+    provider_icon = "mdi-github"
+
+    def authorize_url(self, state, redirect_uri):
+        return f"https://idp.example.com/auth?state={state}&redirect_uri={redirect_uri}"
+
+    def fetch_identity(self, code, redirect_uri):
+        return AuthProviderIdentity(subject="1", username="octocat")
+
+
+# ---------------------------------------------------------------- 契约校验
+class VerifyContractTest(TestCase):
+
+    def test_valid_provider_passes(self):
+        ok, reasons = verify_auth_provider_contract(_GoodProvider())
+        self.assertTrue(ok)
+        self.assertEqual(reasons, [])
+
+    def test_missing_provider_id_rejected(self):
+        p = _GoodProvider()
+        p.provider_id = ""
+        ok, reasons = verify_auth_provider_contract(p)
+        self.assertFalse(ok)
+        self.assertTrue(any("provider_id" in r for r in reasons))
+
+    def test_non_string_name_rejected(self):
+        p = _GoodProvider()
+        p.provider_name = 123
+        ok, reasons = verify_auth_provider_contract(p)
+        self.assertFalse(ok)
+        self.assertTrue(any("provider_name" in r for r in reasons))
+
+    def test_provider_id_with_separator_rejected(self):
+        # 安全：provider_id 含下划线会破坏 sso_{pid}_{user} 命名空间隔离（跨提供方撞名）
+        for bad_id in ("gh_sso", "github/../x", "a b", "../evil"):
+            p = _GoodProvider()
+            p.provider_id = bad_id
+            ok, reasons = verify_auth_provider_contract(p)
+            self.assertFalse(ok, f"非法 provider_id 应拒绝：{bad_id}")
+            self.assertTrue(any("provider_id" in r for r in reasons))
+
+    def test_provider_id_with_hyphen_allowed(self):
+        p = _GoodProvider()
+        p.provider_id = "github-enterprise"
+        self.assertTrue(verify_auth_provider_contract(p)[0])
+
+    def test_missing_method_rejected(self):
+        class _NoMethods:
+            provider_id = "x"
+            provider_name = "X"
+            provider_icon = "i"
+        ok, reasons = verify_auth_provider_contract(_NoMethods())
+        self.assertFalse(ok)
+        self.assertTrue(any("authorize_url" in r for r in reasons))
+        self.assertTrue(any("fetch_identity" in r for r in reasons))
+
+
+# ---------------------------------------------------------------- 注册表
+class AuthProviderRegistryTest(TestCase):
+
+    def setUp(self):
+        self.reg = AuthProviderRegistry()
+
+    def test_register_and_get(self):
+        ok, reason = self.reg.register(_GoodProvider(), owner="pluginA")
+        self.assertTrue(ok, reason)
+        self.assertEqual(self.reg.provider_ids(), ["github"])
+        self.assertIsNotNone(self.reg.get("github"))
+        self.assertIsNone(self.reg.get("nope"))
+
+    def test_invalid_provider_rejected_with_reason(self):
+        bad = _GoodProvider()
+        bad.provider_id = ""
+        ok, reason = self.reg.register(bad, owner="pluginA")
+        self.assertFalse(ok)
+        self.assertIn("provider_id", reason)
+        self.assertEqual(self.reg.provider_ids(), [])
+
+    def test_provider_id_collision_across_owners_rejected(self):
+        self.assertTrue(self.reg.register(_GoodProvider(), owner="pluginA")[0])
+        ok, reason = self.reg.register(_GoodProvider(), owner="pluginB")
+        self.assertFalse(ok, "不同 owner 占用同 provider_id 必须拒绝")
+        self.assertIn("冲突", reason)
+
+    def test_same_owner_reregister_is_idempotent(self):
+        self.assertTrue(self.reg.register(_GoodProvider(), owner="pluginA")[0])
+        ok, _ = self.reg.register(_GoodProvider(), owner="pluginA")
+        self.assertTrue(ok, "同 owner 重注册同 id 应幂等通过")
+        self.assertEqual(self.reg.provider_ids(), ["github"])
+
+    def test_unregister_removes_only_owner(self):
+        a = _GoodProvider()
+        b = _GoodProvider()
+        b.provider_id = "feishu"
+        b.provider_name = "Feishu"
+        self.reg.register(a, owner="pluginA")
+        self.reg.register(b, owner="pluginB")
+        self.reg.unregister(owner="pluginA")
+        self.assertEqual(self.reg.provider_ids(), ["feishu"])  # 仅卸载 A，B 保留
+
+
+# ---------------------------------------------------------------- 模块级便捷函数
+class ModuleLevelHelpersTest(TestCase):
+
+    def test_register_get_unregister_roundtrip(self):
+        prov = _GoodProvider()
+        prov.provider_id = "github-modtest"   # 用唯一 id 避免污染共享单例
+        try:
+            ok, reason = sso.register_auth_provider(prov, owner="modtest-owner")
+            self.assertTrue(ok, reason)
+            self.assertIsNotNone(sso.get_auth_provider("github-modtest"))
+            self.assertIn("github-modtest", sso.registered_provider_ids())
+        finally:
+            sso.unregister_auth_providers(owner="modtest-owner")
+        self.assertIsNone(sso.get_auth_provider("github-modtest"))
+
+
+# ---------------------------------------------------------------- CSRF state
+class SsoStateStoreTest(TestCase):
+
+    def test_single_use(self):
+        s = SsoStateStore(ttl_seconds=600)
+        st = s.issue()
+        self.assertTrue(s.consume(st))
+        self.assertFalse(s.consume(st), "state 必须单次有效")
+
+    def test_reject_unknown_and_none(self):
+        s = SsoStateStore(ttl_seconds=600)
+        self.assertFalse(s.consume("bogus"))
+        self.assertFalse(s.consume(None))
+
+    def test_expired_rejected(self):
+        s = SsoStateStore(ttl_seconds=0)
+        self.assertFalse(s.consume(s.issue()), "过期 state 必须拒绝")
+
+
+# ---------------------------------------------------------------- 钩子 + 聚合
+class _AuthPlugin:
+    """声明 SSO 提供方的插件替身（duck-type）。"""
+
+    def get_state(self):
+        return True
+
+    def provides_auth_providers(self):
+        return [_GoodProvider()]
+
+
+class ProvidesHookAndAggregatorTest(TestCase):
+
+    def test_base_hook_defaults_empty(self):
+        # _PluginBase 默认 provides_auth_providers 返回 []（非 SSO 插件零贡献）
+        self.assertIsNotNone(_PluginBase.provides_auth_providers.__doc__)
+
+    def test_aggregator_collects_from_plugin(self):
+        provided = plugin_metadata.get_plugin_provided_auth_providers({"ghsso": _AuthPlugin()})
+        self.assertIn("ghsso", provided)
+        self.assertEqual(len(provided["ghsso"]), 1)
+        self.assertEqual(provided["ghsso"][0].provider_id, "github")
+
+    def test_aggregator_skips_disabled(self):
+        class _Off(_AuthPlugin):
+            def get_state(self):
+                return False
+        self.assertEqual(plugin_metadata.get_plugin_provided_auth_providers({"off": _Off()}), {})

--- a/tests/test_sso_login_flow.py
+++ b/tests/test_sso_login_flow.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""
+SSO 登录流程（app.helper.sso）回归：G3 样板下沉后的统一编排与安全不变量。
+
+complete_login 现承载每个 SSO 插件原本重复的逻辑（state/换身份/用户解析建号/铸票），
+以 mock 替换 UserOper / 票据 / 密码散列，只验证编排与安全门。
+"""
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.core.sso import AuthProviderIdentity, issue_state
+from app.helper import sso as sso_helper
+
+
+class _Provider:
+    provider_id = "github"
+    provider_name = "GitHub"
+    provider_icon = "mdi-github"
+
+    def __init__(self, identity=None, raise_fetch=False):
+        self._identity = identity
+        self._raise = raise_fetch
+
+    def authorize_url(self, state, redirect_uri):
+        return f"https://idp.example.com/auth?state={state}&redirect_uri={redirect_uri}"
+
+    def fetch_identity(self, code, redirect_uri):
+        if self._raise:
+            raise RuntimeError("boom")
+        return self._identity
+
+
+class _User:
+    def __init__(self, uid=1, name="sso_github_octocat", is_active=True):
+        self.id = uid
+        self.name = name
+        self.is_active = is_active
+
+
+def _identity(username="octocat"):
+    return AuthProviderIdentity(subject="sub-1", username=username, avatar="a")
+
+
+class BeginLoginTest(TestCase):
+
+    def test_begin_login_issues_state_in_authorize_url(self):
+        url = sso_helper.begin_login(_Provider(), "https://mp.example.com/cb")
+        self.assertIn("https://idp.example.com/auth?state=", url)
+        # 签发的 state 应能被随后的 consume 接受（单次）
+        state = url.split("state=")[1].split("&")[0]
+        self.assertTrue(sso_helper.sso_core.consume_state(state))
+
+
+class CompleteLoginTest(TestCase):
+
+    def test_invalid_state_blocks_before_fetch(self):
+        prov = _Provider(identity=_identity())
+        with patch.object(_Provider, "fetch_identity", side_effect=AssertionError("不应被调用")):
+            ticket, error = sso_helper.complete_login(prov, "code", "forged-state", "cb")
+        self.assertIsNone(ticket)
+        self.assertEqual(error, "invalid_state")
+
+    def test_invalid_code_rejected(self):
+        prov = _Provider(identity=_identity())
+        ticket, error = sso_helper.complete_login(prov, "bad\ncode", issue_state(), "cb")
+        self.assertEqual((ticket, error), (None, "invalid_code"))
+
+    def test_fetch_identity_none(self):
+        prov = _Provider(identity=None)
+        ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
+        self.assertEqual((ticket, error), (None, "fetch_identity_failed"))
+
+    def test_fetch_identity_raises_is_safe(self):
+        prov = _Provider(raise_fetch=True)
+        ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
+        self.assertEqual((ticket, error), (None, "fetch_identity_failed"))
+
+    def test_existing_user_mints_ticket_with_namespaced_name(self):
+        prov = _Provider(identity=_identity("octocat"))
+        with patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK") as mint:
+            UO.return_value.get_by_name.return_value = _User(uid=7)
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
+        self.assertEqual((ticket, error), ("TK", None))
+        UO.return_value.get_by_name.assert_called_with(name="sso_github_octocat")  # 提供方+前缀双重隔离
+        self.assertEqual(mint.call_args.kwargs["user_id"], 7)
+        self.assertEqual(mint.call_args.kwargs["provider_id"], "github")
+
+    def test_not_provisioned_without_auto_create(self):
+        prov = _Provider(identity=_identity("stranger"))
+        with patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket") as mint:
+            UO.return_value.get_by_name.return_value = None
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=False)
+        self.assertEqual((ticket, error), (None, "user_not_provisioned"))
+        UO.return_value.add.assert_not_called()
+        mint.assert_not_called()
+
+    def test_auto_create_makes_non_superuser(self):
+        prov = _Provider(identity=_identity("newbie"))
+        with patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK"), \
+                patch("app.helper.sso.get_password_hash", return_value="hashed"):
+            UO.return_value.get_by_name.side_effect = [None, _User(uid=9, name="sso_github_newbie")]
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), ("TK", None))
+        kw = UO.return_value.add.call_args.kwargs
+        self.assertEqual(kw["name"], "sso_github_newbie")
+        self.assertFalse(kw["is_superuser"], "自动建号不得为管理员")
+        self.assertTrue(kw["is_active"])
+        self.assertEqual(kw["hashed_password"], "hashed")
+
+    def test_disabled_user_rejected(self):
+        prov = _Provider(identity=_identity("banned"))
+        with patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket") as mint:
+            UO.return_value.get_by_name.return_value = _User(name="sso_github_banned", is_active=False)
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
+        self.assertEqual((ticket, error), (None, "user_not_provisioned"))
+        mint.assert_not_called()
+
+    def test_malformed_external_username_rejected(self):
+        prov = _Provider(identity=_identity("evil/../admin"))
+        with patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket") as mint:
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), (None, "user_not_provisioned"))
+        UO.return_value.get_by_name.assert_not_called()
+        mint.assert_not_called()


### PR DESCRIPTION
## 背景

继 PR #71（SSO 现有面防回归守卫）后，固化 `provides_auth_providers` 注册机制，**消除 G3**——每个第三方 SSO 插件原本各自重复的样板（CSRF state / 用户名映射 / 自动建号 / 铸票 / 重定向）下沉为框架能力。插件只需实现 IdP 特定的两件事：`authorize_url` + `fetch_identity`。

**零碰密码登录链**（`user_authenticate`）；core 保持 db-free（延续 auth_bridge 去 db 方向）。

## 改动

**片 1 — db-free 核心 + 注册管线**
- `app/core/sso.py`（新）：`IAuthProvider` runtime_checkable Protocol + `AuthProviderIdentity` + `verify_auth_provider_contract` + `SsoStateStore`(CSRF) + `AuthProviderRegistry`（按 `provider_id` 单索引带 owner、碰撞检测，仿 storage_registry）。
- `provides_auth_providers()` 钩子（默认 `[]`）+ `get_plugin_provided_auth_providers` 聚合（复用 `_get_plugin_provided`）+ `plugin_manager` 注册/卸载接线。

**片 2 — 流程编排 + 端点**
- `app/helper/sso.py`（新，db 层）：`begin_login` / `complete_login` —— state 校验→换身份→用户解析建号→铸票，统一编排。
- `app/api/endpoints/auth.py`：新增 `GET /auth/sso/{id}/login`、`/callback` 通用端点；`/auth/providers` 自动并入注册的 SSO 提供方。

## 安全（security-review：0 Critical）

修 1 HIGH + 1 MEDIUM + 2 LOW：
- **HIGH**：`provider_id` 加正则 `^[A-Za-z0-9-]{1,32}$`（禁分隔符）——数学上杜绝跨提供方撞名劫持（`sso_{pid}_{user}` 命名空间）与回调 URL 路径注入。
- **MEDIUM**：`_sso_redirect_back` 内部保底 `_safe_relative`，防票据被 302 到外域。
- **LOW**：Host 兜底告警；`_safe_relative` 补反斜杠/控制字符拒绝。
- 既有不变量：用户名 `sso_{pid}_{user}` 双重隔离、`auto_create` 默认关 + 建号非管理员 + 随机密码、禁用用户拒登、state 外呼前校验、`code` 边界校验、票据 `user_id` 来自已认证身份。

## 测试

```
test_auth_provider_registration.py(18) + test_sso_login_flow.py(10) → 28 passed
认证+各域注册回归（auth_bridge/user_authenticate/plugin_metadata/notification/mediaserver/storage/discover/metadata）→ 全过、零破坏
```

注：参考插件 `githubsso` 属外部插件仓（`.gitignore` 排除 `app/plugins/**`），不在本 PR；其改造为采用本框架是插件仓的后续工作。