### PR TITLE
feat: SSO 身份绑定表，按稳定 subject 解析（改名安全）

### DIFF
--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -8,6 +8,7 @@ from .site import Site
 from .siteicon import SiteIcon
 from .sitestatistic import SiteStatistic
 from .siteuserdata import SiteUserData
+from .ssoidentity import SsoIdentity
 from .subscribe import Subscribe
 from .subscribehistory import SubscribeHistory
 from .systemconfig import SystemConfig

--- a/app/db/models/ssoidentity.py
+++ b/app/db/models/ssoidentity.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.db import Base, async_db_query, db_query, get_id_column
+
+
+class SsoIdentity(Base):
+    """
+    SSO 外部身份 ↔ 本地用户 绑定表。
+
+    按稳定的 (provider_id, subject) 唯一映射到本地 user，使得：
+      - 外部用户改名（username 变）不丢号——解析以 subject 为主键，与可变用户名解耦；
+      - 支持账号关联（把一个外部身份绑定到已存在的本地用户）与多提供方并存。
+    身份持久化属用户账号域（框架表），不随插件卸载而失，故不放插件 plugin_data。
+    """
+    # ID
+    id = get_id_column()
+    # 提供方标识（如 github），与 app.core.sso 注册的 provider_id 一致
+    provider_id = Column(String, nullable=False, index=True)
+    # IdP 侧稳定用户标识（OIDC sub / GitHub 数字 id 等），绑定主键之一
+    subject = Column(String, nullable=False)
+    # 本地用户 ID（用户删除时级联清理绑定，避免孤儿行；sqlite 需开启 FK 约束才生效）
+    user_id = Column(Integer, ForeignKey('user.id', ondelete='CASCADE'), nullable=False, index=True)
+    # 外部用户名快照（仅用于展示/审计，不参与身份解析）
+    username = Column(String, nullable=True)
+    # 创建时间
+    created_at = Column(DateTime, default=datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint('provider_id', 'subject', name='uq_ssoidentity_provider_subject'),
+    )
+
+    @classmethod
+    @db_query
+    def get_by_subject(cls, db: Session, provider_id: str, subject: str):
+        """按 (provider_id, subject) 取绑定，不存在返回 None。"""
+        return db.query(cls).filter(cls.provider_id == provider_id, cls.subject == subject).first()
+
+    @classmethod
+    @db_query
+    def list_by_user(cls, db: Session, user_id: int):
+        """列出某本地用户的所有外部身份绑定（供账号关联管理）。"""
+        return db.query(cls).filter(cls.user_id == user_id).all()
+
+    @classmethod
+    @async_db_query
+    async def async_get_by_subject(cls, db: AsyncSession, provider_id: str, subject: str):
+        """异步按 (provider_id, subject) 取绑定。"""
+        result = await db.execute(
+            select(cls).filter(cls.provider_id == provider_id, cls.subject == subject)
+        )
+        return result.scalars().first()

--- a/app/helper/sso.py
+++ b/app/helper/sso.py
@@ -13,13 +13,17 @@ from typing import Optional, Tuple
 from app.core import sso as sso_core
 from app.core.auth_bridge import create_plugin_auth_ticket
 from app.core.security import get_password_hash
+from app.db.models.ssoidentity import SsoIdentity
+from app.db.models.user import User
 from app.db.user_oper import UserOper
 from app.log import logger
 
 # 授权码合法字符集（边界输入校验，防注入下游/日志）
 _CODE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
-# 外部用户名合法字符集（保守集合：字母数字与 . _ -，最长 64）
-_USERNAME_RE = re.compile(r"^[A-Za-z0-9._\-]{1,64}$")
+# subject 合法字符集（用户名安全集合：字母数字与 . _ -，最长 64）。subject 是身份主键，
+# 同时用于派生本地用户名 sso_{provider_id}_{subject}；provider_id 不含分隔符（核心契约保证）
+# 故 (provider_id, subject) → 用户名 单射，无撞名。插件须返回此集合内的稳定 subject。
+_SUBJECT_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._\-]{0,62}[A-Za-z0-9])?$")
 # 本地 SSO 用户名前缀（与本地账号命名空间隔离）
 _USERNAME_PREFIX = "sso_"
 
@@ -70,32 +74,70 @@ def complete_login(provider, code: Optional[str], state: Optional[str], redirect
 
 def _resolve_user(provider_id: str, identity, auto_create: bool):
     """
-    将外部身份映射为本地用户。
+    按稳定 subject 将外部身份映射到本地用户（改名安全）。
 
-    安全：用户名 = ``sso_{provider_id}_{外部用户名}``，按提供方+前缀双重命名空间隔离，杜绝与本地账号
-    或跨提供方撞名劫持；首次登录是否建号由 auto_create 门控（默认关），自动建号一律非管理员、随机密码。
+    解析以 SsoIdentity 绑定表 (provider_id, subject) 为权威：命中即返回绑定的本地用户；
+    未绑定且开启 auto_create 时新建用户并落绑定，否则拒绝。外部用户名（可变）只作快照，不参与解析。
+
+    安全：subject 经 _SUBJECT_RE 校验；本地用户名 ``sso_{provider_id}_{subject}`` 由稳定主键派生，
+    provider_id 不含分隔符（核心契约保证）故映射单射、无跨提供方撞名；建号一律非管理员、随机密码。
     """
-    raw = getattr(identity, "username", "") or ""
-    if not _USERNAME_RE.match(raw):
-        logger.warning(f"SSO 提供方 {provider_id} 返回非法格式的用户名，已拒绝")
+    subject = (getattr(identity, "subject", "") or "").strip()
+    if not _SUBJECT_RE.match(subject):
+        logger.warning(f"SSO 提供方 {provider_id} 返回非法格式的 subject，已拒绝")
         return None
-    username = f"{_USERNAME_PREFIX}{provider_id}_{raw}"
-    useroper = UserOper()
-    user = useroper.get_by_name(name=username)
-    if user:
-        if not user.is_active:
-            logger.warning(f"SSO 用户 {username} 已被禁用，拒绝登录")
+    # 1) 权威解析：按 (provider_id, subject) 查绑定
+    binding = SsoIdentity.get_by_subject(db=None, provider_id=provider_id, subject=subject)
+    if binding:
+        user = User.get(db=None, rid=binding.user_id)
+        if not user or not user.is_active:
+            logger.warning(f"SSO 绑定用户 {binding.user_id}（{provider_id}:{subject}）不存在或已禁用，拒绝登录")
             return None
         return user
+    # 2) 未绑定：按 auto_create 门控建号
     if not auto_create:
-        logger.info(f"SSO 用户 {username} 不存在且未开启自动建号，拒绝登录")
+        logger.info(f"SSO 身份 {provider_id}:{subject} 未绑定且未开启自动建号，拒绝登录")
         return None
-    useroper.add(
-        name=username,
-        avatar=getattr(identity, "avatar", None),
-        is_active=True,
-        is_superuser=False,
-        hashed_password=get_password_hash(secrets.token_urlsafe(16)),
-    )
-    logger.info(f"SSO 首次登录，已创建本地用户：{username}")
-    return useroper.get_by_name(name=username)
+    username = f"{_USERNAME_PREFIX}{provider_id}_{subject}"
+    useroper = UserOper()
+    # 用户名由稳定 subject 派生。同名用户已存在时，仅当其确为 SSO 托管账号（有任意身份绑定）且未禁用才复用，
+    # 否则拒绝——避免接管管理员手建的同名非 SSO 账号（C-1），以及绕过对同名残留账号的封禁（B-4）。
+    user = useroper.get_by_name(name=username)
+    if user is not None:
+        if not user.is_active:
+            logger.warning(f"SSO 同名残留用户 {username} 已禁用，拒绝复用")
+            return None
+        if not SsoIdentity.list_by_user(db=None, user_id=user.id):
+            logger.warning(f"SSO 派生用户名 {username} 被非 SSO 账号占用，拒绝接管")
+            return None
+    else:
+        useroper.add(
+            name=username,
+            avatar=getattr(identity, "avatar", None),
+            is_active=True,
+            is_superuser=False,
+            hashed_password=get_password_hash(secrets.token_urlsafe(16)),
+        )
+        user = useroper.get_by_name(name=username)
+    if not user:
+        logger.error(f"SSO 新建本地用户 {username} 失败")
+        return None
+    # 3) 落绑定（subject 为权威主键，外部用户名仅作快照）；并发首登致唯一键冲突时改用已存在绑定
+    try:
+        SsoIdentity(
+            provider_id=provider_id,
+            subject=subject,
+            user_id=user.id,
+            username=(getattr(identity, "username", None) or None),
+        ).create(db=None)
+    except Exception as e:
+        existing = SsoIdentity.get_by_subject(db=None, provider_id=provider_id, subject=subject)
+        if existing:
+            bound = User.get(db=None, rid=existing.user_id)
+            if bound and bound.is_active:
+                logger.info(f"SSO 身份 {provider_id}:{subject} 已被并发绑定，复用绑定用户")
+                return bound
+        logger.error(f"SSO 绑定 {provider_id}:{subject} 失败：{str(e)}")
+        return None
+    logger.info(f"SSO 首次登录，已创建本地用户 {username} 并绑定 {provider_id}:{subject}")
+    return user

--- a/tests/test_sso_login_flow.py
+++ b/tests/test_sso_login_flow.py
@@ -37,8 +37,8 @@ class _User:
         self.is_active = is_active
 
 
-def _identity(username="octocat"):
-    return AuthProviderIdentity(subject="sub-1", username=username, avatar="a")
+def _identity(username="octocat", subject="sub-1"):
+    return AuthProviderIdentity(subject=subject, username=username, avatar="a")
 
 
 class BeginLoginTest(TestCase):
@@ -75,55 +75,136 @@ class CompleteLoginTest(TestCase):
         ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
         self.assertEqual((ticket, error), (None, "fetch_identity_failed"))
 
-    def test_existing_user_mints_ticket_with_namespaced_name(self):
-        prov = _Provider(identity=_identity("octocat"))
-        with patch("app.helper.sso.UserOper") as UO, \
+    def test_bound_identity_mints_ticket(self):
+        # 已绑定身份：按 (provider_id, subject) 命中绑定 → 返回绑定用户、铸票（改名安全：不查用户名）
+        prov = _Provider(identity=_identity(username="renamed-login", subject="42"))
+        binding = type("B", (), {"user_id": 7})()
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.User") as U, \
                 patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK") as mint:
-            UO.return_value.get_by_name.return_value = _User(uid=7)
+            SI.get_by_subject.return_value = binding
+            U.get.return_value = _User(uid=7)
             ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
         self.assertEqual((ticket, error), ("TK", None))
-        UO.return_value.get_by_name.assert_called_with(name="sso_github_octocat")  # 提供方+前缀双重隔离
+        SI.get_by_subject.assert_called_with(db=None, provider_id="github", subject="42")
         self.assertEqual(mint.call_args.kwargs["user_id"], 7)
         self.assertEqual(mint.call_args.kwargs["provider_id"], "github")
 
-    def test_not_provisioned_without_auto_create(self):
-        prov = _Provider(identity=_identity("stranger"))
-        with patch("app.helper.sso.UserOper") as UO, \
+    def test_unbound_without_auto_create(self):
+        prov = _Provider(identity=_identity(subject="99"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.UserOper") as UO, \
                 patch("app.helper.sso.create_plugin_auth_ticket") as mint:
-            UO.return_value.get_by_name.return_value = None
+            SI.get_by_subject.return_value = None
             ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=False)
         self.assertEqual((ticket, error), (None, "user_not_provisioned"))
         UO.return_value.add.assert_not_called()
         mint.assert_not_called()
 
-    def test_auto_create_makes_non_superuser(self):
-        prov = _Provider(identity=_identity("newbie"))
-        with patch("app.helper.sso.UserOper") as UO, \
+    def test_auto_create_makes_non_superuser_and_binds(self):
+        # 未绑定 + auto_create：建非管理员用户（用户名由 subject 派生）+ 落 SsoIdentity 绑定
+        prov = _Provider(identity=_identity(username="newbie", subject="123"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.UserOper") as UO, \
                 patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK"), \
                 patch("app.helper.sso.get_password_hash", return_value="hashed"):
-            UO.return_value.get_by_name.side_effect = [None, _User(uid=9, name="sso_github_newbie")]
+            SI.get_by_subject.return_value = None
+            UO.return_value.get_by_name.side_effect = [None, _User(uid=9, name="sso_github_123")]
             ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
         self.assertEqual((ticket, error), ("TK", None))
         kw = UO.return_value.add.call_args.kwargs
-        self.assertEqual(kw["name"], "sso_github_newbie")
+        self.assertEqual(kw["name"], "sso_github_123")          # 用户名由稳定 subject 派生
         self.assertFalse(kw["is_superuser"], "自动建号不得为管理员")
         self.assertTrue(kw["is_active"])
         self.assertEqual(kw["hashed_password"], "hashed")
+        SI.assert_called_once()                                 # 落了绑定
+        bkw = SI.call_args.kwargs
+        self.assertEqual((bkw["provider_id"], bkw["subject"], bkw["user_id"]), ("github", "123", 9))
+        SI.return_value.create.assert_called_once()
 
-    def test_disabled_user_rejected(self):
-        prov = _Provider(identity=_identity("banned"))
-        with patch("app.helper.sso.UserOper") as UO, \
+    def test_auto_create_reuses_sso_managed_residual_user(self):
+        # 同名残留用户且确为 SSO 托管账号（有绑定）+ 未禁用 → 复用，不重复建号
+        prov = _Provider(identity=_identity(subject="77"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK"):
+            SI.get_by_subject.return_value = None
+            SI.list_by_user.return_value = [object()]            # 确为 SSO 托管账号
+            UO.return_value.get_by_name.return_value = _User(uid=3, name="sso_github_77")
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), ("TK", None))
+        UO.return_value.add.assert_not_called()
+
+    def test_residual_disabled_user_not_reused(self):
+        # B-4：同名残留用户被禁用 → 拒绝复用（防绕过封禁）
+        prov = _Provider(identity=_identity(subject="78"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.UserOper") as UO, \
                 patch("app.helper.sso.create_plugin_auth_ticket") as mint:
-            UO.return_value.get_by_name.return_value = _User(name="sso_github_banned", is_active=False)
+            SI.get_by_subject.return_value = None
+            UO.return_value.get_by_name.return_value = _User(uid=3, is_active=False)
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), (None, "user_not_provisioned"))
+        SI.list_by_user.assert_not_called()
+        mint.assert_not_called()
+
+    def test_residual_non_sso_user_not_taken_over(self):
+        # C-1：同名残留用户无任何身份绑定（非 SSO 本地账号）→ 拒绝接管
+        prov = _Provider(identity=_identity(subject="79"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket") as mint:
+            SI.get_by_subject.return_value = None
+            SI.list_by_user.return_value = []                    # 无绑定 → 非 SSO 账号
+            UO.return_value.get_by_name.return_value = _User(uid=3, name="sso_github_79")
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), (None, "user_not_provisioned"))
+        UO.return_value.add.assert_not_called()
+        mint.assert_not_called()
+
+    def test_degenerate_subject_rejected(self):
+        # A-3：纯分隔符 subject（无字母数字）被拒
+        for bad in ("...", "---", ".-_"):
+            prov = _Provider(identity=_identity(subject=bad))
+            with patch("app.helper.sso.SsoIdentity") as SI:
+                ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+            self.assertEqual((ticket, error), (None, "user_not_provisioned"), f"应拒绝 subject={bad}")
+            SI.get_by_subject.assert_not_called()
+
+    def test_concurrent_binding_conflict_reuses_existing(self):
+        # 并发首登：落绑定唯一键冲突 → 复用已存在绑定用户，不 500
+        prov = _Provider(identity=_identity(subject="88"))
+        existing = type("B", (), {"user_id": 4})()
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.User") as U, \
+                patch("app.helper.sso.UserOper") as UO, \
+                patch("app.helper.sso.create_plugin_auth_ticket", return_value="TK") as mint:
+            SI.get_by_subject.side_effect = [None, existing]      # 首查未绑定，冲突后再查命中
+            SI.return_value.create.side_effect = Exception("UNIQUE")
+            UO.return_value.get_by_name.side_effect = [None, _User(uid=4)]
+            U.get.return_value = _User(uid=4)
+            ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
+        self.assertEqual((ticket, error), ("TK", None))
+        self.assertEqual(mint.call_args.kwargs["user_id"], 4)
+
+    def test_disabled_bound_user_rejected(self):
+        prov = _Provider(identity=_identity(subject="55"))
+        binding = type("B", (), {"user_id": 5})()
+        with patch("app.helper.sso.SsoIdentity") as SI, \
+                patch("app.helper.sso.User") as U, \
+                patch("app.helper.sso.create_plugin_auth_ticket") as mint:
+            SI.get_by_subject.return_value = binding
+            U.get.return_value = _User(uid=5, is_active=False)
             ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb")
         self.assertEqual((ticket, error), (None, "user_not_provisioned"))
         mint.assert_not_called()
 
-    def test_malformed_external_username_rejected(self):
-        prov = _Provider(identity=_identity("evil/../admin"))
-        with patch("app.helper.sso.UserOper") as UO, \
+    def test_malformed_subject_rejected(self):
+        # 安全：非法 subject 在任何绑定查询/建号之前被拒
+        prov = _Provider(identity=_identity(subject="bad/../x"))
+        with patch("app.helper.sso.SsoIdentity") as SI, \
                 patch("app.helper.sso.create_plugin_auth_ticket") as mint:
             ticket, error = sso_helper.complete_login(prov, "c", issue_state(), "cb", auto_create=True)
         self.assertEqual((ticket, error), (None, "user_not_provisioned"))
-        UO.return_value.get_by_name.assert_not_called()
+        SI.get_by_subject.assert_not_called()
         mint.assert_not_called()


### PR DESCRIPTION
## 背景

继 PR #72（固化 provides_auth_providers 消除 G3）后，把 SSO 用户解析从「可变用户名推导」升级为「按稳定 `subject` 查绑定表」，解决用户名作身份主键的固有坑（外部改名即换号）。

## 改动

- **`app/db/models/ssoidentity.py`（新框架表）**：`SsoIdentity(provider_id, subject, user_id→user.id ON DELETE CASCADE, username 快照, created_at)`，唯一键 `(provider_id, subject)`，`get_by_subject`/`list_by_user`。`create_all` 启动建表（无需手写 alembic 迁移）。
- **`app/helper/sso.py` `_resolve_user`**：按 `(provider_id, subject)` 查绑定 → 命中返回（禁用拒登、绑定指向已删用户 `User.get→None` 安全拒绝）；未绑定 + `auto_create` 建非管理员用户（用户名 `sso_{pid}_{subject}` 由稳定主键派生）+ 落绑定；并发首登唯一键冲突复用已存在绑定。

## 收益（为何用框架表而非 plugin_data）

- 外部改名（username 变）**不丢号**——按 subject 解析，与可变用户名解耦。
- 表为**账号关联 / 多提供方合一**留好结构。
- 身份持久化属用户账号域（框架表），**不随插件卸载而失**；plugin_data 会再次打散 G3 已统一的解析逻辑、且生命周期错配。

## 安全（security-review：0 Critical）

修 1 HIGH + 3 MED：
- **HIGH B-4**：同名残留用户复用前加 `is_active` 检查（防绕过封禁）。
- **MED C-1**：仅复用确为 SSO 托管（有任意身份绑定）的同名账号，**拒绝接管管理员手建的同名非 SSO 账号**。
- **MED A-3**：`subject` 正则收紧（首尾须字母数字，拒纯分隔符）。
- **MED F-2**：FK 加 `ON DELETE CASCADE`。
- 既有不变量：subject 白名单校验、用户名 `sso_{pid}_{subject}` 单射（provider_id 无分隔符）、建号非管理员 + 随机密码。
- 已知延后（非本 PR）：`User.name` 无唯一约束（更底层表设计，except 分支已保证 auth 正确性）。

## 测试

```
test_sso_login_flow.py(17，含 B-4/C-1/A-3/并发冲突/SSO残留复用) → 全过
真实 db 往返 + 唯一键冲突冒烟坐实表可用；认证全回归（69）零破坏
```