### PR TITLE
feat(datasource): 识别/数据源域三层化（IMediaRecognize + MediaRecognizeManager 门面）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -19,6 +19,7 @@ from app.core.module import ModuleManager
 from app.helper.downloader_manager import DownloaderManager
 from app.helper.mediaserver_manager import MediaServerManager
 from app.helper.notification_manager import NotificationManager
+from app.helper.mediarecognize_manager import MediaRecognizeManager
 from app.helper.plugin_manager import PluginManager
 from app.db.message_oper import MessageOper
 from app.db.user_oper import UserOper
@@ -66,6 +67,7 @@ class ChainBase(metaclass=ABCMeta):
         downloadermanager=None,
         mediaservermanager=None,
         notificationmanager=None,
+        mediarecognizemanager=None,
         eventmanager=None,
         messageoper=None,
         messagehelper=None,
@@ -88,6 +90,8 @@ class ChainBase(metaclass=ABCMeta):
         # 媒体服务器（MediaServer 域）门面：媒服相关包装方法经此分发，取代 run_module 字符串 ABI。
         self.mediaservermanager = mediaservermanager or MediaServerManager()
         self.notificationmanager = notificationmanager or NotificationManager()
+        # 媒体识别/数据源（MediaRecognize 域）门面：识别相关包装方法经此分发，取代 run_module 字符串 ABI。
+        self.mediarecognizemanager = mediarecognizemanager or MediaRecognizeManager()
         self.eventmanager = eventmanager or EventManager()
         self.messageoper = messageoper or MessageOper()
         self.messagehelper = messagehelper or MessageHelper()
@@ -852,7 +856,8 @@ class ChainBase(metaclass=ABCMeta):
         :param mediainfo:  识别的媒体信息
         :return: 更新后的媒体信息
         """
-        return self.run_module("obtain_images", mediainfo=mediainfo)
+        # 走识别域门面（MediaRecognizeManager），等价于 v2 run_module("obtain_images")（保留可用、标废弃）
+        return self.mediarecognizemanager.obtain_images(mediainfo=mediainfo)
 
     async def async_obtain_images(self, mediainfo: MediaInfo) -> Optional[MediaInfo]:
         """
@@ -860,7 +865,7 @@ class ChainBase(metaclass=ABCMeta):
         :param mediainfo:  识别的媒体信息
         :return: 更新后的媒体信息
         """
-        return await self.async_run_module("async_obtain_images", mediainfo=mediainfo)
+        return await self.mediarecognizemanager.async_obtain_images(mediainfo=mediainfo)
 
     def obtain_specific_image(
             self,
@@ -1016,7 +1021,7 @@ class ChainBase(metaclass=ABCMeta):
         :param meta:  识别的元数据
         :reutrn: 媒体信息列表
         """
-        return self.run_module("search_medias", meta=meta)
+        return self.mediarecognizemanager.search_medias(meta=meta)
 
     async def async_search_medias(self, meta: MetaBase) -> Optional[List[MediaInfo]]:
         """
@@ -1024,35 +1029,35 @@ class ChainBase(metaclass=ABCMeta):
         :param meta:  识别的元数据
         :reutrn: 媒体信息列表
         """
-        return await self.async_run_module("async_search_medias", meta=meta)
+        return await self.mediarecognizemanager.async_search_medias(meta=meta)
 
     def search_persons(self, name: str) -> Optional[List[MediaPerson]]:
         """
         搜索人物信息
         :param name:  人物名称
         """
-        return self.run_module("search_persons", name=name)
+        return self.mediarecognizemanager.search_persons(name=name)
 
     async def async_search_persons(self, name: str) -> Optional[List[MediaPerson]]:
         """
         搜索人物信息（异步版本）
         :param name:  人物名称
         """
-        return await self.async_run_module("async_search_persons", name=name)
+        return await self.mediarecognizemanager.async_search_persons(name=name)
 
     def search_collections(self, name: str) -> Optional[List[MediaInfo]]:
         """
         搜索集合信息
         :param name:  集合名称
         """
-        return self.run_module("search_collections", name=name)
+        return self.mediarecognizemanager.search_collections(name=name)
 
     async def async_search_collections(self, name: str) -> Optional[List[MediaInfo]]:
         """
         搜索集合信息（异步版本）
         :param name:  集合名称
         """
-        return await self.async_run_module("async_search_collections", name=name)
+        return await self.mediarecognizemanager.async_search_collections(name=name)
 
     def get_search_page_size(
             self,

--- a/app/helper/mediarecognize_manager.py
+++ b/app/helper/mediarecognize_manager.py
@@ -1,0 +1,303 @@
+import traceback
+from typing import Any, List, Optional
+
+from fastapi.concurrency import run_in_threadpool
+
+from app.core.event import eventmanager
+from app.core.module import ModuleManager
+from app.helper.message import MessageHelper
+from app.log import logger
+from app.schemas.exception import RateLimitExceededException
+from app.schemas.types import EventType
+from app.utils.object import ObjectUtils
+from app.utils.singleton import Singleton
+
+
+class MediaRecognizeManager(metaclass=Singleton):
+    """
+    媒体识别 / 数据源（MediaRecognize 域）门面。
+
+    对照下载器 DownloaderManager / 媒服 MediaServerManager / 通知 NotificationManager：把"识别/数据源"
+    领域升级为"门面 + 后端"模式——对外提供实现 app.modules.IMediaRecognize 契约的类型化统一方法，对内
+    按方法名分发到所有数据源后端（内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经 provides_data_sources()
+    注册的源）。
+
+    **派发语义——管道（pipeline）**：识别是跨源管道域，`recognize_media` 等方法的返回值在源之间**流转**
+    （`check_signature` 分支：上一源的非空结果与下一源方法签名一致时作为入参传入，逐源精化）；search_*
+    等列表方法跨源 extend 合并；首个非空非列表结果短路。这与通知（广播）、下载器（取首个非空）不同，
+    但**统一由复刻 run_module 的 dispatch 内核表达**（is_valid_empty / check_signature / list extend / break
+    四分支正是管道语义的载体）。
+
+    **复刻完整 run_module（插件劫持面 + 系统面）以兼容 v2 现存插件**：识别域历史上存在 v2 插件经
+    get_module() 劫持 recognize_media 等方法槽以接入自定义识别源。为兼容这些插件，dispatch/async_dispatch
+    **完整复刻** ChainBase.run_module / async_run_module = 插件劫持面 + 系统面，成为其 byte-equivalent
+    drop-in。**v2 兼容路径保留**：内建数据源仍作为 _ModuleBase 模块注册，run_module 字符串分发仍可用
+    （标 v2 兼容、计划后续废弃）。门面只作为新代码的首选类型化入口叠加其上。
+    """
+
+    def __init__(self):
+        self._modulemanager = ModuleManager()
+        self._messagehelper = MessageHelper()
+
+    # ------------------------------------------------------------------ #
+    # 错误/空值处理（与 ChainBase 对外可见行为一致）
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _is_valid_empty(ret: Any) -> bool:
+        """与 ChainBase.__is_valid_empty 同义：元组要求全 None，否则判 is None。"""
+        if isinstance(ret, tuple):
+            return all(value is None for value in ret)
+        return ret is None
+
+    def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
+                             method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_system_error。"""
+        if raise_exception:
+            raise err
+        logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{module_name}发生了错误", message=str(err), role="system")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "module",
+                "module_id": module_id,
+                "module_name": module_name,
+                "module_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    def _handle_plugin_error(self, err: Exception, plugin_id: str, plugin_name: str,
+                            method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_plugin_error。"""
+        if raise_exception:
+            raise err
+        logger.error(f"运行插件 {plugin_id} 模块 {method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{plugin_name} 发生了错误", message=str(err), role="plugin")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "plugin",
+                "plugin_id": plugin_id,
+                "plugin_name": plugin_name,
+                "plugin_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    @staticmethod
+    def _handle_rate_limit_error(err: RateLimitExceededException, owner: str, ident: str,
+                                 method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_rate_limit_error：raise 或 仅 INFO。"""
+        if raise_exception:
+            raise err
+        logger.info(f"{owner} {ident}.{method} 已限流，跳过执行：{str(err)}")
+
+    # ------------------------------------------------------------------ #
+    # 同步分发内核：复刻 ChainBase.run_module（插件劫持面 + 系统面）
+    # ------------------------------------------------------------------ #
+
+    def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """复刻 ChainBase.__execute_plugin_modules。"""
+        from app.helper.plugin_manager import PluginManager
+        # 插件劫持面与 run_module 一致：raise_exception 透传给插件 func；系统面沿用 pop 语义。
+        plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
+        for plugin, module_dict in PluginManager().get_plugin_modules().items():
+            plugin_id, plugin_name = plugin
+            if method not in module_dict:
+                continue
+            func = module_dict[method]
+            if not func:
+                continue
+            logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
+            try:
+                if self._is_valid_empty(result):
+                    result = func(*args, **plugin_kwargs)
+                elif isinstance(result, list):
+                    temp = func(*args, **plugin_kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "插件", plugin_id, method, raise_exception)
+            except Exception as err:
+                self._handle_plugin_error(err, plugin_id, plugin_name, method, raise_exception)
+        return result
+
+    def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """复刻 ChainBase.__execute_system_modules：管道语义的载体（check_signature 透传结果）。"""
+        logger.debug(f"请求系统模块执行：{method} ...")
+        for module in sorted(
+                self._modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            try:
+                func = getattr(module, method)
+                if self._is_valid_empty(result):
+                    result = func(*args, **kwargs)
+                elif ObjectUtils.check_signature(func, result):
+                    result = func(result)
+                elif isinstance(result, list):
+                    temp = func(*args, **kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "模块", module_id, method, raise_exception)
+            except Exception as err:
+                logger.error(traceback.format_exc())
+                self._handle_system_error(err, module_id, module_name, method, raise_exception)
+        return result
+
+    def dispatch(self, method: str, *args, **kwargs) -> Any:
+        """识别方法分发（run_module 的 byte-equivalent drop-in）：先插件劫持面、非空非列表短路、再系统面。"""
+        raise_exception = bool(kwargs.pop("raise_exception", False))
+        result: Any = None
+        result = self._dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
+        if not self._is_valid_empty(result) and not isinstance(result, list):
+            return result
+        return self._dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
+
+    # ------------------------------------------------------------------ #
+    # 异步分发内核：复刻 ChainBase.async_run_module（异步插件面 + 异步系统面）
+    # ------------------------------------------------------------------ #
+
+    async def _async_dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
+                                             *args, **kwargs) -> Any:
+        """复刻 ChainBase.__async_execute_plugin_modules（同步插件 func 经线程池避免阻塞事件循环）。"""
+        import inspect
+        from app.helper.plugin_manager import PluginManager
+        plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
+        for plugin, module_dict in PluginManager().get_plugin_modules().items():
+            plugin_id, plugin_name = plugin
+            if method not in module_dict:
+                continue
+            func = module_dict[method]
+            if not func:
+                continue
+            logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
+            try:
+                if self._is_valid_empty(result):
+                    if inspect.iscoroutinefunction(func):
+                        result = await func(*args, **plugin_kwargs)
+                    else:
+                        result = await run_in_threadpool(func, *args, **plugin_kwargs)
+                elif isinstance(result, list):
+                    if inspect.iscoroutinefunction(func):
+                        temp = await func(*args, **plugin_kwargs)
+                    else:
+                        temp = await run_in_threadpool(func, *args, **plugin_kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "插件", plugin_id, method, raise_exception)
+            except Exception as err:
+                self._handle_plugin_error(err, plugin_id, plugin_name, method, raise_exception)
+        return result
+
+    async def _async_dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
+                                             *args, **kwargs) -> Any:
+        """复刻 ChainBase.__async_execute_system_modules（同步系统模块经线程池）。"""
+        import inspect
+        logger.debug(f"请求系统模块执行：{method} ...")
+        for module in sorted(
+                self._modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            try:
+                func = getattr(module, method)
+                if self._is_valid_empty(result):
+                    if inspect.iscoroutinefunction(func):
+                        result = await func(*args, **kwargs)
+                    else:
+                        result = await run_in_threadpool(func, *args, **kwargs)
+                elif ObjectUtils.check_signature(func, result):
+                    if inspect.iscoroutinefunction(func):
+                        result = await func(result)
+                    else:
+                        result = await run_in_threadpool(func, result)
+                elif isinstance(result, list):
+                    if inspect.iscoroutinefunction(func):
+                        temp = await func(*args, **kwargs)
+                    else:
+                        temp = await run_in_threadpool(func, *args, **kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "模块", module_id, method, raise_exception)
+            except Exception as err:
+                logger.error(traceback.format_exc())
+                self._handle_system_error(err, module_id, module_name, method, raise_exception)
+        return result
+
+    async def async_dispatch(self, method: str, *args, **kwargs) -> Any:
+        """识别方法异步分发（async_run_module 的 byte-equivalent drop-in）。"""
+        raise_exception = bool(kwargs.pop("raise_exception", False))
+        result: Any = None
+        result = await self._async_dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
+        if not self._is_valid_empty(result) and not isinstance(result, list):
+            return result
+        return await self._async_dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
+
+    # ------------------------------------------------------------------ #
+    # IMediaRecognize 对外面：按方法名转发到 dispatch / async_dispatch。
+    # ------------------------------------------------------------------ #
+
+    def recognize_media(self, *args, **kwargs) -> Any:
+        """识别媒体信息（跨源管道，逐源精化）。"""
+        return self.dispatch("recognize_media", *args, **kwargs)
+
+    def search_medias(self, *args, **kwargs) -> Optional[List[Any]]:
+        """搜索媒体信息（跨源 extend 合并）。"""
+        return self.dispatch("search_medias", *args, **kwargs)
+
+    async def async_search_medias(self, *args, **kwargs) -> Optional[List[Any]]:
+        """异步搜索媒体信息。"""
+        return await self.async_dispatch("async_search_medias", *args, **kwargs)
+
+    def search_persons(self, *args, **kwargs) -> Optional[List[Any]]:
+        """搜索人物。"""
+        return self.dispatch("search_persons", *args, **kwargs)
+
+    async def async_search_persons(self, *args, **kwargs) -> Optional[List[Any]]:
+        """异步搜索人物。"""
+        return await self.async_dispatch("async_search_persons", *args, **kwargs)
+
+    def search_collections(self, *args, **kwargs) -> Optional[List[Any]]:
+        """搜索系列/合集。"""
+        return self.dispatch("search_collections", *args, **kwargs)
+
+    async def async_search_collections(self, *args, **kwargs) -> Optional[List[Any]]:
+        """异步搜索系列/合集。"""
+        return await self.async_dispatch("async_search_collections", *args, **kwargs)
+
+    def obtain_images(self, *args, **kwargs) -> Any:
+        """补充获取媒体图片（跨源精化）。"""
+        return self.dispatch("obtain_images", *args, **kwargs)
+
+    async def async_obtain_images(self, *args, **kwargs) -> Any:
+        """异步补充获取媒体图片。"""
+        return await self.async_dispatch("async_obtain_images", *args, **kwargs)

--- a/app/helper/mediarecognize_manager.py
+++ b/app/helper/mediarecognize_manager.py
@@ -113,8 +113,8 @@ class MediaRecognizeManager(metaclass=Singleton):
             func = module_dict[method]
             if not func:
                 continue
-            logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
             try:
+                logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
                 if self._is_valid_empty(result):
                     result = func(*args, **plugin_kwargs)
                 elif isinstance(result, list):
@@ -188,8 +188,8 @@ class MediaRecognizeManager(metaclass=Singleton):
             func = module_dict[method]
             if not func:
                 continue
-            logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
             try:
+                logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
                 if self._is_valid_empty(result):
                     if inspect.iscoroutinefunction(func):
                         result = await func(*args, **plugin_kwargs)

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -596,3 +596,39 @@ class INotification(Protocol):
     def send_direct_message(self, message: "Notification") -> "Optional[MessageResponse]": ...
 
     def finalize_message(self, response: "MessageResponse") -> Optional[bool]: ...
+
+
+@runtime_checkable
+class IMediaRecognize(Protocol):
+    """
+    媒体识别 / 数据源（MediaRecognize 域）行为接口契约。
+
+    对照下载器 IDownloader / 媒服 IMediaServer / 通知 INotification / 存储 StorageBase：声明门面
+    app.helper.mediarecognize_manager.MediaRecognizeManager 统一对外暴露、并按方法名分发到各数据源后端
+    （内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经 provides_data_sources() 注册的源）的识别操作面。
+    采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足契约，无需显式继承。
+
+    派发语义——**管道（pipeline）**：recognize_media 等方法的返回值在源之间流转、逐源精化；search_* 列表
+    方法跨源 extend 合并；首个非空非列表结果短路。后端按需实现子集（如 Bangumi 缺 obtain_images、
+    TheTvDb 仅实现 tvdb_info），按方法名分发自然只命中实现者——故下列方法均非强制实现。
+    异步变体（async_*）与同步同义，门面经 async_dispatch 分发。
+    """
+
+    def recognize_media(self, meta: "MetaBase" = None, mtype: "MediaType" = None,
+                        tmdbid: Optional[int] = None, doubanid: Optional[str] = None,
+                        bangumiid: Optional[int] = None, **kwargs) -> "Optional[MediaInfo]": ...
+
+    def search_medias(self, meta: "MetaBase") -> "Optional[List[MediaInfo]]": ...
+
+    def search_persons(self, name: str) -> "Optional[List[MediaPerson]]": ...
+
+    def search_collections(self, name: str) -> "Optional[List[MediaInfo]]": ...
+
+    def obtain_images(self, mediainfo: "MediaInfo") -> "Optional[MediaInfo]": ...
+
+    def obtain_specific_image(self, mediaid: Union[str, int], mtype: "MediaType",
+                              **kwargs) -> Optional[str]: ...
+
+    def metadata_nfo(self, meta: "MetaBase", mediainfo: "MediaInfo", **kwargs) -> Optional[str]: ...
+
+    def media_category(self) -> Optional[Dict[str, list]]: ...

--- a/tests/test_datasource_facade.py
+++ b/tests/test_datasource_facade.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+识别/数据源域门面（MediaRecognizeManager）回归：证明 dispatch/async_dispatch 与 ChainBase.run_module/
+async_run_module 语义等价。识别是**管道域**：search_* 列表跨源 extend；非列表非空结果短路（首源识别成功
+即止）；插件劫持面优先。门面完整复刻 run_module（插件+系统面）以兼容 v2 经 get_module 劫持的识别插件。
+"""
+import asyncio
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from app.helper.mediarecognize_manager import MediaRecognizeManager
+from app.schemas.exception import RateLimitExceededException
+
+
+class _FakeModule:
+    """伪数据源后端：任意方法名合成为记录调用的可调用对象。"""
+
+    def __init__(self, name, priority=0, results=None, raises=None):
+        self._name = name
+        self._priority = priority
+        self._results = results or {}
+        self._raises = raises or {}
+        self.calls = []
+
+    def get_priority(self):
+        return self._priority
+
+    def get_name(self):
+        return self._name
+
+    def __getattr__(self, method):
+        if method.startswith("_") or method in ("get_priority", "get_name"):
+            raise AttributeError(method)
+
+        def _call(*args, **kwargs):
+            self.calls.append(method)
+            if method in self._raises:
+                raise self._raises[method]
+            return self._results.get(method)
+
+        return _call
+
+
+def _mgr(system_modules, plugin_modules=None):
+    mgr = MediaRecognizeManager()
+    fake_mm = MagicMock()
+    fake_mm.get_running_modules.return_value = list(system_modules)
+    mgr._modulemanager = fake_mm
+    pm = MagicMock()
+    pm.return_value.get_plugin_modules.return_value = plugin_modules or {}
+    return mgr, pm
+
+
+class MediaRecognizeFacadeTest(TestCase):
+
+    def test_search_medias_extends_across_sources(self):
+        a = _FakeModule("A", priority=0, results={"search_medias": [1, 2]})
+        b = _FakeModule("B", priority=1, results={"search_medias": [3]})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.search_medias(meta="m")
+        self.assertEqual(ret, [1, 2, 3])  # 跨源 extend 合并
+
+    def test_recognize_first_nonempty_scalar_short_circuits(self):
+        # 非列表非空结果 → 短路（首源识别成功即止，后续源不再执行）
+        a = _FakeModule("A", priority=0, results={"recognize_media": "movie"})
+        b = _FakeModule("B", priority=1, results={"recognize_media": "should-not-run"})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.recognize_media(meta="m")
+        self.assertEqual(ret, "movie")
+        self.assertEqual(b.calls, [])
+
+    def test_plugin_hijack_runs_first_and_short_circuits(self):
+        sysmod = _FakeModule("Sys", results={"recognize_media": "sys"})
+        hijack = MagicMock(return_value="plugin")
+        plugins = {("pid", "P"): {"recognize_media": hijack}}
+        mgr, pm = _mgr([sysmod], plugins)
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.recognize_media(meta="m")
+        self.assertEqual(ret, "plugin")            # 插件劫持优先且短路
+        self.assertEqual(sysmod.calls, [])
+
+    def test_async_search_medias_extends_across_sources(self):
+        a = _FakeModule("A", priority=0, results={"async_search_medias": [1]})
+        b = _FakeModule("B", priority=1, results={"async_search_medias": [2]})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = asyncio.run(mgr.async_search_medias(meta="m"))
+        self.assertEqual(ret, [1, 2])              # 异步跨源 extend（同步源经线程池）
+
+    def test_async_obtain_images_first_nonempty_short_circuits(self):
+        a = _FakeModule("A", priority=0, results={"async_obtain_images": "img"})
+        b = _FakeModule("B", priority=1, results={"async_obtain_images": "nope"})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = asyncio.run(mgr.async_obtain_images(mediainfo="x"))
+        self.assertEqual(ret, "img")
+        self.assertEqual(b.calls, [])
+
+    def test_rate_limit_skipped_quietly(self):
+        a = _FakeModule("A", raises={"search_medias": RateLimitExceededException("limited")})
+        b = _FakeModule("B", results={"search_medias": [9]})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.search_medias(meta="m")        # 不抛出，限流源跳过
+        self.assertEqual(ret, [9])
+
+    def test_exception_isolated_and_continues(self):
+        a = _FakeModule("A", raises={"search_medias": RuntimeError("boom")})
+        b = _FakeModule("B", results={"search_medias": [7]})
+        mgr, pm = _mgr([a, b])
+        with patch("app.helper.plugin_manager.PluginManager", pm), \
+                patch.object(MediaRecognizeManager, "_handle_system_error") as he:
+            ret = mgr.search_medias(meta="m")
+        he.assert_called_once()
+        self.assertEqual(ret, [7])                   # 异常源被隔离，其它源续跑
+
+    def test_raise_exception_propagates(self):
+        a = _FakeModule("A", raises={"recognize_media": RuntimeError("boom")})
+        mgr, pm = _mgr([a])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            with self.assertRaises(RuntimeError):
+                mgr.recognize_media(meta="m", raise_exception=True)
+
+    def test_plugin_func_receives_raise_exception(self):
+        hijack = MagicMock(return_value=None)
+        plugins = {("pid", "P"): {"recognize_media": hijack}}
+        mgr, pm = _mgr([_FakeModule("Sys")], plugins)
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            mgr.recognize_media(meta="m", raise_exception=True)
+        self.assertTrue(hijack.call_args.kwargs.get("raise_exception"))


### PR DESCRIPTION
## 背景

按「契约接口 + 注册工厂 + 门面管理器」三层目标架构，把 MediaRecognize（识别/数据源）域补齐（与下载器 #63 / 媒服 #68 / 通知 #76 对齐）。

## 三层

- **契约**：`app/modules/IMediaRecognize`（runtime_checkable Protocol：recognize_media / search_medias / search_persons / search_collections / obtain_images / obtain_specific_image / metadata_nfo / media_category；后端实现子集，如 Bangumi 缺 obtain_images）。
- **注册**：已有 `provides_data_sources` + `verify_data_source_contract`（#61）。
- **门面**：`app/helper/mediarecognize_manager.MediaRecognizeManager(Singleton)`。

## 派发语义——管道（pipeline）

recognize_media 返回值**跨源流转、逐源精化**（`check_signature` 透传上源结果）；search_* 列表**跨源 extend**；首个非空非列表结果短路。统一由复刻 run_module 的 dispatch 内核表达（is_valid_empty / check_signature / list extend / break 四分支即管道载体）。

## 双核 + v2 兼容

门面 **sync `dispatch` + async `async_dispatch` 双核**，均**完整复刻** run_module / async_run_module（插件劫持面 + 系统面），成为其 byte-equivalent drop-in，以兼容 v2 经 get_module 劫持识别源的现存插件。插件 func 透传 raise_exception（与 run_module 一致）、系统面 pop（后端可能无该形参）。

## ChainBase 接线（本 PR 范围）

- DI 注入 `mediarecognizemanager`（keyword-only，默认全局单例，零插件破坏）；
- `search_medias` / `search_persons` / `search_collections` / `obtain_images` 及其 **async 变体**（共 8 个干净单行跨源查询方法）改走门面；
- v2 `run_module` 路径全程保留可用、注释标废弃；
- `recognize_media`（多行+缓存包裹）/ `metadata_nfo` / category 等留 run_module 作紧随增量。

## 验证

- `test_datasource_facade` 9 例：跨源 extend / 首非空短路 / 插件劫持优先 / **async extend + 短路** / 限流跳过 / 异常隔离 / raise 透传 / 插件收 raise_exception。
- 全量 **1730 passed / 19 skipped**。