### PR TITLE
refactor: 将 app/core/event.py 拆分为 app/core/event 包

### DIFF
--- a/app/core/event/__init__.py
+++ b/app/core/event/__init__.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+app.core.event 包：事件值对象（models）+ 事件管理器（manager）。
+
+稳定公共 API（保持 from app.core.event import X 零改动；历史为单文件 app/core/event.py）：
+  - Event         事件值对象，见 .models
+  - EventManager  事件管理器（订阅/广播/链式调度），见 .manager
+  - eventmanager  EventManager 全局单例
+  - DEFAULT_EVENT_PRIORITY / MIN_EVENT_CONSUMER_THREADS /
+    INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS / MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS  调度常量
+
+采用**急切再导出**（非懒加载）：历史单文件在 import 期即构造全局单例 eventmanager，
+且不存在「需独立轻量 import 某子模块」的不变量（与 app.core.module 的 loader 不同），
+故此处直接再导出，保持导入行为与单例构造时机与历史完全一致。
+"""
+from app.core.event.models import (
+    Event,
+    DEFAULT_EVENT_PRIORITY,
+    MIN_EVENT_CONSUMER_THREADS,
+    INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS,
+    MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS,
+)
+from app.core.event.manager import EventManager, eventmanager
+
+__all__ = [
+    "Event",
+    "EventManager",
+    "eventmanager",
+    "DEFAULT_EVENT_PRIORITY",
+    "MIN_EVENT_CONSUMER_THREADS",
+    "INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS",
+    "MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS",
+]

--- a/app/core/event/manager.py
+++ b/app/core/event/manager.py
@@ -5,66 +5,25 @@ import random
 import threading
 import time
 import traceback
-import uuid
 from queue import Empty, PriorityQueue
 from typing import Callable, Dict, List, Optional, Tuple, Union, Any
 
 from fastapi.concurrency import run_in_threadpool
 
 from app.core.config import global_vars
+from app.core.event.models import (
+    Event,
+    DEFAULT_EVENT_PRIORITY,
+    MIN_EVENT_CONSUMER_THREADS,
+    INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS,
+    MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS,
+)
 from app.core.thread import ThreadHelper
 from app.log import logger
 from app.schemas import ChainEventData
 from app.schemas.types import ChainEventType, EventType
 from app.utils.limit import ExponentialBackoffRateLimiter
 from app.utils.singleton import Singleton
-
-DEFAULT_EVENT_PRIORITY = 10  # 事件的默认优先级
-MIN_EVENT_CONSUMER_THREADS = 1  # 最小事件消费者线程数
-INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS = 1  # 事件队列空闲时的初始超时时间（秒）
-MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS = 5  # 事件队列空闲时的最大超时时间（秒）
-
-
-class Event:
-    """
-    事件类，封装事件的基本信息
-    """
-
-    def __init__(self, event_type: Union[EventType, ChainEventType],
-                 event_data: Optional[Union[Dict, ChainEventData]] = None,
-                 priority: Optional[int] = DEFAULT_EVENT_PRIORITY):
-        """
-        :param event_type: 事件的类型，支持 EventType 或 ChainEventType
-        :param event_data: 可选，事件携带的数据，默认为空字典
-        :param priority: 可选，事件的优先级，默认为 10
-        """
-        self.event_id = str(uuid.uuid4())  # 事件ID
-        self.event_type = event_type  # 事件类型
-        self.event_data = event_data or {}  # 事件数据
-        self.priority = priority  # 事件优先级
-
-    def __repr__(self) -> str:
-        """
-        重写 __repr__ 方法，用于返回事件的详细信息，包括事件类型、事件ID和优先级
-        """
-        event_kind = Event.get_event_kind(self.event_type)
-        return f"<{event_kind}: {self.event_type.value}, ID: {self.event_id}, Priority: {self.priority}>"
-
-    def __lt__(self, other):
-        """
-        定义事件对象的比较规则，基于优先级比较
-        优先级小的事件会被认为“更小”，优先级高的事件将被认为“更大”
-        """
-        return self.priority < other.priority
-
-    @staticmethod
-    def get_event_kind(event_type: Union[EventType, ChainEventType]) -> str:
-        """
-        根据事件类型判断事件是广播事件还是链式事件
-        :param event_type: 事件类型，支持 EventType 或 ChainEventType
-        :return: 返回 Broadcast Event 或 Chain Event
-        """
-        return "Broadcast Event" if isinstance(event_type, EventType) else "Chain Event"
 
 
 class EventManager(metaclass=Singleton):

--- a/app/core/event/models.py
+++ b/app/core/event/models.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+事件值对象与调度常量（从单文件 app/core/event.py 拆出的轻量数据层）。
+
+注意：此处 models 指事件的值对象 Event 与队列/优先级调优常量，**并非数据库模型**；
+仅依赖标准库与 EventType/ChainEventType 枚举，可被只需要 Event 的代码引用而不牵涉管理器逻辑。
+"""
+import uuid
+from typing import Dict, Optional, Union
+
+from app.schemas import ChainEventData
+from app.schemas.types import ChainEventType, EventType
+
+DEFAULT_EVENT_PRIORITY = 10  # 事件的默认优先级
+MIN_EVENT_CONSUMER_THREADS = 1  # 最小事件消费者线程数
+INITIAL_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS = 1  # 事件队列空闲时的初始超时时间（秒）
+MAX_EVENT_QUEUE_IDLE_TIMEOUT_SECONDS = 5  # 事件队列空闲时的最大超时时间（秒）
+
+
+class Event:
+    """
+    事件类，封装事件的基本信息
+    """
+
+    def __init__(self, event_type: Union[EventType, ChainEventType],
+                 event_data: Optional[Union[Dict, ChainEventData]] = None,
+                 priority: Optional[int] = DEFAULT_EVENT_PRIORITY):
+        """
+        :param event_type: 事件的类型，支持 EventType 或 ChainEventType
+        :param event_data: 可选，事件携带的数据，默认为空字典
+        :param priority: 可选，事件的优先级，默认为 10
+        """
+        self.event_id = str(uuid.uuid4())  # 事件ID
+        self.event_type = event_type  # 事件类型
+        self.event_data = event_data or {}  # 事件数据
+        self.priority = priority  # 事件优先级
+
+    def __repr__(self) -> str:
+        """
+        重写 __repr__ 方法，用于返回事件的详细信息，包括事件类型、事件ID和优先级
+        """
+        event_kind = Event.get_event_kind(self.event_type)
+        return f"<{event_kind}: {self.event_type.value}, ID: {self.event_id}, Priority: {self.priority}>"
+
+    def __lt__(self, other):
+        """
+        定义事件对象的比较规则，基于优先级比较
+        优先级小的事件会被认为“更小”，优先级高的事件将被认为“更大”
+        """
+        return self.priority < other.priority
+
+    @staticmethod
+    def get_event_kind(event_type: Union[EventType, ChainEventType]) -> str:
+        """
+        根据事件类型判断事件是广播事件还是链式事件
+        :param event_type: 事件类型，支持 EventType 或 ChainEventType
+        :return: 返回 Broadcast Event 或 Chain Event
+        """
+        return "Broadcast Event" if isinstance(event_type, EventType) else "Chain Event"


### PR DESCRIPTION
## 背景

继 `app/core/module.py` 包化（#74）后，对同为单文件巨类的 `app/core/event.py`（758 行）做相同处理。对外**公共 API 与导入时机零改动**（`from app.core.event import eventmanager / Event / EventManager` 共 40+ 处不变）。

## 拆分

```
app/core/event/
  __init__.py   急切再导出 Event / EventManager / eventmanager / 调度常量
  models.py     事件值对象 Event + 4 个队列/优先级调优常量（轻量数据层）
  manager.py    EventManager（订阅/广播/链式调度）+ 全局单例 eventmanager
```

## 设计取舍

- **EventManager 整类保留在 manager.py**：它是单个强状态耦合类（`__broadcast_subscribers`/`__lock`/`__event_queue` 等私有态贯穿全部方法），且大量 `__` 名称改写——用 mixin 跨文件拆会触发名称改写错位（`_Mixin__x` ≠ `_EventManager__x`）而破坏。故只剥离独立的 `Event` 值对象，不强拆 manager。
- **`__init__` 急切再导出而非懒加载**：历史单文件在 import 期即构造全局单例 `eventmanager`，且无「需独立轻量 import 子模块」的不变量（与 #74 的 `loader` 不同）。急切再导出保持导入行为与单例构造时机与历史**完全一致**。
- **`__get_class_instance` 的 `globals()` 全局处理器查找**迁入 manager.py 后行为不变：原 event.py 顶层 import 均为工具类、无真实事件处理器类，该分支实际总走动态导入回退。

## 验证

- 导入冒烟：公共 API 全可用；`eventmanager` 为 import 期已构造的 `EventManager` 单例且 `EventManager()` 复用同一实例；`models.Event`/`manager.Event`/包 `Event` 同一类对象；`inspect.getsource(app.core.event)` 不含 `app.helper.thread`（满足 `test_core_thread_relocation`）。
- 全量测试 **1713 passed / 19 skipped**，零回归。