### PR TITLE
refactor: 将 app/core/module.py 拆分为 app/core/module 包

### DIFF
--- a/app/core/module/__init__.py
+++ b/app/core/module/__init__.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+app.core.module 包：模块管理（manager）/ 动态加载（loader）/ 契约校验（contract）。
+
+稳定公共 API（保持 from app.core.module import X 零改动；历史上为单文件 app/core/module.py）：
+  - ModuleManager        模块管理器（注册/生命周期），见 .manager
+  - ModuleType           模块类型枚举（再导出自 app.schemas.types）
+  - verify_*_contract     契约校验家族（module/data_source/downloader/notification/mediaserver），见 .contract
+
+公共名按需懒加载（PEP 562 __getattr__）。关键不变量：``import app.core.module.loader`` 不应触发
+manager 的重依赖（config/event/singleton…）——动态加载工具 ModuleHelper 被 filemanager/indexer/
+workflow 等在 import 期使用，必须可单独 import 而不拖入模块管理器依赖图（S3 解耦成果）。故此 __init__
+不在模块顶层 import 任何子模块，仅在属性首次访问时按需解析。
+"""
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "ModuleManager",
+    "ModuleType",
+    "verify_module_contract",
+    "verify_data_source_contract",
+    "verify_downloader_contract",
+    "verify_notification_contract",
+    "verify_mediaserver_contract",
+]
+
+# 公共名 → (子模块全名, 属性名)。延迟到首次属性访问时再 import，避免子模块（尤其 loader）
+# 的 import 触发 manager 的重依赖链。
+_LAZY_EXPORTS = {
+    "ModuleManager": ("app.core.module.manager", "ModuleManager"),
+    "ModuleType": ("app.schemas.types", "ModuleType"),
+    "verify_module_contract": ("app.core.module.contract", "verify_module_contract"),
+    "verify_data_source_contract": ("app.core.module.contract", "verify_data_source_contract"),
+    "verify_downloader_contract": ("app.core.module.contract", "verify_downloader_contract"),
+    "verify_notification_contract": ("app.core.module.contract", "verify_notification_contract"),
+    "verify_mediaserver_contract": ("app.core.module.contract", "verify_mediaserver_contract"),
+}
+
+
+def __getattr__(name: str):
+    """PEP 562 懒加载：仅当访问公共名时才 import 对应子模块并取出属性。"""
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+    return getattr(importlib.import_module(target[0]), target[1])
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))
+
+
+if TYPE_CHECKING:  # 仅供静态检查/IDE 解析；运行时一律走上面的懒加载
+    from app.schemas.types import ModuleType
+    from app.core.module.contract import (
+        verify_data_source_contract,
+        verify_downloader_contract,
+        verify_mediaserver_contract,
+        verify_module_contract,
+        verify_notification_contract,
+    )
+    from app.core.module.manager import ModuleManager

--- a/app/core/module/contract.py
+++ b/app/core/module/contract.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+模块契约校验家族（从 ModuleManager 抽出为独立模块）。
+
+与 manager/loader 解耦：仅依赖标准库 inspect 与 ModuleType 枚举，_ModuleBase 走 lazy import 防环。
+verify_module_contract 为 _ModuleBase 基类契约的核心判定；各域 verify_*_contract 在其上叠加
+get_type 与核心方法要求，共用 _verify_typed_contract。ModuleManager 仍以静态方法别名再导出全部函数，
+故 ModuleManager.verify_*_contract 调用方零改动。
+"""
+import inspect
+from typing import List, Tuple
+
+from app.schemas.types import ModuleType
+
+
+def verify_module_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    """
+    校验外部模块类是否满足 _ModuleBase 基类契约，作为「验证注册」的核心判定。
+
+    宽松策略（缺注解/不可内省时降级跳过、不抛异常），返回 (是否通过, 失败原因列表)。
+    供 register_module 把旧「注入」式注册升级为「验证后注册」——不通过仅作废弃提醒、
+    不强制拒绝，保证零插件破坏。
+    """
+    if not isinstance(module_cls, type):
+        return False, ["不是类对象"]
+    reasons: List[str] = []
+    # 1) 应继承 _ModuleBase（真模块 vs 任意注入类的核心区分）；lazy import 避免 import-time 环
+    try:
+        from app.modules import _ModuleBase
+        if not issubclass(module_cls, _ModuleBase):
+            reasons.append("未继承 app.modules._ModuleBase")
+    except ImportError:
+        pass  # app.modules 依赖未就绪时仅降级跳过该项；其它异常照常上报
+    # 2) 抽象方法须全部落地，否则不可实例化
+    abstracts = getattr(module_cls, "__abstractmethods__", frozenset())
+    if abstracts:
+        reasons.append(f"抽象方法未实现：{sorted(abstracts)}")
+    # 3) 契约方法存在且可调用 + 签名宽松兼容（生命周期/声明方法不应要求额外必填位置参）
+    for _name in ("init_module", "init_setting", "stop", "test", "get_type", "get_subtype"):
+        _fn = getattr(module_cls, _name, None)
+        if not callable(_fn):
+            reasons.append(f"缺少契约方法：{_name}")
+            continue
+        try:
+            _extra = [
+                p.name for p in inspect.signature(_fn).parameters.values()
+                if p.name not in ("self", "cls")
+                and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+                and p.default is p.empty
+            ]
+            if _extra:
+                reasons.append(f"{_name} 签名不兼容：要求额外必填参 {_extra}")
+        except (ValueError, TypeError):
+            pass  # 无法内省 → 降级跳过
+    return (not reasons), reasons
+
+
+def _verify_typed_contract(module_cls: type, expected_type: ModuleType,
+                           required_methods: Tuple[str, ...] = (),
+                           method_label: str = "") -> Tuple[bool, List[str]]:
+    """
+    域契约通用校验（各 verify_*_contract 的共用实现）：在 _ModuleBase 基类契约之上，要求
+    get_type()==expected_type，并要求 required_methods 全部可调用。能力方法按需实现的域
+    传空 required_methods 即可。返回 (是否通过, 失败原因列表)。
+    """
+    ok, reasons = verify_module_contract(module_cls)
+    reasons = list(reasons)
+    _get_type = getattr(module_cls, "get_type", None)
+    if not callable(_get_type):
+        reasons.append("缺少 get_type")
+    else:
+        try:
+            if _get_type() != expected_type:
+                reasons.append(f"get_type 须为 {expected_type}（实际 {_get_type()}）")
+        except Exception as err:
+            reasons.append(f"get_type 调用失败：{err}")
+    for _name in required_methods:
+        if not callable(getattr(module_cls, _name, None)):
+            reasons.append(f"缺少{method_label}方法：{_name}")
+    return (not reasons), reasons
+
+
+def verify_data_source_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    """
+    校验数据源（媒体识别/信息源，MediaRecognize 域）契约：基类契约 + get_type==MediaRecognize。
+    识别能力方法（recognize_media/search_medias/obtain_images 等）按方法名分发、按需实现，
+    故不强制（避免误拒 thetvdb 这类仅实现部分/其它方法的真实源）。
+    """
+    return _verify_typed_contract(module_cls, ModuleType.MediaRecognize)
+
+
+def verify_downloader_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    """
+    校验下载器（Downloader 域）契约：基类契约 + get_type==Downloader + 核心操作
+    download/list_torrents/remove_torrents。完整 IDownloader 面（start/stop/torrent_files 等）
+    按方法名分发、按需实现。供 provides_downloaders() 注册前严格校验。
+    """
+    return _verify_typed_contract(
+        module_cls, ModuleType.Downloader,
+        ("download", "list_torrents", "remove_torrents"), "下载器")
+
+
+def verify_notification_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    """
+    校验消息渠道（Notification 域）契约：基类契约 + get_type==Notification + 核心方法 post_message。
+    其余消息能力方法（post_medias/post_torrents/delete_message 等）按方法名分发、按需实现。
+    供 provides_notifications() 注册前严格校验。
+    """
+    return _verify_typed_contract(
+        module_cls, ModuleType.Notification, ("post_message",), "消息渠道")
+
+
+def verify_mediaserver_contract(module_cls: type) -> Tuple[bool, List[str]]:
+    """
+    校验媒体服务器（MediaServer 域）契约：基类契约 + get_type==MediaServer。能力方法
+    （mediaserver_librarys/media_statistic 等）各后端实现子集不同，按方法名分发、按需实现，
+    故不强制。供 provides_mediaservers() 注册前严格校验。
+    """
+    return _verify_typed_contract(module_cls, ModuleType.MediaServer)

--- a/app/core/module/loader.py
+++ b/app/core/module/loader.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+import importlib
+import pkgutil
+import traceback
+from pathlib import Path
+from typing import List, Any, Callable
+
+from app.log import logger
+
+FilterFuncType = Callable[[str, Any], bool]
+
+
+def _default_filter(name: str, obj: Any) -> bool:
+    """
+    默认过滤器
+    """
+    return True if name and obj else False
+
+
+class ModuleHelper:
+    """
+    模块动态加载
+    """
+
+    @classmethod
+    def load(cls, package_path: str, filter_func: FilterFuncType = _default_filter) -> List[Any]:
+        """
+        导入模块
+        :param package_path: 父包名
+        :param filter_func: 子模块过滤函数，入参为模块名和模块对象，返回True则导入，否则不导入
+        :return: 导入的模块对象列表
+        """
+
+        submodules: list = []
+        loaded_modules = set()
+        packages = importlib.import_module(package_path)
+        for importer, package_name, _ in pkgutil.iter_modules(packages.__path__):
+            try:
+                if package_name.startswith('_'):
+                    continue
+                full_package_name = f'{package_path}.{package_name}'
+                module = importlib.import_module(full_package_name)
+                importlib.reload(module)
+                for name, obj in module.__dict__.items():
+                    if name.startswith('_'):
+                        continue
+                    if isinstance(obj, type) and filter_func(name, obj):
+                        if name in loaded_modules:
+                            continue
+                        loaded_modules.add(name)
+                        submodules.append(obj)
+            except Exception as err:
+                logger.debug(f'加载模块 {package_name} 失败：{str(err)} - {traceback.format_exc()}')
+
+        return submodules
+
+    @classmethod
+    def load_with_pre_filter(cls, package_path: str, filter_func: FilterFuncType = _default_filter) -> List[Any]:
+        """
+        导入子模块
+        :param package_path: 父包名
+        :param filter_func: 子模块过滤函数，入参为模块名和模块对象，返回True则导入，否则不导入
+        :return: 导入的模块对象列表
+        """
+
+        submodules: list = []
+        packages = importlib.import_module(package_path)
+
+        def reload_module_objects(target_module):
+            """加载模块并返回对象"""
+            importlib.reload(target_module)
+            # reload后，重新过滤已经重新加载后的模块中的对象
+            return [
+                obj for name, obj in target_module.__dict__.items()
+                if not name.startswith('_') and isinstance(obj, type) and filter_func(name, obj)
+            ]
+
+        def reload_sub_modules(parent_module, parent_module_name):
+            """重新加载一级子模块"""
+            for sub_importer, sub_module_name, sub_is_pkg in pkgutil.walk_packages(parent_module.__path__,
+                                                                                   parent_module_name + '.'):
+                try:
+                    full_sub_module = importlib.import_module(sub_module_name)
+                    importlib.reload(full_sub_module)
+                except Exception as sub_err:
+                    logger.debug(f'加载子模块 {sub_module_name} 失败：{str(sub_err)} - {traceback.format_exc()}')
+
+        # 遍历包中的所有子模块
+        for importer, package_name, is_pkg in pkgutil.iter_modules(packages.__path__):
+            if package_name.startswith('_'):
+                continue
+            full_package_name = f'{package_path}.{package_name}'
+            try:
+                module = importlib.import_module(full_package_name)
+                # 预检查模块中的对象
+                candidates = [(name, obj) for name, obj in module.__dict__.items() if
+                              not name.startswith('_') and isinstance(obj, type)]
+                # 确定是否需要重新加载
+                if any(filter_func(name, obj) for name, obj in candidates):
+                    # 如果子模块是包，重新加载其子模块
+                    if is_pkg:
+                        reload_sub_modules(module, full_package_name)
+                    submodules.extend(reload_module_objects(module))
+            except Exception as err:
+                logger.debug(f'加载模块 {package_name} 失败：{str(err)} - {traceback.format_exc()}')
+
+        return submodules
+
+    @staticmethod
+    def dynamic_import_all_modules(base_path: Path, package_name: str):
+        """
+        动态导入目录下所有模块
+        """
+        modules = []
+        # 遍历文件夹，找到所有模块文件
+        for file in base_path.glob("*.py"):
+            file_name = file.stem
+            if file_name != "__init__":
+                modules.append(file_name)
+                full_module_name = f"{package_name}.{file_name}"
+                importlib.import_module(full_module_name)

--- a/app/core/module/manager.py
+++ b/app/core/module/manager.py
@@ -1,4 +1,3 @@
-import inspect
 import threading
 import traceback
 from enum import Enum
@@ -6,7 +5,15 @@ from typing import Generator, Optional, Tuple, Any, Union, List, Dict
 
 from app.core.config import settings
 from app.core.event import eventmanager
-from app.core.module_loader import ModuleHelper
+from app.core.module.contract import (
+    verify_module_contract as _verify_module_contract,
+    verify_data_source_contract as _verify_data_source_contract,
+    verify_downloader_contract as _verify_downloader_contract,
+    verify_notification_contract as _verify_notification_contract,
+    verify_mediaserver_contract as _verify_mediaserver_contract,
+    _verify_typed_contract as _verify_typed_contract,
+)
+from app.core.module.loader import ModuleHelper
 from app.log import logger
 from app.schemas.types import EventType, ModuleType, DownloaderType, MediaServerType, MessageChannel, StorageSchema, \
     OtherModulesType
@@ -210,111 +217,15 @@ class ModuleManager(metaclass=Singleton):
     # 无差别接管，无需改动分发链。运行期线程安全，支持热插拔。
     # ---------------------------------------------------------------------
 
-    @staticmethod
-    def verify_module_contract(module_cls: type) -> Tuple[bool, List[str]]:
-        """
-        校验外部模块类是否满足 _ModuleBase 基类契约，作为「验证注册」的核心判定。
-
-        宽松策略（缺注解/不可内省时降级跳过、不抛异常），返回 (是否通过, 失败原因列表)。
-        供 register_module 把旧「注入」式注册升级为「验证后注册」——不通过仅作废弃提醒、
-        不强制拒绝，保证零插件破坏。
-        """
-        if not isinstance(module_cls, type):
-            return False, ["不是类对象"]
-        reasons: List[str] = []
-        # 1) 应继承 _ModuleBase（真模块 vs 任意注入类的核心区分）；lazy import 避免 import-time 环
-        try:
-            from app.modules import _ModuleBase
-            if not issubclass(module_cls, _ModuleBase):
-                reasons.append("未继承 app.modules._ModuleBase")
-        except ImportError:
-            pass  # app.modules 依赖未就绪时仅降级跳过该项；其它异常照常上报
-        # 2) 抽象方法须全部落地，否则不可实例化
-        abstracts = getattr(module_cls, "__abstractmethods__", frozenset())
-        if abstracts:
-            reasons.append(f"抽象方法未实现：{sorted(abstracts)}")
-        # 3) 契约方法存在且可调用 + 签名宽松兼容（生命周期/声明方法不应要求额外必填位置参）
-        for _name in ("init_module", "init_setting", "stop", "test", "get_type", "get_subtype"):
-            _fn = getattr(module_cls, _name, None)
-            if not callable(_fn):
-                reasons.append(f"缺少契约方法：{_name}")
-                continue
-            try:
-                _extra = [
-                    p.name for p in inspect.signature(_fn).parameters.values()
-                    if p.name not in ("self", "cls")
-                    and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
-                    and p.default is p.empty
-                ]
-                if _extra:
-                    reasons.append(f"{_name} 签名不兼容：要求额外必填参 {_extra}")
-            except (ValueError, TypeError):
-                pass  # 无法内省 → 降级跳过
-        return (not reasons), reasons
-
-    @staticmethod
-    def _verify_typed_contract(module_cls: type, expected_type: ModuleType,
-                               required_methods: Tuple[str, ...] = (),
-                               method_label: str = "") -> Tuple[bool, List[str]]:
-        """
-        域契约通用校验（各 verify_*_contract 的共用实现）：在 _ModuleBase 基类契约之上，要求
-        get_type()==expected_type，并要求 required_methods 全部可调用。能力方法按需实现的域
-        传空 required_methods 即可。返回 (是否通过, 失败原因列表)。
-        """
-        ok, reasons = ModuleManager.verify_module_contract(module_cls)
-        reasons = list(reasons)
-        _get_type = getattr(module_cls, "get_type", None)
-        if not callable(_get_type):
-            reasons.append("缺少 get_type")
-        else:
-            try:
-                if _get_type() != expected_type:
-                    reasons.append(f"get_type 须为 {expected_type}（实际 {_get_type()}）")
-            except Exception as err:
-                reasons.append(f"get_type 调用失败：{err}")
-        for _name in required_methods:
-            if not callable(getattr(module_cls, _name, None)):
-                reasons.append(f"缺少{method_label}方法：{_name}")
-        return (not reasons), reasons
-
-    @staticmethod
-    def verify_data_source_contract(module_cls: type) -> Tuple[bool, List[str]]:
-        """
-        校验数据源（媒体识别/信息源，MediaRecognize 域）契约：基类契约 + get_type==MediaRecognize。
-        识别能力方法（recognize_media/search_medias/obtain_images 等）按方法名分发、按需实现，
-        故不强制（避免误拒 thetvdb 这类仅实现部分/其它方法的真实源）。
-        """
-        return ModuleManager._verify_typed_contract(module_cls, ModuleType.MediaRecognize)
-
-    @staticmethod
-    def verify_downloader_contract(module_cls: type) -> Tuple[bool, List[str]]:
-        """
-        校验下载器（Downloader 域）契约：基类契约 + get_type==Downloader + 核心操作
-        download/list_torrents/remove_torrents。完整 IDownloader 面（start/stop/torrent_files 等）
-        按方法名分发、按需实现。供 provides_downloaders() 注册前严格校验。
-        """
-        return ModuleManager._verify_typed_contract(
-            module_cls, ModuleType.Downloader,
-            ("download", "list_torrents", "remove_torrents"), "下载器")
-
-    @staticmethod
-    def verify_notification_contract(module_cls: type) -> Tuple[bool, List[str]]:
-        """
-        校验消息渠道（Notification 域）契约：基类契约 + get_type==Notification + 核心方法 post_message。
-        其余消息能力方法（post_medias/post_torrents/delete_message 等）按方法名分发、按需实现。
-        供 provides_notifications() 注册前严格校验。
-        """
-        return ModuleManager._verify_typed_contract(
-            module_cls, ModuleType.Notification, ("post_message",), "消息渠道")
-
-    @staticmethod
-    def verify_mediaserver_contract(module_cls: type) -> Tuple[bool, List[str]]:
-        """
-        校验媒体服务器（MediaServer 域）契约：基类契约 + get_type==MediaServer。能力方法
-        （mediaserver_librarys/media_statistic 等）各后端实现子集不同，按方法名分发、按需实现，
-        故不强制。供 provides_mediaservers() 注册前严格校验。
-        """
-        return ModuleManager._verify_typed_contract(module_cls, ModuleType.MediaServer)
+    # 契约校验家族已抽至 app.core.module.contract（独立、轻量、可被 plugin_manager 直接 import）。
+    # 此处以静态方法别名再导出，保持 ModuleManager.verify_*_contract 与 register_module 内部
+    # self.verify_module_contract 调用零改动；plugin_manager.py 仍按 ModuleManager.verify_*_contract 取引用。
+    verify_module_contract = staticmethod(_verify_module_contract)
+    verify_data_source_contract = staticmethod(_verify_data_source_contract)
+    verify_downloader_contract = staticmethod(_verify_downloader_contract)
+    verify_notification_contract = staticmethod(_verify_notification_contract)
+    verify_mediaserver_contract = staticmethod(_verify_mediaserver_contract)
+    _verify_typed_contract = staticmethod(_verify_typed_contract)
 
     def register_module(self, module_cls: type, owner: str) -> bool:
         """

--- a/app/core/module_loader.py
+++ b/app/core/module_loader.py
@@ -1,121 +1,12 @@
 # -*- coding: utf-8 -*-
-import importlib
-import pkgutil
-import traceback
-from pathlib import Path
-from typing import List, Any, Callable
+"""
+兼容垫片：模块动态加载工具已随 module 包化迁移至 app.core.module.loader。
 
-from app.log import logger
+历史导入路径 app.core.module_loader 保持零改动可用——本垫片与新路径解析到同一批对象
+（ModuleHelper / FilterFuncType / _default_filter）。新代码请直接 import app.core.module.loader。
 
-FilterFuncType = Callable[[str, Any], bool]
+本垫片仅依赖标准库与新 loader 模块，不引入任何上层依赖，保持 core 层动态加载工具的轻量独立。
+"""
+from app.core.module.loader import FilterFuncType, ModuleHelper, _default_filter  # noqa: F401
 
-
-def _default_filter(name: str, obj: Any) -> bool:
-    """
-    默认过滤器
-    """
-    return True if name and obj else False
-
-
-class ModuleHelper:
-    """
-    模块动态加载
-    """
-
-    @classmethod
-    def load(cls, package_path: str, filter_func: FilterFuncType = _default_filter) -> List[Any]:
-        """
-        导入模块
-        :param package_path: 父包名
-        :param filter_func: 子模块过滤函数，入参为模块名和模块对象，返回True则导入，否则不导入
-        :return: 导入的模块对象列表
-        """
-
-        submodules: list = []
-        loaded_modules = set()
-        packages = importlib.import_module(package_path)
-        for importer, package_name, _ in pkgutil.iter_modules(packages.__path__):
-            try:
-                if package_name.startswith('_'):
-                    continue
-                full_package_name = f'{package_path}.{package_name}'
-                module = importlib.import_module(full_package_name)
-                importlib.reload(module)
-                for name, obj in module.__dict__.items():
-                    if name.startswith('_'):
-                        continue
-                    if isinstance(obj, type) and filter_func(name, obj):
-                        if name in loaded_modules:
-                            continue
-                        loaded_modules.add(name)
-                        submodules.append(obj)
-            except Exception as err:
-                logger.debug(f'加载模块 {package_name} 失败：{str(err)} - {traceback.format_exc()}')
-
-        return submodules
-
-    @classmethod
-    def load_with_pre_filter(cls, package_path: str, filter_func: FilterFuncType = _default_filter) -> List[Any]:
-        """
-        导入子模块
-        :param package_path: 父包名
-        :param filter_func: 子模块过滤函数，入参为模块名和模块对象，返回True则导入，否则不导入
-        :return: 导入的模块对象列表
-        """
-
-        submodules: list = []
-        packages = importlib.import_module(package_path)
-
-        def reload_module_objects(target_module):
-            """加载模块并返回对象"""
-            importlib.reload(target_module)
-            # reload后，重新过滤已经重新加载后的模块中的对象
-            return [
-                obj for name, obj in target_module.__dict__.items()
-                if not name.startswith('_') and isinstance(obj, type) and filter_func(name, obj)
-            ]
-
-        def reload_sub_modules(parent_module, parent_module_name):
-            """重新加载一级子模块"""
-            for sub_importer, sub_module_name, sub_is_pkg in pkgutil.walk_packages(parent_module.__path__,
-                                                                                   parent_module_name + '.'):
-                try:
-                    full_sub_module = importlib.import_module(sub_module_name)
-                    importlib.reload(full_sub_module)
-                except Exception as sub_err:
-                    logger.debug(f'加载子模块 {sub_module_name} 失败：{str(sub_err)} - {traceback.format_exc()}')
-
-        # 遍历包中的所有子模块
-        for importer, package_name, is_pkg in pkgutil.iter_modules(packages.__path__):
-            if package_name.startswith('_'):
-                continue
-            full_package_name = f'{package_path}.{package_name}'
-            try:
-                module = importlib.import_module(full_package_name)
-                # 预检查模块中的对象
-                candidates = [(name, obj) for name, obj in module.__dict__.items() if
-                              not name.startswith('_') and isinstance(obj, type)]
-                # 确定是否需要重新加载
-                if any(filter_func(name, obj) for name, obj in candidates):
-                    # 如果子模块是包，重新加载其子模块
-                    if is_pkg:
-                        reload_sub_modules(module, full_package_name)
-                    submodules.extend(reload_module_objects(module))
-            except Exception as err:
-                logger.debug(f'加载模块 {package_name} 失败：{str(err)} - {traceback.format_exc()}')
-
-        return submodules
-
-    @staticmethod
-    def dynamic_import_all_modules(base_path: Path, package_name: str):
-        """
-        动态导入目录下所有模块
-        """
-        modules = []
-        # 遍历文件夹，找到所有模块文件
-        for file in base_path.glob("*.py"):
-            file_name = file.stem
-            if file_name != "__init__":
-                modules.append(file_name)
-                full_module_name = f"{package_name}.{file_name}"
-                importlib.import_module(full_module_name)
+__all__ = ["ModuleHelper", "FilterFuncType"]


### PR DESCRIPTION
## 背景

`app/core/module.py`（单文件 428 行）承载了模块管理、动态加载与契约校验三类职责，且 `from app.core.module import ModuleManager` 这类调用方有几十处。本 PR 按职责拆为包，对外**公共 API 零改动**。

## 拆分

```
app/core/module/
  __init__.py   再导出稳定公共 API：ModuleManager / ModuleType / verify_*_contract
  loader.py     原 module_loader.py 的扫描/发现（ModuleHelper / FilterFuncType）
  manager.py    ModuleManager 注册/生命周期
  contract.py   verify_module_contract / _verify_typed_contract / verify_*_contract 家族
```

## 兼容性保证

- **`from app.core.module import ModuleManager`**（10 处生产 + 11 处测试）零改动；`ModuleType` 同样经包再导出。
- **`ModuleManager.verify_*_contract`**（plugin_manager.py:666-669 + 5 个 registration/validation 测试把它们当绑定引用传递）以 `staticmethod` 别名保留，与 `contract.py` 函数同源。
- **`app/core/module_loader.py`** 转为指向 `app.core.module.loader` 的兼容垫片；`app.helper.module` → `app.core.module_loader` → `app.core.module.loader` 三路解析到**同一批对象**（插件 `from app.helper.module import ModuleHelper` 零改动）。
- **S3 解耦不变量保持**：`__init__.py` 用 PEP 562 `__getattr__` 懒加载，使 `import app.core.module.loader` **不触发** manager 的重依赖（config/event/singleton…）——动态加载工具 `ModuleHelper` 被 filemanager/indexer/workflow 在 import 期使用，必须可单独 import 而不拖入模块管理器依赖图。冒烟已断言 `import loader` 后 `app.core.module.manager` 不在 `sys.modules`。

## 验证

- 导入冒烟：仅 import loader 未拉入 manager；三路垫片同一对象；公共 API 全可用；`ModuleManager.verify_*` 别名与 contract 同源。
- 全部生产侧 ModuleManager 导入方 import 无环。
- 全量测试 **1713 passed / 19 skipped**。