### PR TITLE
feat(storage): 储存域门面 StorageManager（补齐储存真三层，清双层派发）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -20,6 +20,7 @@ from app.helper.downloader_manager import DownloaderManager
 from app.helper.mediaserver_manager import MediaServerManager
 from app.helper.notification_manager import NotificationManager
 from app.helper.mediarecognize_manager import MediaRecognizeManager
+from app.helper.storage_manager import StorageManager
 from app.helper.plugin_manager import PluginManager
 from app.db.message_oper import MessageOper
 from app.db.user_oper import UserOper
@@ -68,6 +69,7 @@ class ChainBase(metaclass=ABCMeta):
         mediaservermanager=None,
         notificationmanager=None,
         mediarecognizemanager=None,
+        storagemanager=None,
         eventmanager=None,
         messageoper=None,
         messagehelper=None,
@@ -92,6 +94,8 @@ class ChainBase(metaclass=ABCMeta):
         self.notificationmanager = notificationmanager or NotificationManager()
         # 媒体识别/数据源（MediaRecognize 域）门面：识别相关包装方法经此分发，取代 run_module 字符串 ABI。
         self.mediarecognizemanager = mediarecognizemanager or MediaRecognizeManager()
+        # 存储（Storage 域）门面：储存相关包装方法经此分发，取代 run_module → 唯一 FileManagerModule 的双层派发。
+        self.storagemanager = storagemanager or StorageManager()
         self.eventmanager = eventmanager or EventManager()
         self.messageoper = messageoper or MessageOper()
         self.messagehelper = messagehelper or MessageHelper()

--- a/app/chain/storage.py
+++ b/app/chain/storage.py
@@ -17,55 +17,55 @@ class StorageChain(ChainBase):
         """
         保存存储配置
         """
-        self.run_module("save_config", storage=storage, conf=conf)
+        self.storagemanager.save_config(storage=storage, conf=conf)
 
     def reset_config(self, storage: str) -> None:
         """
         重置存储配置
         """
-        self.run_module("reset_config", storage=storage)
+        self.storagemanager.reset_config(storage=storage)
 
     def generate_qrcode(self, storage: str) -> Optional[Tuple[dict, str]]:
         """
         生成二维码
         """
-        return self.run_module("generate_qrcode", storage=storage)
+        return self.storagemanager.generate_qrcode(storage=storage)
 
     def generate_auth_url(self, storage: str) -> Optional[Tuple[dict, str]]:
         """
         生成 OAuth2 授权 URL
         """
-        return self.run_module("generate_auth_url", storage=storage)
+        return self.storagemanager.generate_auth_url(storage=storage)
 
     def check_login(self, storage: str, **kwargs) -> Optional[Tuple[dict, str]]:
         """
         登录确认
         """
-        return self.run_module("check_login", storage=storage, **kwargs)
+        return self.storagemanager.check_login(storage=storage, **kwargs)
 
     def list_files(self, fileitem: schemas.FileItem, recursion: bool = False) -> Optional[List[schemas.FileItem]]:
         """
         查询当前目录下所有目录和文件
         """
-        return self.run_module("list_files", fileitem=fileitem, recursion=recursion)
+        return self.storagemanager.list_files(fileitem=fileitem, recursion=recursion)
 
     def any_files(self, fileitem: schemas.FileItem, extensions: list = None) -> Optional[bool]:
         """
         查询当前目录下是否存在指定扩展名任意文件
         """
-        return self.run_module("any_files", fileitem=fileitem, extensions=extensions)
+        return self.storagemanager.any_files(fileitem=fileitem, extensions=extensions)
 
     def create_folder(self, fileitem: schemas.FileItem, name: str) -> Optional[schemas.FileItem]:
         """
         创建目录
         """
-        return self.run_module("create_folder", fileitem=fileitem, name=name)
+        return self.storagemanager.create_folder(fileitem=fileitem, name=name)
 
     def get_folder(self, storage: str, path: Path) -> Optional[schemas.FileItem]:
         """
         获取目录，不存在则递归创建
         """
-        return self.run_module("get_folder", storage=storage, path=path)
+        return self.storagemanager.get_folder(storage=storage, path=path)
 
     def download_file(self, fileitem: schemas.FileItem, path: Path = None) -> Optional[Path]:
         """
@@ -73,7 +73,7 @@ class StorageChain(ChainBase):
         :param fileitem: 文件项
         :param path: 本地保存路径
         """
-        return self.run_module("download_file", fileitem=fileitem, path=path)
+        return self.storagemanager.download_file(fileitem=fileitem, path=path)
 
     def upload_file(self, fileitem: schemas.FileItem, path: Path,
                     new_name: Optional[str] = None) -> Optional[schemas.FileItem]:
@@ -83,19 +83,19 @@ class StorageChain(ChainBase):
         :param path: 本地文件路径
         :param new_name: 新文件名
         """
-        return self.run_module("upload_file", fileitem=fileitem, path=path, new_name=new_name)
+        return self.storagemanager.upload_file(fileitem=fileitem, path=path, new_name=new_name)
 
     def delete_file(self, fileitem: schemas.FileItem) -> Optional[bool]:
         """
         删除文件或目录
         """
-        return self.run_module("delete_file", fileitem=fileitem)
+        return self.storagemanager.delete_file(fileitem=fileitem)
 
     def rename_file(self, fileitem: schemas.FileItem, name: str) -> Optional[bool]:
         """
         重命名文件或目录
         """
-        return self.run_module("rename_file", fileitem=fileitem, name=name)
+        return self.storagemanager.rename_file(fileitem=fileitem, name=name)
 
     def exists(self, fileitem: schemas.FileItem) -> Optional[bool]:
         """
@@ -113,13 +113,13 @@ class StorageChain(ChainBase):
         """
         根据路径获取文件项
         """
-        return self.run_module("get_file_item", storage=storage, path=path)
+        return self.storagemanager.get_file_item(storage=storage, path=path)
 
     def get_parent_item(self, fileitem: schemas.FileItem) -> Optional[schemas.FileItem]:
         """
         获取上级目录项
         """
-        return self.run_module("get_parent_item", fileitem=fileitem)
+        return self.storagemanager.get_parent_item(fileitem=fileitem)
 
     def snapshot_storage(self, storage: str, path: Path,
                          last_snapshot_time: float = None, max_depth: int = 5) -> Optional[Dict[str, Dict]]:
@@ -130,20 +130,20 @@ class StorageChain(ChainBase):
         :param last_snapshot_time: 上次快照时间，用于增量快照
         :param max_depth: 最大递归深度，避免过深遍历
         """
-        return self.run_module("snapshot_storage", storage=storage, path=path,
+        return self.storagemanager.snapshot_storage(storage=storage, path=path,
                                last_snapshot_time=last_snapshot_time, max_depth=max_depth)
 
     def storage_usage(self, storage: str) -> Optional[schemas.StorageUsage]:
         """
         存储使用情况
         """
-        return self.run_module("storage_usage", storage=storage)
+        return self.storagemanager.storage_usage(storage=storage)
 
     def support_transtype(self, storage: str) -> Optional[dict]:
         """
         获取支持的整理方式
         """
-        return self.run_module("support_transtype", storage=storage)
+        return self.storagemanager.support_transtype(storage=storage)
 
     def is_bluray_folder(self, fileitem: Optional[schemas.FileItem]) -> bool:
         """

--- a/app/helper/storage_manager.py
+++ b/app/helper/storage_manager.py
@@ -1,0 +1,238 @@
+import traceback
+from typing import Any, Optional
+
+from app.core.event import eventmanager
+from app.core.module import ModuleManager
+from app.helper.message import MessageHelper
+from app.log import logger
+from app.schemas.exception import RateLimitExceededException
+from app.schemas.types import EventType
+from app.utils.object import ObjectUtils
+from app.utils.singleton import Singleton
+
+
+class StorageManager(metaclass=Singleton):
+    """
+    存储（Storage 域）门面。
+
+    补齐储存域的「三层」末层：储存域的**契约层已是 StorageBase**（16 abstractmethod，全仓最成熟范式）、
+    **注册层已是 storage_registry**（按 schema.value 单索引），但其「门面」角色历史上被**揉进了
+    FileManagerModule 这个 _ModuleBase 模块**里——FileManagerModule 既是被 ModuleManager 扫描的模块、
+    又承担按 schema 路由到 storages/ 后端的聚合。本门面把「门面」从模块中**显式抽出**，与下载器
+    DownloaderManager / 媒服 MediaServerManager / 通知 NotificationManager / 识别 MediaRecognizeManager
+    对齐：StorageChain 直接调本门面，取代 `StorageChain.run_module(...) → 唯一 FileManagerModule` 这层
+    **仪式性的字符串 ABI 双层派发**。
+
+    派发结构：储存域只有一个系统模块 FileManagerModule（schema 路由在其内部完成），故本门面按方法名
+    分发自然命中它；**复刻完整 run_module（插件劫持面 + 系统面）** ——储存/整理域是 v2 插件经 get_module()
+    劫持方法槽的重灾区（如 p115 接入 115 储存），唯有完整复刻才能在改接后零破坏这些劫持插件。dispatch
+    成为 run_module 的 byte-equivalent drop-in。
+
+    **v2 兼容路径保留**：FileManagerModule 仍作为 _ModuleBase 模块注册，StorageChain/ChainBase 的
+    run_module 字符串分发仍可用（标 v2 兼容、计划后续废弃）；schema 路由、storage_registry、StorageBase
+    后端零改动。门面只取代外层字符串派发、不动内层 schema 路由。
+    """
+
+    def __init__(self):
+        self._modulemanager = ModuleManager()
+        self._messagehelper = MessageHelper()
+
+    @staticmethod
+    def _is_valid_empty(ret: Any) -> bool:
+        """与 ChainBase.__is_valid_empty 同义：元组要求全 None，否则判 is None。"""
+        if isinstance(ret, tuple):
+            return all(value is None for value in ret)
+        return ret is None
+
+    def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
+                             method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_system_error。"""
+        if raise_exception:
+            raise err
+        logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{module_name}发生了错误", message=str(err), role="system")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "module",
+                "module_id": module_id,
+                "module_name": module_name,
+                "module_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    def _handle_plugin_error(self, err: Exception, plugin_id: str, plugin_name: str,
+                            method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_plugin_error。"""
+        if raise_exception:
+            raise err
+        logger.error(f"运行插件 {plugin_id} 模块 {method} 出错：{str(err)}\n{traceback.format_exc()}")
+        self._messagehelper.put(title=f"{plugin_name} 发生了错误", message=str(err), role="plugin")
+        eventmanager.send_event(
+            EventType.SystemError,
+            {
+                "type": "plugin",
+                "plugin_id": plugin_id,
+                "plugin_name": plugin_name,
+                "plugin_method": method,
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+        )
+
+    @staticmethod
+    def _handle_rate_limit_error(err: RateLimitExceededException, owner: str, ident: str,
+                                 method: str, raise_exception: bool) -> None:
+        """复刻 ChainBase.__handle_rate_limit_error：raise 或 仅 INFO。"""
+        if raise_exception:
+            raise err
+        logger.info(f"{owner} {ident}.{method} 已限流，跳过执行：{str(err)}")
+
+    def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """复刻 ChainBase.__execute_plugin_modules（储存/整理域 get_module 劫持重灾区）。"""
+        from app.helper.plugin_manager import PluginManager
+        # 插件劫持面与 run_module 一致：raise_exception 透传给插件 func；系统面沿用 pop 语义。
+        plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
+        for plugin, module_dict in PluginManager().get_plugin_modules().items():
+            plugin_id, plugin_name = plugin
+            if method not in module_dict:
+                continue
+            func = module_dict[method]
+            if not func:
+                continue
+            try:
+                logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
+                if self._is_valid_empty(result):
+                    result = func(*args, **plugin_kwargs)
+                elif isinstance(result, list):
+                    temp = func(*args, **plugin_kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "插件", plugin_id, method, raise_exception)
+            except Exception as err:
+                self._handle_plugin_error(err, plugin_id, plugin_name, method, raise_exception)
+        return result
+
+    def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """复刻 ChainBase.__execute_system_modules（储存域系统模块=FileManagerModule，schema 路由在其内部）。"""
+        logger.debug(f"请求系统模块执行：{method} ...")
+        for module in sorted(
+                self._modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            try:
+                func = getattr(module, method)
+                if self._is_valid_empty(result):
+                    result = func(*args, **kwargs)
+                elif ObjectUtils.check_signature(func, result):
+                    result = func(result)
+                elif isinstance(result, list):
+                    temp = func(*args, **kwargs)
+                    if isinstance(temp, list):
+                        result.extend(temp)
+                else:
+                    break
+            except RateLimitExceededException as err:
+                self._handle_rate_limit_error(err, "模块", module_id, method, raise_exception)
+            except Exception as err:
+                logger.error(traceback.format_exc())
+                self._handle_system_error(err, module_id, module_name, method, raise_exception)
+        return result
+
+    def dispatch(self, method: str, *args, **kwargs) -> Any:
+        """储存方法分发（run_module 的 byte-equivalent drop-in）：先插件劫持面、非空非列表短路、再系统面。"""
+        raise_exception = bool(kwargs.pop("raise_exception", False))
+        result: Any = None
+        result = self._dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
+        if not self._is_valid_empty(result) and not isinstance(result, list):
+            return result
+        return self._dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
+
+    # ------------------------------------------------------------------ #
+    # 储存对外面：与 StorageChain 包装方法 / FileManagerModule 方法同名，按方法名转发到 dispatch。
+    # ------------------------------------------------------------------ #
+
+    def save_config(self, *args, **kwargs) -> Any:
+        """保存存储配置。"""
+        return self.dispatch("save_config", *args, **kwargs)
+
+    def reset_config(self, *args, **kwargs) -> Any:
+        """重置存储配置。"""
+        return self.dispatch("reset_config", *args, **kwargs)
+
+    def generate_qrcode(self, *args, **kwargs) -> Optional[dict]:
+        """生成登录二维码。"""
+        return self.dispatch("generate_qrcode", *args, **kwargs)
+
+    def generate_auth_url(self, *args, **kwargs) -> Optional[str]:
+        """生成授权链接。"""
+        return self.dispatch("generate_auth_url", *args, **kwargs)
+
+    def check_login(self, *args, **kwargs) -> Optional[dict]:
+        """检查登录状态。"""
+        return self.dispatch("check_login", *args, **kwargs)
+
+    def list_files(self, *args, **kwargs) -> Any:
+        """浏览目录文件。"""
+        return self.dispatch("list_files", *args, **kwargs)
+
+    def any_files(self, *args, **kwargs) -> Optional[bool]:
+        """判断目录下是否存在指定扩展名的文件。"""
+        return self.dispatch("any_files", *args, **kwargs)
+
+    def create_folder(self, *args, **kwargs) -> Any:
+        """创建目录。"""
+        return self.dispatch("create_folder", *args, **kwargs)
+
+    def get_folder(self, *args, **kwargs) -> Any:
+        """获取目录（不存在则创建）。"""
+        return self.dispatch("get_folder", *args, **kwargs)
+
+    def download_file(self, *args, **kwargs) -> Any:
+        """下载文件。"""
+        return self.dispatch("download_file", *args, **kwargs)
+
+    def upload_file(self, *args, **kwargs) -> Any:
+        """上传文件。"""
+        return self.dispatch("upload_file", *args, **kwargs)
+
+    def delete_file(self, *args, **kwargs) -> Optional[bool]:
+        """删除文件/目录。"""
+        return self.dispatch("delete_file", *args, **kwargs)
+
+    def rename_file(self, *args, **kwargs) -> Optional[bool]:
+        """重命名文件/目录。"""
+        return self.dispatch("rename_file", *args, **kwargs)
+
+    def get_file_item(self, *args, **kwargs) -> Any:
+        """按路径获取文件项。"""
+        return self.dispatch("get_file_item", *args, **kwargs)
+
+    def get_parent_item(self, *args, **kwargs) -> Any:
+        """获取父目录项。"""
+        return self.dispatch("get_parent_item", *args, **kwargs)
+
+    def snapshot_storage(self, *args, **kwargs) -> Any:
+        """存储快照。"""
+        return self.dispatch("snapshot_storage", *args, **kwargs)
+
+    def storage_usage(self, *args, **kwargs) -> Any:
+        """存储使用情况。"""
+        return self.dispatch("storage_usage", *args, **kwargs)
+
+    def support_transtype(self, *args, **kwargs) -> Any:
+        """存储支持的整理方式。"""
+        return self.dispatch("support_transtype", *args, **kwargs)

--- a/tests/test_storage_facade.py
+++ b/tests/test_storage_facade.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+储存域门面（StorageManager）回归：证明 dispatch 与 ChainBase.run_module 语义等价。储存域只有一个系统
+模块 FileManagerModule（schema 路由在其内部），但门面仍**完整复刻 run_module（插件劫持面 + 系统面）**——
+储存/整理域是 v2 插件经 get_module 劫持方法槽的重灾区（如 p115 接入 115），改接后须零破坏这些插件。
+"""
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from app.helper.storage_manager import StorageManager
+from app.schemas.exception import RateLimitExceededException
+
+
+class _FakeModule:
+    """伪储存后端：任意方法名合成为记录调用的可调用对象。"""
+
+    def __init__(self, name, priority=0, results=None, raises=None):
+        self._name = name
+        self._priority = priority
+        self._results = results or {}
+        self._raises = raises or {}
+        self.calls = []
+
+    def get_priority(self):
+        return self._priority
+
+    def get_name(self):
+        return self._name
+
+    def __getattr__(self, method):
+        if method.startswith("_") or method in ("get_priority", "get_name"):
+            raise AttributeError(method)
+
+        def _call(*args, **kwargs):
+            self.calls.append(method)
+            if method in self._raises:
+                raise self._raises[method]
+            return self._results.get(method)
+
+        return _call
+
+
+def _mgr(system_modules, plugin_modules=None):
+    mgr = StorageManager()
+    fake_mm = MagicMock()
+    fake_mm.get_running_modules.return_value = list(system_modules)
+    mgr._modulemanager = fake_mm
+    pm = MagicMock()
+    pm.return_value.get_plugin_modules.return_value = plugin_modules or {}
+    return mgr, pm
+
+
+class StorageFacadeTest(TestCase):
+
+    def test_list_files_dispatches_to_storage_module(self):
+        fm = _FakeModule("FileManager", results={"list_files": ["a", "b"]})
+        mgr, pm = _mgr([fm])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.list_files(fileitem="x", recursion=False)
+        self.assertEqual(ret, ["a", "b"])
+        self.assertEqual(fm.calls, ["list_files"])
+
+    def test_delete_file_first_nonempty_short_circuits(self):
+        fm = _FakeModule("FileManager", results={"delete_file": True})
+        mgr, pm = _mgr([fm])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.delete_file(fileitem="x")
+        self.assertIs(ret, True)
+
+    def test_plugin_hijack_list_extends_system(self):
+        # 储存域 get_module 劫持重灾区：插件劫持 list_files 返回 list → 与系统结果 extend 合并
+        fm = _FakeModule("FileManager", results={"list_files": ["sys"]})
+        hijack = MagicMock(return_value=["plugin"])
+        plugins = {("p115", "P115StrmHelper"): {"list_files": hijack}}
+        mgr, pm = _mgr([fm], plugins)
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.list_files(fileitem="x")
+        self.assertEqual(ret, ["plugin", "sys"])   # 与 run_module 一致：list 不短路、跨面合并
+        self.assertEqual(fm.calls, ["list_files"])
+
+    def test_plugin_hijack_scalar_short_circuits_system(self):
+        fm = _FakeModule("FileManager", results={"delete_file": True})
+        hijack = MagicMock(return_value=False)
+        plugins = {("p115", "P"): {"delete_file": hijack}}
+        mgr, pm = _mgr([fm], plugins)
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.delete_file(fileitem="x")
+        self.assertIs(ret, False)                  # 插件非空非列表 → 短路
+        self.assertEqual(fm.calls, [])
+
+    def test_rate_limit_skipped_quietly(self):
+        fm = _FakeModule("FileManager", raises={"storage_usage": RateLimitExceededException("limited")})
+        mgr, pm = _mgr([fm])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            ret = mgr.storage_usage(storage="u115")   # 不抛出
+        self.assertIsNone(ret)
+
+    def test_exception_isolated(self):
+        fm = _FakeModule("FileManager", raises={"list_files": RuntimeError("boom")})
+        mgr, pm = _mgr([fm])
+        with patch("app.helper.plugin_manager.PluginManager", pm), \
+                patch.object(StorageManager, "_handle_system_error") as he:
+            mgr.list_files(fileitem="x")
+        he.assert_called_once()
+
+    def test_raise_exception_propagates(self):
+        fm = _FakeModule("FileManager", raises={"list_files": RuntimeError("boom")})
+        mgr, pm = _mgr([fm])
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            with self.assertRaises(RuntimeError):
+                mgr.list_files(fileitem="x", raise_exception=True)
+
+    def test_plugin_func_receives_raise_exception(self):
+        hijack = MagicMock(return_value=None)
+        plugins = {("p115", "P"): {"list_files": hijack}}
+        mgr, pm = _mgr([_FakeModule("FileManager")], plugins)
+        with patch("app.helper.plugin_manager.PluginManager", pm):
+            mgr.list_files(fileitem="x", raise_exception=True)
+        self.assertTrue(hijack.call_args.kwargs.get("raise_exception"))


### PR DESCRIPTION
## 背景

兑现储存域「契约接口 + 注册工厂 + 门面管理器」三层的**末层**。储存域的：
- **契约层**已是 `StorageBase`（16 abstractmethod，全仓最成熟范式）
- **注册层**已是 `storage_registry`（schema.value 单索引）

但其「门面」角色历史上被**揉进了 `FileManagerModule` 这个 `_ModuleBase` 模块**（既是被 ModuleManager 扫描的模块、又承担按 schema 路由到 storages/ 后端的聚合）。`FileManagerModule` 其实是 EmbyModule 的平级模块，所以储存**没有**像 MediaServerManager 那样的独立门面。本 PR 把门面从模块**显式抽出**，与下载器 #63 / 媒服 #68 / 通知 #76 / 识别 #77 对齐。

## 变更

- 新增 `app/helper/storage_manager.StorageManager(Singleton)`：`dispatch` **完整复刻 run_module（插件劫持面 + 系统面）**——储存/整理域是 v2 插件经 `get_module()` 劫持方法槽的**重灾区**（如 p115 接入 115 储存），唯有完整复刻才能改接后零破坏这些劫持插件。插件 func 透传 raise_exception、系统面 pop（与 #76/#77 一致）。储存域只有一个系统模块 FileManagerModule，schema 路由在其内部，门面按方法名分发自然命中它。
- ChainBase DI 注入 `storagemanager`（keyword-only，默认全局单例，零插件破坏）。
- `StorageChain` **18 个储存方法**（save_config / list_files / create_folder / download_file / upload_file / delete_file / rename_file / snapshot_storage / storage_usage…）改走门面，取代 `StorageChain.run_module → 唯一 FileManagerModule` 的**仪式性双层派发**（储存 A-档评估标记的待清项）。脚本化机械变换，grep 校验 **0 残留 run_module / 18 storagemanager 调用**。
- v2 `run_module` 路径保留标废弃；schema 路由 / storage_registry / StorageBase 后端**零改动**。
- **无需新 Protocol**（StorageBase 即契约）。

## 验证

- `test_storage_facade` 8 例：派发 / 首非空短路 / 插件劫持 list-extend 与 scalar 短路 / 限流跳过 / 异常隔离 / raise 透传 / 插件收 raise_exception。
- 派发核与已两轮对抗审查通过的 `NotificationManager`（含所有修复）**逐字相同**、纯 sync 无新颖逻辑。
- 全量 **1738 passed / 19 skipped**。