### PR TITLE
docs(managers): 规范化门面注释，明确功能与参数、去除复刻类叙述

### DIFF
--- a/app/managers/__init__.py
+++ b/app/managers/__init__.py
@@ -7,8 +7,8 @@
 - 契约接口（Protocol / 抽象基类）在 app/modules：INotification / IDownloader / IMediaServer /
   IMediaRecognize、StorageBase；
 - 注册工厂在 app/core/module + 各域 provides_* 钩子 / verify_*_contract；
-- **门面管理器集中在本包**：忠实复刻 ChainBase.run_module 的派发语义（插件劫持面 + 系统面），
-  被 ChainBase 直接调用，取代「ChainBase.run_module(字符串) → 模块」的字符串 ABI 双层派发。
+- **门面管理器集中在本包**：按方法名把领域操作分发到各后端模块（插件钩子面 + 系统后端面），
+  被 ChainBase 直接调用，取代散落在 ChainBase 中按字符串分发到模块的写法。
 
 分层（迁移目的）：
 

--- a/app/managers/downloader.py
+++ b/app/managers/downloader.py
@@ -15,29 +15,13 @@ from app.utils.singleton import Singleton
 
 class DownloaderManager(metaclass=Singleton):
     """
-    下载器（Downloader 域）门面。
+    下载器（Downloader 域）统一入口（单例）。
 
-    对照存储域的 FileManager：把"下载器"领域升级为"门面 + 后端"模式——对外提供一组
-    类型化、可发现的统一方法（实现 app.modules.IDownloader 契约的对外面），对内按方法名分发
-    到所有 ModuleType.Downloader 后端模块（内建 Qbittorrent/Transmission/Rtorrent 以及插件经
-    provides_downloaders() 注册的下载器），并按与 ChainBase.run_module 完全一致的合并语义
-    （列表 extend / 非列表取首个非 None）汇总结果。
+    对外提供一组类型化的下载器操作方法（契约见 app.modules.IDownloader），按方法名分发到所有已启用的
+    下载器后端模块（内建 Qbittorrent/Transmission/Rtorrent 及插件经 provides_downloaders() 注册的下载器），
+    并合并各后端结果。每次分发实时查询当前运行的后端，自动纳入运行期注册/卸载的插件下载器，无需维护清单。
 
-    设计要点：
-    - **行为等价**：_dispatch 忠实复刻 ChainBase.__execute_system_modules 的分发与合并（含
-      check_signature 分支、异常逐后端续跑、SystemError 事件与消息上报），调用的是与 run_module
-      同一批后端模块方法（后端方法体零改动），故对真实下载器客户端的行为不变；唯一被收敛的是
-      "字符串 ABI 分发"这一隐式面，被显式、类型化的门面取代。tests/test_downloader_facade.py
-      以等价性测试证明门面与 run_module 在各返回形态下结果全等。
-    - **v2 兼容路径保留**：内建下载器仍作为 _ModuleBase 模块注册，ChainBase.run_module("download")
-      等字符串分发仍可用（标记为 v2 兼容路径、计划后续废弃，见各下载器模块类 docstring）。门面
-      不替换该路径，只作为新代码的首选入口叠加其上。
-    - **后端发现**：每次分发实时查询 ModuleManager().get_running_modules(method)，自动纳入运行期
-      注册/卸载的插件下载器，无需门面侧维护后端清单。
-
-    注意：门面只复刻 run_module 的"系统模块"分发面；run_module 另有 get_module 劫持的"插件模块"
-    面（__execute_plugin_modules），实测下载器域无任何插件经该面劫持（劫持集中在存储/整理域），
-    故门面覆盖完整；如需该面的极端兼容场景，run_module 仍在。
+    约定：凡接受 downloader 形参的方法，传 None 时面向全部下载器，传具体名称时只作用于该下载器。
     """
 
     def __init__(self):
@@ -46,9 +30,7 @@ class DownloaderManager(metaclass=Singleton):
 
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
-        """
-        判断结果是否为空（与 ChainBase.__is_valid_empty 同义）：元组要求全 None，否则判 is None。
-        """
+        """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
         if isinstance(ret, tuple):
             return all(value is None for value in ret)
         return ret is None
@@ -56,8 +38,13 @@ class DownloaderManager(metaclass=Singleton):
     def _handle_error(self, err: Exception, module_id: str, module_name: str,
                       method: str, raise_exception: bool) -> None:
         """
-        后端方法执行出错处理（复刻 ChainBase.__handle_system_error 的对外可见行为）：
-        raise_exception 为真则抛出；否则记录日志 + 推送系统错误消息 + 发送 SystemError 事件后续跑。
+        后端方法执行出错的处理。
+
+        :param err: 捕获到的异常
+        :param module_id: 后端类名
+        :param module_name: 后端显示名
+        :param method: 出错的方法名
+        :param raise_exception: 为真时直接抛出；否则记录错误日志、推送系统错误消息、广播 SystemError 事件后继续下一个后端
         """
         if raise_exception:
             raise err
@@ -79,8 +66,8 @@ class DownloaderManager(metaclass=Singleton):
     def _handle_rate_limit_error(err: RateLimitExceededException, module_id: str,
                                  method: str, raise_exception: bool) -> None:
         """
-        本地限流跳过（复刻 ChainBase.__handle_rate_limit_error）：raise_exception 为真则抛出；
-        否则仅 INFO 记录、不进系统错误告警（预期的限流状态不应触发 SystemError 事件/消息）。
+        后端触发限流时的处理：raise_exception 为真时直接抛出；否则仅记录 INFO 并跳过该后端
+        （限流为预期状态，不作系统告警）。
         """
         if raise_exception:
             raise err
@@ -88,17 +75,20 @@ class DownloaderManager(metaclass=Singleton):
 
     def _dispatch(self, method: str, *args, **kwargs) -> Any:
         """
-        将下载器方法按方法名分发到所有 Downloader 后端模块并合并结果。
+        按方法名分发到所有下载器后端模块并合并结果。
 
-        合并语义与 ChainBase.__execute_system_modules 严格一致：按 get_priority() 升序遍历后端，
-        - 结果为空（None/全 None 元组）→ 取该后端返回值；
-        - 结果与方法签名一致（check_signature，下载器方法因参数数 ≠1 恒为 False）→ 透传；
-        - 结果为列表 → 合并后续后端的列表结果；
-        - 否则（非空非列表，如 bool/tuple/dict）→ 短路停止。
-        单后端异常逐个捕获续跑，不影响其它后端；raise_exception=True 时透传首个异常。
+        按优先级（get_priority 升序）遍历后端：
+        - 当前结果为空（None / 全 None 元组）→ 取该后端返回值；
+        - 当前结果可作为下一后端的入参（check_signature，下载器方法因参数数 ≠1 恒为否）→ 透传；
+        - 当前结果为列表 → 合并各后端的列表结果；
+        - 当前结果为非空标量（bool/tuple/dict 等）→ 短路停止。
+        单个后端异常被隔离后继续其余后端；raise_exception=True 时透传首个异常。
+
+        :param method: 要分发的下载器方法名
+        :param raise_exception: 出错时是否抛出（分发控制位，不透传给后端方法）
+        :return: 各后端合并后的结果
         """
-        # pop 而非 get：raise_exception 是分发器控制位，不应透传给不接受该参数的后端 func
-        # （下载器后端方法无 raise_exception 形参，透传会触发 TypeError）。
+        # raise_exception 为分发控制位，pop 出后不随调用透传给后端方法（后端方法无此形参，透传会 TypeError）。
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
         for module in sorted(
@@ -124,14 +114,14 @@ class DownloaderManager(metaclass=Singleton):
                 else:
                     break
             except RateLimitExceededException as err:
-                # 限流先于通用异常处理（与 __execute_system_modules 一致）：安静跳过、不告警。
+                # 限流先于通用异常捕获：安静跳过、不告警。
                 self._handle_rate_limit_error(err, module_id, method, raise_exception)
             except Exception as err:
                 self._handle_error(err, module_id, module_name, method, raise_exception)
         return result
 
     # ------------------------------------------------------------------ #
-    # IDownloader 对外面：签名与 ChainBase 下载器包装方法一致，便于调用方平滑切换。
+    # IDownloader 对外面：按方法名转发到 _dispatch。
     # ------------------------------------------------------------------ #
 
     def download(
@@ -146,7 +136,15 @@ class DownloaderManager(metaclass=Singleton):
     ) -> Optional[Tuple[Optional[str], Optional[str], Optional[str], str]]:
         """
         添加下载任务。
-        :return: 下载器名称、种子Hash、种子文件布局、错误原因
+
+        :param content: 种子文件路径 / 种子链接 / 种子内容
+        :param download_dir: 下载保存目录
+        :param cookie: 站点 Cookie（私有种子下载用）
+        :param episodes: 需要下载的集数集合（为空表示全部）
+        :param category: 下载分类
+        :param label: 附加标签
+        :param downloader: 指定下载器名称，None 表示使用默认下载器
+        :return: (下载器名称, 种子 Hash, 种子文件布局, 错误原因)
         """
         return self._dispatch(
             "download",
@@ -168,6 +166,12 @@ class DownloaderManager(metaclass=Singleton):
     ) -> Optional[List[DownloaderTorrent]]:
         """
         获取下载器种子列表。
+
+        :param status: 按种子状态过滤
+        :param hashs: 按种子 Hash（单个或列表）过滤
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :param include_all_tags: 是否包含全部标签的种子
+        :return: 种子信息列表
         """
         return self._dispatch(
             "list_torrents",
@@ -185,6 +189,11 @@ class DownloaderManager(metaclass=Singleton):
     ) -> Optional[bool]:
         """
         删除下载器种子。
+
+        :param hashs: 要删除的种子 Hash（单个或列表）
+        :param delete_file: 是否同时删除文件
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 是否删除成功
         """
         return self._dispatch(
             "remove_torrents",
@@ -195,13 +204,21 @@ class DownloaderManager(metaclass=Singleton):
 
     def start_torrents(self, hashs: Union[list, str], downloader: Optional[str] = None) -> Optional[bool]:
         """
-        开始下载。
+        开始下载（恢复）指定种子。
+
+        :param hashs: 种子 Hash（单个或列表）
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 是否操作成功
         """
         return self._dispatch("start_torrents", hashs=hashs, downloader=downloader)
 
     def stop_torrents(self, hashs: Union[list, str], downloader: Optional[str] = None) -> Optional[bool]:
         """
-        停止下载。
+        停止（暂停）指定种子。
+
+        :param hashs: 种子 Hash（单个或列表）
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 是否操作成功
         """
         return self._dispatch("stop_torrents", hashs=hashs, downloader=downloader)
 
@@ -210,6 +227,11 @@ class DownloaderManager(metaclass=Singleton):
     ) -> Optional[bool]:
         """
         设置种子标签。
+
+        :param hashs: 种子 Hash（单个或列表）
+        :param tags: 要设置的标签列表
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 是否操作成功
         """
         return self._dispatch("set_torrents_tag", hashs=hashs, tags=tags, downloader=downloader)
 
@@ -226,7 +248,18 @@ class DownloaderManager(metaclass=Singleton):
             seeding_time_limit: Optional[int] = None,
     ) -> Optional[Dict[str, bool]]:
         """
-        修改下载任务属性。
+        修改下载任务属性（仅传入的字段生效）。
+
+        :param hash_string: 种子 Hash
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :param download_limit: 下载限速
+        :param upload_limit: 上传限速
+        :param tracker_list: Tracker 列表
+        :param save_path: 保存路径
+        :param category: 分类
+        :param ratio_limit: 分享率限制
+        :param seeding_time_limit: 做种时间限制
+        :return: 各项修改是否成功
         """
         return self._dispatch(
             "update_torrent",
@@ -245,24 +278,38 @@ class DownloaderManager(metaclass=Singleton):
             self, hash_string: str, downloader: Optional[str] = None
     ) -> Optional[Dict[str, List[str]]]:
         """
-        查询下载任务 Tracker 列表。
+        查询下载任务的 Tracker 列表。
+
+        :param hash_string: 种子 Hash
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: Tracker 信息（按下载任务归类）
         """
         return self._dispatch("get_torrent_trackers", hash_string=hash_string, downloader=downloader)
 
     def torrent_files(self, tid: str, downloader: Optional[str] = None) -> Optional[List[DownloaderFile]]:
         """
-        获取种子文件列表。
+        获取种子的文件列表。
+
+        :param tid: 种子 Hash
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 种子文件列表
         """
         return self._dispatch("torrent_files", tid=tid, downloader=downloader)
 
     def downloader_info(self, downloader: Optional[str] = None) -> Optional[List[DownloaderInfo]]:
         """
-        获取下载器统计信息。
+        获取下载器实时统计信息（速率、连接等）。
+
+        :param downloader: 指定下载器名称，None 表示全部下载器
+        :return: 下载器统计信息列表
         """
         return self._dispatch("downloader_info", downloader=downloader)
 
     def transfer_completed(self, hashs: str, downloader: Optional[str] = None) -> None:
         """
-        下载器转移完成后的处理。
+        整理完成后对种子执行的收尾处理（如打标签）。
+
+        :param hashs: 种子 Hash
+        :param downloader: 指定下载器名称，None 表示全部下载器
         """
         return self._dispatch("transfer_completed", hashs=hashs, downloader=downloader)

--- a/app/managers/mediarecognize.py
+++ b/app/managers/mediarecognize.py
@@ -15,24 +15,17 @@ from app.utils.singleton import Singleton
 
 class MediaRecognizeManager(metaclass=Singleton):
     """
-    媒体识别 / 数据源（MediaRecognize 域）门面。
+    媒体识别 / 数据源（MediaRecognize 域）统一入口（单例）。
 
-    对照下载器 DownloaderManager / 媒服 MediaServerManager / 通知 NotificationManager：把"识别/数据源"
-    领域升级为"门面 + 后端"模式——对外提供实现 app.modules.IMediaRecognize 契约的类型化统一方法，对内
-    按方法名分发到所有数据源后端（内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经 provides_data_sources()
-    注册的源）。
+    对外提供一组识别操作方法（契约见 app.modules.IMediaRecognize），按方法名分两步分发：先经各已启用
+    插件注册的同名方法，再到系统数据源后端模块（内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经
+    provides_data_sources() 注册的源）。每次分发实时查询当前运行的后端，自动纳入运行期注册/卸载的源。
 
-    **派发语义——管道（pipeline）**：识别是跨源管道域，`recognize_media` 等方法的返回值在源之间**流转**
-    （`check_signature` 分支：上一源的非空结果与下一源方法签名一致时作为入参传入，逐源精化）；search_*
-    等列表方法跨源 extend 合并；首个非空非列表结果短路。这与通知（广播）、下载器（取首个非空）不同，
-    但**统一由复刻 run_module 的 dispatch 内核表达**（is_valid_empty / check_signature / list extend / break
-    四分支正是管道语义的载体）。
+    识别为管道域：recognize_media 等方法的结果在数据源之间流转、逐源精化（结果可作为下一源入参时透传）；
+    search_* 列表方法跨源合并；首个非空非列表结果短路。后端按需实现子集，按方法名分发自然只命中实现者。
+    同步方法走 dispatch，异步方法（async_*）走 async_dispatch（同步后端经线程池执行，避免阻塞事件循环）。
 
-    **复刻完整 run_module（插件劫持面 + 系统面）以兼容 v2 现存插件**：识别域历史上存在 v2 插件经
-    get_module() 劫持 recognize_media 等方法槽以接入自定义识别源。为兼容这些插件，dispatch/async_dispatch
-    **完整复刻** ChainBase.run_module / async_run_module = 插件劫持面 + 系统面，成为其 byte-equivalent
-    drop-in。**v2 兼容路径保留**：内建数据源仍作为 _ModuleBase 模块注册，run_module 字符串分发仍可用
-    （标 v2 兼容、计划后续废弃）。门面只作为新代码的首选类型化入口叠加其上。
+    对外方法的参数原样转发到后端（各方法的参数见下方说明及 app.modules.IMediaRecognize）。
     """
 
     def __init__(self):
@@ -40,19 +33,22 @@ class MediaRecognizeManager(metaclass=Singleton):
         self._messagehelper = MessageHelper()
 
     # ------------------------------------------------------------------ #
-    # 错误/空值处理（与 ChainBase 对外可见行为一致）
+    # 错误/空值处理
     # ------------------------------------------------------------------ #
 
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
-        """与 ChainBase.__is_valid_empty 同义：元组要求全 None，否则判 is None。"""
+        """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
         if isinstance(ret, tuple):
             return all(value is None for value in ret)
         return ret is None
 
     def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
                              method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_system_error。"""
+        """
+        系统后端方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送系统错误消息
+        （role=system）、广播 SystemError 事件后继续下一个后端。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -71,7 +67,10 @@ class MediaRecognizeManager(metaclass=Singleton):
 
     def _handle_plugin_error(self, err: Exception, plugin_id: str, plugin_name: str,
                             method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_plugin_error。"""
+        """
+        插件方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送插件错误消息
+        （role=plugin）、广播 SystemError 事件后继续下一个插件。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行插件 {plugin_id} 模块 {method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -91,20 +90,30 @@ class MediaRecognizeManager(metaclass=Singleton):
     @staticmethod
     def _handle_rate_limit_error(err: RateLimitExceededException, owner: str, ident: str,
                                  method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_rate_limit_error：raise 或 仅 INFO。"""
+        """
+        触发限流时的处理：raise_exception 为真时直接抛出；否则仅记录 INFO 并跳过
+        （限流为预期状态，不作系统告警）。
+        """
         if raise_exception:
             raise err
         logger.info(f"{owner} {ident}.{method} 已限流，跳过执行：{str(err)}")
 
     # ------------------------------------------------------------------ #
-    # 同步分发内核：复刻 ChainBase.run_module（插件劫持面 + 系统面）
+    # 同步分发内核：插件钩子面 + 系统后端面
     # ------------------------------------------------------------------ #
 
     def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_plugin_modules。"""
+        """
+        依次调用各已启用插件注册的同名方法，按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果，用于判定空值合并 / 列表合并 / 短路
+        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
+        :return: 累积后的结果
+        """
         from app.helper.plugin_manager import PluginManager
-        # 插件劫持面与 run_module 一致：raise_exception 透传给插件 func；系统面沿用 pop 语义。
+        # raise_exception 随调用透传给插件方法（插件可据此决定内部异常是否上抛）；系统后端面则不透传。
         plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
         for plugin, module_dict in PluginManager().get_plugin_modules().items():
             plugin_id, plugin_name = plugin
@@ -131,7 +140,15 @@ class MediaRecognizeManager(metaclass=Singleton):
 
     def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_system_modules：管道语义的载体（check_signature 透传结果）。"""
+        """
+        按优先级（get_priority 升序）依次调用各系统后端模块的同名方法，按合并规则累积结果
+        （识别为管道域：当前结果可作为下一后端入参时经 check_signature 透传，逐源精化）。
+
+        :param method: 方法名
+        :param result: 已累积的结果
+        :param raise_exception: 出错时是否抛出
+        :return: 累积后的结果
+        """
         logger.debug(f"请求系统模块执行：{method} ...")
         for module in sorted(
                 self._modulemanager.get_running_modules(method),
@@ -163,7 +180,16 @@ class MediaRecognizeManager(metaclass=Singleton):
         return result
 
     def dispatch(self, method: str, *args, **kwargs) -> Any:
-        """识别方法分发（run_module 的 byte-equivalent drop-in）：先插件劫持面、非空非列表短路、再系统面。"""
+        """
+        按方法名分发：先经插件注册的同名方法，得到非空且非列表的结果即返回，否则继续系统后端模块。
+
+        合并规则：当前结果为空时取后端返回值；可作为下一后端入参时透传（管道精化）；为列表时合并各后端列表；
+        为非空标量时短路返回。
+
+        :param method: 要分发的方法名
+        :param raise_exception: 出错时是否抛出（默认 False）
+        :return: 各数据源合并/精化后的结果
+        """
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
         result = self._dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
@@ -172,12 +198,19 @@ class MediaRecognizeManager(metaclass=Singleton):
         return self._dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
 
     # ------------------------------------------------------------------ #
-    # 异步分发内核：复刻 ChainBase.async_run_module（异步插件面 + 异步系统面）
+    # 异步分发内核：异步插件钩子面 + 异步系统后端面
     # ------------------------------------------------------------------ #
 
     async def _async_dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
                                              *args, **kwargs) -> Any:
-        """复刻 ChainBase.__async_execute_plugin_modules（同步插件 func 经线程池避免阻塞事件循环）。"""
+        """
+        异步依次调用各已启用插件注册的同名方法（同步方法经线程池执行避免阻塞事件循环），按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果
+        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
+        :return: 累积后的结果
+        """
         import inspect
         from app.helper.plugin_manager import PluginManager
         plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
@@ -212,7 +245,15 @@ class MediaRecognizeManager(metaclass=Singleton):
 
     async def _async_dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
                                              *args, **kwargs) -> Any:
-        """复刻 ChainBase.__async_execute_system_modules（同步系统模块经线程池）。"""
+        """
+        异步按优先级（get_priority 升序）依次调用各系统后端模块的同名方法（同步方法经线程池执行），
+        按合并规则累积结果（识别为管道域：结果可作为下一后端入参时经 check_signature 透传，逐源精化）。
+
+        :param method: 方法名
+        :param result: 已累积的结果
+        :param raise_exception: 出错时是否抛出
+        :return: 累积后的结果
+        """
         import inspect
         logger.debug(f"请求系统模块执行：{method} ...")
         for module in sorted(
@@ -254,7 +295,13 @@ class MediaRecognizeManager(metaclass=Singleton):
         return result
 
     async def async_dispatch(self, method: str, *args, **kwargs) -> Any:
-        """识别方法异步分发（async_run_module 的 byte-equivalent drop-in）。"""
+        """
+        dispatch 的异步版本：同步的后端方法经线程池执行避免阻塞事件循环，分发与合并规则与 dispatch 一致。
+
+        :param method: 要分发的方法名
+        :param raise_exception: 出错时是否抛出（默认 False）
+        :return: 各数据源合并/精化后的结果
+        """
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
         result = await self._async_dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
@@ -267,37 +314,86 @@ class MediaRecognizeManager(metaclass=Singleton):
     # ------------------------------------------------------------------ #
 
     def recognize_media(self, *args, **kwargs) -> Any:
-        """识别媒体信息（跨源管道，逐源精化）。"""
+        """
+        识别媒体信息（跨数据源管道，逐源精化结果）。
+
+        :param meta: 文件元数据
+        :param mtype: 媒体类型
+        :param tmdbid: TheMovieDb ID
+        :param doubanid: 豆瓣 ID
+        :param bangumiid: Bangumi ID
+        :return: 识别到的媒体信息
+        """
         return self.dispatch("recognize_media", *args, **kwargs)
 
     def search_medias(self, *args, **kwargs) -> Optional[List[Any]]:
-        """搜索媒体信息（跨源 extend 合并）。"""
+        """
+        按元数据搜索媒体信息（跨数据源合并结果）。
+
+        :param meta: 文件元数据
+        :return: 媒体信息列表
+        """
         return self.dispatch("search_medias", *args, **kwargs)
 
     async def async_search_medias(self, *args, **kwargs) -> Optional[List[Any]]:
-        """异步搜索媒体信息。"""
+        """
+        search_medias 的异步版本。
+
+        :param meta: 文件元数据
+        :return: 媒体信息列表
+        """
         return await self.async_dispatch("async_search_medias", *args, **kwargs)
 
     def search_persons(self, *args, **kwargs) -> Optional[List[Any]]:
-        """搜索人物。"""
+        """
+        按名称搜索人物（跨数据源合并结果）。
+
+        :param name: 人物名称
+        :return: 人物信息列表
+        """
         return self.dispatch("search_persons", *args, **kwargs)
 
     async def async_search_persons(self, *args, **kwargs) -> Optional[List[Any]]:
-        """异步搜索人物。"""
+        """
+        search_persons 的异步版本。
+
+        :param name: 人物名称
+        :return: 人物信息列表
+        """
         return await self.async_dispatch("async_search_persons", *args, **kwargs)
 
     def search_collections(self, *args, **kwargs) -> Optional[List[Any]]:
-        """搜索系列/合集。"""
+        """
+        按名称搜索系列/合集（跨数据源合并结果）。
+
+        :param name: 系列/合集名称
+        :return: 媒体信息列表
+        """
         return self.dispatch("search_collections", *args, **kwargs)
 
     async def async_search_collections(self, *args, **kwargs) -> Optional[List[Any]]:
-        """异步搜索系列/合集。"""
+        """
+        search_collections 的异步版本。
+
+        :param name: 系列/合集名称
+        :return: 媒体信息列表
+        """
         return await self.async_dispatch("async_search_collections", *args, **kwargs)
 
     def obtain_images(self, *args, **kwargs) -> Any:
-        """补充获取媒体图片（跨源精化）。"""
+        """
+        补充获取媒体图片（跨数据源精化）。
+
+        :param mediainfo: 媒体信息
+        :return: 补充图片后的媒体信息
+        """
         return self.dispatch("obtain_images", *args, **kwargs)
 
     async def async_obtain_images(self, *args, **kwargs) -> Any:
-        """异步补充获取媒体图片。"""
+        """
+        obtain_images 的异步版本。
+
+        :param mediainfo: 媒体信息
+        :return: 补充图片后的媒体信息
+        """
         return await self.async_dispatch("async_obtain_images", *args, **kwargs)

--- a/app/managers/mediaserver.py
+++ b/app/managers/mediaserver.py
@@ -18,27 +18,14 @@ if TYPE_CHECKING:
 
 class MediaServerManager(metaclass=Singleton):
     """
-    媒体服务器（MediaServer 域）门面。
+    媒体服务器（MediaServer 域）统一入口（单例）。
 
-    对照下载器域的 DownloaderManager / 存储域的 FileManager：把"媒体服务器"领域升级为
-    "门面 + 后端"模式——对外提供一组类型化、可发现的统一方法（实现 app.modules.IMediaServer
-    契约的对外面），对内按方法名分发到所有 ModuleType.MediaServer 后端模块（内建 Emby/Jellyfin/
-    Plex/TrimeMedia/Ugreen/ZSpace 以及插件经 provides_mediaservers() 注册的媒体服务器），并按与
-    ChainBase.run_module 完全一致的合并语义（列表 extend / 非列表取首个非 None）汇总结果。
+    对外提供一组类型化的媒体服务器操作方法（契约见 app.modules.IMediaServer），按方法名分发到所有已启用的
+    媒体服务器后端模块（内建 Emby/Jellyfin/Plex/TrimeMedia/Ugreen/ZSpace 及插件经 provides_mediaservers()
+    注册的媒体服务器），并合并各后端结果。每次分发实时查询当前运行的后端，自动纳入运行期注册/卸载的插件。
 
-    设计要点：
-    - **行为等价**：_dispatch 忠实复刻 ChainBase.__execute_system_modules 的分发与合并（含
-      check_signature 分支、异常逐后端续跑、SystemError 事件与消息上报），调用的是与 run_module
-      同一批后端模块方法（后端方法体零改动），故对真实媒体服务器的行为不变；唯一被收敛的是
-      "字符串 ABI 分发"这一隐式面，被显式、类型化的门面取代。等价性测试见 tests/test_mediaserver_facade.py。
-    - **签名漂移收敛**：各后端 mediaserver_* 的 server 必填性 / username 形参 / **kwargs 存在差异；
-      门面统一为最宽松 canonical 签名并按 kwarg 分发——后端要么声明该形参、要么有 **kwargs 吸收，
-      故与 run_module 一样对全部后端兼容（详见 app.modules.IMediaServer）。
-    - **v2 兼容路径保留**：内建媒体服务器仍作为 _ModuleBase 模块注册，run_module("mediaserver_librarys")
-      等字符串分发仍可用（标记为 v2 兼容路径、计划后续废弃）。门面不替换该路径，只作为新代码的
-      首选入口叠加其上。
-    - **后端发现**：每次分发实时查询 ModuleManager().get_running_modules(method)，自动纳入运行期
-      注册/卸载的插件媒体服务器，无需门面侧维护后端清单。
+    约定：凡接受 server 形参的方法，传 None 时面向全部媒体服务器，传具体名称时只作用于该服务器。
+    各后端 server 必填性 / username 形参存在差异，对外统一为最宽松签名并按关键字分发，对全部后端兼容。
     """
 
     def __init__(self):
@@ -47,9 +34,7 @@ class MediaServerManager(metaclass=Singleton):
 
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
-        """
-        判断结果是否为空（与 ChainBase.__is_valid_empty 同义）：元组要求全 None，否则判 is None。
-        """
+        """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
         if isinstance(ret, tuple):
             return all(value is None for value in ret)
         return ret is None
@@ -57,8 +42,13 @@ class MediaServerManager(metaclass=Singleton):
     def _handle_error(self, err: Exception, module_id: str, module_name: str,
                       method: str, raise_exception: bool) -> None:
         """
-        后端方法执行出错处理（复刻 ChainBase.__handle_system_error 的对外可见行为）：
-        raise_exception 为真则抛出；否则记录日志 + 推送系统错误消息 + 发送 SystemError 事件后续跑。
+        后端方法执行出错的处理。
+
+        :param err: 捕获到的异常
+        :param module_id: 后端类名
+        :param module_name: 后端显示名
+        :param method: 出错的方法名
+        :param raise_exception: 为真时直接抛出；否则记录错误日志、推送系统错误消息、广播 SystemError 事件后继续下一个后端
         """
         if raise_exception:
             raise err
@@ -80,8 +70,8 @@ class MediaServerManager(metaclass=Singleton):
     def _handle_rate_limit_error(err: RateLimitExceededException, module_id: str,
                                  method: str, raise_exception: bool) -> None:
         """
-        本地限流跳过（复刻 ChainBase.__handle_rate_limit_error）：raise_exception 为真则抛出；
-        否则仅 INFO 记录、不进系统错误告警（预期的限流状态不应触发 SystemError 事件/消息）。
+        后端触发限流时的处理：raise_exception 为真时直接抛出；否则仅记录 INFO 并跳过该后端
+        （限流为预期状态，不作系统告警）。
         """
         if raise_exception:
             raise err
@@ -89,16 +79,20 @@ class MediaServerManager(metaclass=Singleton):
 
     def _dispatch(self, method: str, *args, **kwargs) -> Any:
         """
-        将媒体服务器方法按方法名分发到所有 MediaServer 后端模块并合并结果。
+        按方法名分发到所有媒体服务器后端模块并合并结果。
 
-        合并语义与 ChainBase.__execute_system_modules 严格一致：按 get_priority() 升序遍历后端，
-        - 结果为空（None/全 None 元组）→ 取该后端返回值；
-        - 结果与方法签名一致（check_signature）→ 透传；
-        - 结果为列表 → 合并后续后端的列表结果；
-        - 否则（非空非列表，如 str/dict/生成器）→ 短路停止。
-        单后端异常逐个捕获续跑，不影响其它后端；raise_exception=True 时透传首个异常。
+        按优先级（get_priority 升序）遍历后端：
+        - 当前结果为空（None / 全 None 元组）→ 取该后端返回值；
+        - 当前结果可作为下一后端的入参（check_signature）→ 透传；
+        - 当前结果为列表 → 合并各后端的列表结果；
+        - 当前结果为非空标量（str/dict/生成器等）→ 短路停止。
+        单个后端异常被隔离后继续其余后端；raise_exception=True 时透传首个异常。
+
+        :param method: 要分发的媒体服务器方法名
+        :param raise_exception: 出错时是否抛出（分发控制位，不透传给后端方法）
+        :return: 各后端合并后的结果
         """
-        # pop 而非 get：raise_exception 是分发器控制位，不应透传给不接受该参数的后端 func。
+        # raise_exception 为分发控制位，pop 出后不随调用透传给后端方法。
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
         for module in sorted(
@@ -124,40 +118,59 @@ class MediaServerManager(metaclass=Singleton):
                 else:
                     break
             except RateLimitExceededException as err:
-                # 限流先于通用异常处理（与 __execute_system_modules 一致）：安静跳过、不告警。
+                # 限流先于通用异常捕获：安静跳过、不告警。
                 self._handle_rate_limit_error(err, module_id, method, raise_exception)
             except Exception as err:
                 self._handle_error(err, module_id, module_name, method, raise_exception)
         return result
 
     # ------------------------------------------------------------------ #
-    # IMediaServer 对外面：签名与 ChainBase/MediaServerChain 媒服包装方法一致（收敛漂移后的 canonical 形）。
+    # IMediaServer 对外面：按方法名转发到 _dispatch。
     # ------------------------------------------------------------------ #
 
     def media_exists(self, mediainfo: "MediaInfo", itemid: Optional[str] = None,
                      server: Optional[str] = None) -> Optional[ExistMediaInfo]:
         """
-        判断媒体是否存在于媒体服务器。
+        判断媒体是否已存在于媒体服务器。
+
+        :param mediainfo: 媒体信息
+        :param itemid: 媒体服务器中的项目 ID（已知时可直接定位）
+        :param server: 指定媒体服务器名称，None 表示全部
+        :return: 已存在媒体的信息（不存在为 None）
         """
         return self._dispatch("media_exists", mediainfo=mediainfo, itemid=itemid, server=server)
 
     def media_statistic(self, server: Optional[str] = None) -> Optional[List[Statistic]]:
         """
-        媒体数量统计。
+        媒体数量统计（电影/剧集/用户数等）。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :return: 各媒体服务器的统计信息列表
         """
         return self._dispatch("media_statistic", server=server)
 
     def mediaserver_librarys(self, server: Optional[str] = None, username: Optional[str] = None,
                              hidden: Optional[bool] = False) -> Optional[List[MediaServerLibrary]]:
         """
-        获取媒体服务器所有媒体库。
+        获取媒体服务器的媒体库列表。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param username: 按用户名过滤可见媒体库
+        :param hidden: 是否包含隐藏媒体库
+        :return: 媒体库列表
         """
         return self._dispatch("mediaserver_librarys", server=server, username=username, hidden=hidden)
 
     def mediaserver_items(self, server: Optional[str] = None, library_id: Union[str, int] = None,
                           start_index: Optional[int] = 0, limit: Optional[int] = -1) -> Optional[Generator]:
         """
-        获取媒体服务器项目列表（生成器）。
+        获取媒体库内的项目（以生成器逐项产出）。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param library_id: 媒体库 ID
+        :param start_index: 起始位置
+        :param limit: 数量上限，-1 表示不限制
+        :return: 媒体项目生成器
         """
         return self._dispatch("mediaserver_items", server=server, library_id=library_id,
                               start_index=start_index, limit=limit)
@@ -165,35 +178,57 @@ class MediaServerManager(metaclass=Singleton):
     def mediaserver_iteminfo(self, server: Optional[str] = None,
                              item_id: Union[str, int] = None) -> Optional[MediaServerItem]:
         """
-        获取媒体服务器项目信息。
+        获取单个媒体项目的详细信息。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param item_id: 项目 ID
+        :return: 媒体项目信息
         """
         return self._dispatch("mediaserver_iteminfo", server=server, item_id=item_id)
 
     def mediaserver_tv_episodes(self, server: Optional[str] = None,
                                 item_id: Union[str, int] = None) -> Optional[List[MediaServerSeasonInfo]]:
         """
-        获取媒体服务器剧集信息。
+        获取剧集的季/集信息。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param item_id: 剧集项目 ID
+        :return: 各季的集信息列表
         """
         return self._dispatch("mediaserver_tv_episodes", server=server, item_id=item_id)
 
     def mediaserver_playing(self, server: Optional[str] = None, count: Optional[int] = 20,
                             username: Optional[str] = None) -> List[MediaServerPlayItem]:
         """
-        获取媒体服务器正在播放信息。
+        获取正在播放的项目。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param count: 返回数量上限
+        :param username: 按用户名过滤
+        :return: 正在播放的项目列表
         """
         return self._dispatch("mediaserver_playing", server=server, count=count, username=username)
 
     def mediaserver_play_url(self, server: Optional[str] = None,
                              item_id: Union[str, int] = None) -> Optional[str]:
         """
-        获取播放地址。
+        获取项目的播放地址。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param item_id: 项目 ID
+        :return: 播放地址
         """
         return self._dispatch("mediaserver_play_url", server=server, item_id=item_id)
 
     def mediaserver_latest(self, server: Optional[str] = None, count: Optional[int] = 20,
                            username: Optional[str] = None) -> List[MediaServerPlayItem]:
         """
-        获取媒体服务器最新入库条目。
+        获取最新入库的项目。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param count: 返回数量上限
+        :param username: 按用户名过滤
+        :return: 最新入库的项目列表
         """
         return self._dispatch("mediaserver_latest", server=server, count=count, username=username)
 
@@ -201,7 +236,13 @@ class MediaServerManager(metaclass=Singleton):
                                   username: Optional[str] = None,
                                   remote: Optional[bool] = False) -> List[str]:
         """
-        获取最新入库条目海报作为壁纸。
+        获取最新入库项目的海报图片地址（用作壁纸）。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param count: 返回数量上限
+        :param username: 按用户名过滤
+        :param remote: 是否返回可远程访问的地址
+        :return: 海报图片地址列表
         """
         return self._dispatch("mediaserver_latest_images", server=server, count=count,
                               username=username, remote=remote)
@@ -209,6 +250,10 @@ class MediaServerManager(metaclass=Singleton):
     def mediaserver_image_cookies(self, server: Optional[str] = None,
                                   image_url: Optional[str] = None) -> Optional[Union[str, dict]]:
         """
-        获取图片的 Cookies（仅部分后端实现，未实现者不参与分发）。
+        获取访问图片所需的 Cookies（仅部分后端实现，未实现者不参与分发）。
+
+        :param server: 指定媒体服务器名称，None 表示全部
+        :param image_url: 图片地址
+        :return: 访问该图片所需的 Cookies
         """
         return self._dispatch("mediaserver_image_cookies", server=server, image_url=image_url)

--- a/app/managers/notification.py
+++ b/app/managers/notification.py
@@ -13,26 +13,17 @@ from app.utils.singleton import Singleton
 
 class NotificationManager(metaclass=Singleton):
     """
-    消息通知（Notification 域）门面。
+    消息通知（Notification 域）统一入口（单例）。
 
-    对照下载器门面 DownloaderManager / 媒服门面 MediaServerManager：把"通知"领域升级为"门面 + 后端"
-    模式——对外提供实现 app.modules.INotification 契约的类型化统一方法，对内按方法名分发到所有通知
-    后端（内建 Telegram/WeChat/Slack/Discord/... 及插件经 provides_notifications() 注册的渠道）。
+    对外提供一组通知操作方法（契约见 app.modules.INotification），按方法名分两步分发：先经各已启用插件
+    注册的同名方法，再到系统通知后端模块（内建 Telegram/WeChat/Slack/Discord/VoceChat/... 及插件经
+    provides_notifications() 注册的渠道）。每次分发实时查询当前运行的后端，自动纳入运行期注册/卸载的渠道。
 
-    **与下载器/媒服门面的关键差异——复刻完整 run_module（插件劫持面 + 系统面）**：
-    通知域历史上存在 v2 插件经 get_module() 劫持 post_message 等方法槽的用法（自定义渠道插件常见）。
-    为"兼容 v2 现存插件"，本门面 dispatch 不像下载器/媒服门面那样只复刻系统模块面，而是**完整复刻
-    ChainBase.run_module = __execute_plugin_modules（插件劫持面）+ __execute_system_modules（系统面）**：
-    先跑插件劫持面、其返回非空且非列表则短路，否则继续系统模块面。由此门面成为 run_module 的
-    byte-equivalent drop-in，可安全取代 ChainBase 中通知方法的直接 run_module 调用，零破坏 v2 劫持插件。
+    通知为广播域：post_* 类方法返回 None、不短路，对所有启用渠道广播（各渠道内部自行按渠道/来源/类型过滤
+    是否处理）；delete_message/edit_message 等返回非空值，按取首个非空短路。后端按需实现子集，按方法名分发
+    自然只命中实现者。
 
-    **v2 兼容路径保留**：内建通知模块仍作为 _ModuleBase 模块注册，ChainBase.run_module("post_message")
-    等字符串分发仍可用（标记 v2 兼容、计划后续废弃，见各通知模块类 docstring）。门面不替换该路径，
-    只作为新代码的首选类型化入口叠加其上。
-
-    注：通知是**广播域**——post_* 方法返回 None 不短路，对所有启用渠道广播（各渠道内部经 check_message
-    自行过滤）；delete_message/edit_message 返回非空值，按"取首个非空"短路。后端按需实现子集，按方法名
-    分发自然只命中实现者。
+    对外方法的参数原样转发到后端（各方法的参数见下方说明及 app.modules.INotification）。
     """
 
     def __init__(self):
@@ -40,19 +31,22 @@ class NotificationManager(metaclass=Singleton):
         self._messagehelper = MessageHelper()
 
     # ------------------------------------------------------------------ #
-    # 分发内核：忠实复刻 ChainBase.run_module（插件劫持面 + 系统模块面）
+    # 分发内核：插件钩子面 + 系统后端面
     # ------------------------------------------------------------------ #
 
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
-        """与 ChainBase.__is_valid_empty 同义：元组要求全 None，否则判 is None。"""
+        """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
         if isinstance(ret, tuple):
             return all(value is None for value in ret)
         return ret is None
 
     def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
                              method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_system_error：raise 或 记录+系统错误消息+SystemError 事件后续跑。"""
+        """
+        系统后端方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送系统错误消息
+        （role=system）、广播 SystemError 事件后继续下一个后端。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -71,7 +65,10 @@ class NotificationManager(metaclass=Singleton):
 
     def _handle_plugin_error(self, err: Exception, plugin_id: str, plugin_name: str,
                             method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_plugin_error：raise 或 记录+插件错误消息(role=plugin)+SystemError 事件。"""
+        """
+        插件方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送插件错误消息
+        （role=plugin）、广播 SystemError 事件后继续下一个插件。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行插件 {plugin_id} 模块 {method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -91,18 +88,27 @@ class NotificationManager(metaclass=Singleton):
     @staticmethod
     def _handle_rate_limit_error(err: RateLimitExceededException, owner: str, ident: str,
                                  method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_rate_limit_error：raise 或 仅 INFO（限流是预期态，不触发系统告警）。"""
+        """
+        触发限流时的处理：raise_exception 为真时直接抛出；否则仅记录 INFO 并跳过
+        （限流为预期状态，不作系统告警）。
+        """
         if raise_exception:
             raise err
         logger.info(f"{owner} {ident}.{method} 已限流，跳过执行：{str(err)}")
 
     def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_plugin_modules：跑插件经 get_module 劫持的同名方法槽。"""
-        # lazy import 防 import 期环（plugin_manager 依赖较重）；插件面与系统面共用 result 累积语义。
+        """
+        依次调用各已启用插件注册的同名方法，按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果，用于判定空值合并 / 列表合并 / 短路
+        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
+        :return: 累积后的结果
+        """
+        # 延迟导入，避免包初始化期的循环依赖。
         from app.helper.plugin_manager import PluginManager
-        # 插件劫持面与 run_module 一致：raise_exception 透传给插件 func（插件可能据此决定内部异常是否上抛）。
-        # 系统模块面沿用下载器/媒服门面的 pop 语义（系统后端方法可能无 raise_exception 形参，透传会 TypeError）。
+        # raise_exception 随调用透传给插件方法（插件可据此决定内部异常是否上抛）；系统后端面则不透传。
         plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
         for plugin, module_dict in PluginManager().get_plugin_modules().items():
             plugin_id, plugin_name = plugin
@@ -129,7 +135,14 @@ class NotificationManager(metaclass=Singleton):
 
     def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_system_modules：按 get_priority 升序跑系统通知模块、合并结果。"""
+        """
+        按优先级（get_priority 升序）依次调用各系统后端模块的同名方法，按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果
+        :param raise_exception: 出错时是否抛出
+        :return: 累积后的结果
+        """
         logger.debug(f"请求系统模块执行：{method} ...")
         for module in sorted(
                 self._modulemanager.get_running_modules(method),
@@ -162,8 +175,14 @@ class NotificationManager(metaclass=Singleton):
 
     def dispatch(self, method: str, *args, **kwargs) -> Any:
         """
-        通知方法分发（run_module 的 byte-equivalent drop-in）：先插件劫持面，其返回非空且非列表即短路，
-        否则继续系统模块面。raise_exception 为分发器控制位（pop 不透传给后端 func，与下载器门面一致）。
+        按方法名分发：先经插件注册的同名方法，得到非空且非列表的结果即返回，否则继续系统后端模块。
+
+        合并规则（两面一致）：当前结果为空时取后端返回值；为列表时合并各后端列表；为非空标量时短路返回。
+        通知为广播域——post_* 返回 None 不短路，对所有启用渠道广播。
+
+        :param method: 要分发的方法名
+        :param raise_exception: 出错时是否抛出（默认 False）
+        :return: 各后端合并后的结果
         """
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
@@ -173,37 +192,85 @@ class NotificationManager(metaclass=Singleton):
         return self._dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
 
     # ------------------------------------------------------------------ #
-    # INotification 对外面：按方法名转发到 dispatch，便于调用方平滑切换。
+    # INotification 对外面：按方法名转发到 dispatch。
     # ------------------------------------------------------------------ #
 
     def post_message(self, *args, **kwargs) -> None:
-        """发送消息（广播到所有启用渠道）。"""
+        """
+        发送通知消息，广播到所有启用的通知渠道（各渠道内部自行过滤是否处理）。
+
+        :param message: 通知内容（Notification）
+        """
         return self.dispatch("post_message", *args, **kwargs)
 
     def post_medias_message(self, *args, **kwargs) -> None:
-        """发送媒体信息选择列表。"""
+        """
+        发送媒体信息选择列表，广播到所有启用渠道。
+
+        :param message: 通知内容（Notification）
+        :param medias: 媒体信息列表（List[MediaInfo]）
+        """
         return self.dispatch("post_medias_message", *args, **kwargs)
 
     def post_torrents_message(self, *args, **kwargs) -> None:
-        """发送种子信息选择列表。"""
+        """
+        发送种子信息选择列表，广播到所有启用渠道。
+
+        :param message: 通知内容（Notification）
+        :param torrents: 种子上下文列表（List[Context]）
+        """
         return self.dispatch("post_torrents_message", *args, **kwargs)
 
     def delete_message(self, *args, **kwargs) -> Optional[bool]:
-        """删除消息（取首个非空结果）。"""
+        """
+        删除已发送的消息（取首个非空结果）。
+
+        :param channel: 消息渠道
+        :param source: 渠道来源标识
+        :param message_id: 消息 ID
+        :param chat_id: 会话 ID
+        :return: 是否删除成功
+        """
         return self.dispatch("delete_message", *args, **kwargs)
 
     def edit_message(self, *args, **kwargs) -> Any:
-        """编辑消息（取首个非空结果）。"""
+        """
+        编辑已发送的消息（取首个非空结果）。
+
+        :param channel: 消息渠道
+        :param source: 渠道来源标识
+        :param message_id: 消息 ID
+        :param chat_id: 会话 ID
+        :param text: 新正文
+        :param title: 新标题
+        :param buttons: 按钮列表
+        :param metadata: 附加元数据
+        :return: 是否编辑成功
+        """
         return self.dispatch("edit_message", *args, **kwargs)
 
     def send_direct_message(self, *args, **kwargs) -> Any:
-        """直接发送消息并返回响应（取首个非空，不经消息队列/历史）。"""
+        """
+        直接发送消息并返回渠道响应（取首个非空，不入消息队列/历史）。
+
+        :param message: 通知内容（Notification）
+        :return: 渠道响应（MessageResponse）
+        """
         return self.dispatch("send_direct_message", *args, **kwargs)
 
     def finalize_message(self, *args, **kwargs) -> Optional[bool]:
-        """对已发送消息执行渠道收尾动作（取首个非空）。"""
+        """
+        对已发送消息执行渠道收尾动作（取首个非空）。
+
+        :param response: 发送阶段返回的渠道响应（MessageResponse）
+        :return: 是否处理成功
+        """
         return self.dispatch("finalize_message", *args, **kwargs)
 
     def register_commands(self, commands: Dict[str, dict]) -> None:
-        """向所有渠道注册菜单命令（广播）。"""
+        """
+        向所有启用渠道注册菜单命令（广播）。
+
+        :param commands: 命令定义（命令名 -> 命令配置）
+        """
         return self.dispatch("register_commands", commands=commands)

--- a/app/managers/storage.py
+++ b/app/managers/storage.py
@@ -13,40 +13,39 @@ from app.utils.singleton import Singleton
 
 class StorageManager(metaclass=Singleton):
     """
-    存储（Storage 域）门面。
+    存储（Storage 域）统一入口（单例）。
 
-    补齐储存域的「三层」末层：储存域的**契约层已是 StorageBase**（16 abstractmethod，全仓最成熟范式）、
-    **注册层已是 storage_registry**（按 schema.value 单索引），但其「门面」角色历史上被**揉进了
-    FileManagerModule 这个 _ModuleBase 模块**里——FileManagerModule 既是被 ModuleManager 扫描的模块、
-    又承担按 schema 路由到 storages/ 后端的聚合。本门面把「门面」从模块中**显式抽出**，与下载器
-    DownloaderManager / 媒服 MediaServerManager / 通知 NotificationManager / 识别 MediaRecognizeManager
-    对齐：StorageChain 直接调本门面，取代 `StorageChain.run_module(...) → 唯一 FileManagerModule` 这层
-    **仪式性的字符串 ABI 双层派发**。
+    对外提供一组存储操作方法，按方法名分两步分发：先经各已启用插件注册的同名方法，再到系统存储后端
+    （FileManagerModule，内部按存储类型 schema 路由到本地/115/U115/阿里云盘/Rclone 等具体存储后端，
+    后端契约见 app.modules.filemanager.storages.StorageBase）。插件可经同名方法接入自定义存储。
 
-    派发结构：储存域只有一个系统模块 FileManagerModule（schema 路由在其内部完成），故本门面按方法名
-    分发自然命中它；**复刻完整 run_module（插件劫持面 + 系统面）** ——储存/整理域是 v2 插件经 get_module()
-    劫持方法槽的重灾区（如 p115 接入 115 储存），唯有完整复刻才能在改接后零破坏这些劫持插件。dispatch
-    成为 run_module 的 byte-equivalent drop-in。
+    分发结果取首个非空 / 列表合并 / 非空标量短路。存储方法按 storage 名称或 fileitem 所属存储路由到对应
+    后端，故各方法天然作用于单个存储。
 
-    **v2 兼容路径保留**：FileManagerModule 仍作为 _ModuleBase 模块注册，StorageChain/ChainBase 的
-    run_module 字符串分发仍可用（标 v2 兼容、计划后续废弃）；schema 路由、storage_registry、StorageBase
-    后端零改动。门面只取代外层字符串派发、不动内层 schema 路由。
+    对外方法的参数原样转发到后端（各方法的参数见下方说明）。
     """
 
     def __init__(self):
         self._modulemanager = ModuleManager()
         self._messagehelper = MessageHelper()
 
+    # ------------------------------------------------------------------ #
+    # 分发内核：插件钩子面 + 系统后端面
+    # ------------------------------------------------------------------ #
+
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
-        """与 ChainBase.__is_valid_empty 同义：元组要求全 None，否则判 is None。"""
+        """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
         if isinstance(ret, tuple):
             return all(value is None for value in ret)
         return ret is None
 
     def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
                              method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_system_error。"""
+        """
+        系统后端方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送系统错误消息
+        （role=system）、广播 SystemError 事件后继续下一个后端。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行模块 {module_id}.{method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -65,7 +64,10 @@ class StorageManager(metaclass=Singleton):
 
     def _handle_plugin_error(self, err: Exception, plugin_id: str, plugin_name: str,
                             method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_plugin_error。"""
+        """
+        插件方法出错的处理：raise_exception 为真时直接抛出；否则记录错误日志、推送插件错误消息
+        （role=plugin）、广播 SystemError 事件后继续下一个插件。
+        """
         if raise_exception:
             raise err
         logger.error(f"运行插件 {plugin_id} 模块 {method} 出错：{str(err)}\n{traceback.format_exc()}")
@@ -85,16 +87,27 @@ class StorageManager(metaclass=Singleton):
     @staticmethod
     def _handle_rate_limit_error(err: RateLimitExceededException, owner: str, ident: str,
                                  method: str, raise_exception: bool) -> None:
-        """复刻 ChainBase.__handle_rate_limit_error：raise 或 仅 INFO。"""
+        """
+        触发限流时的处理：raise_exception 为真时直接抛出；否则仅记录 INFO 并跳过
+        （限流为预期状态，不作系统告警）。
+        """
         if raise_exception:
             raise err
         logger.info(f"{owner} {ident}.{method} 已限流，跳过执行：{str(err)}")
 
     def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_plugin_modules（储存/整理域 get_module 劫持重灾区）。"""
+        """
+        依次调用各已启用插件注册的同名方法，按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果，用于判定空值合并 / 列表合并 / 短路
+        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
+        :return: 累积后的结果
+        """
+        # 延迟导入，避免包初始化期的循环依赖。
         from app.helper.plugin_manager import PluginManager
-        # 插件劫持面与 run_module 一致：raise_exception 透传给插件 func；系统面沿用 pop 语义。
+        # raise_exception 随调用透传给插件方法（插件可据此决定内部异常是否上抛）；系统后端面则不透传。
         plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
         for plugin, module_dict in PluginManager().get_plugin_modules().items():
             plugin_id, plugin_name = plugin
@@ -121,7 +134,14 @@ class StorageManager(metaclass=Singleton):
 
     def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
                                  *args, **kwargs) -> Any:
-        """复刻 ChainBase.__execute_system_modules（储存域系统模块=FileManagerModule，schema 路由在其内部）。"""
+        """
+        按优先级（get_priority 升序）依次调用各系统后端模块的同名方法，按合并规则累积结果。
+
+        :param method: 方法名
+        :param result: 已累积的结果
+        :param raise_exception: 出错时是否抛出
+        :return: 累积后的结果
+        """
         logger.debug(f"请求系统模块执行：{method} ...")
         for module in sorted(
                 self._modulemanager.get_running_modules(method),
@@ -153,7 +173,15 @@ class StorageManager(metaclass=Singleton):
         return result
 
     def dispatch(self, method: str, *args, **kwargs) -> Any:
-        """储存方法分发（run_module 的 byte-equivalent drop-in）：先插件劫持面、非空非列表短路、再系统面。"""
+        """
+        按方法名分发：先经插件注册的同名方法，得到非空且非列表的结果即返回，否则继续系统后端模块。
+
+        合并规则（两面一致）：当前结果为空时取后端返回值；为列表时合并各后端列表；为非空标量时短路返回。
+
+        :param method: 要分发的方法名
+        :param raise_exception: 出错时是否抛出（默认 False）
+        :return: 各后端合并后的结果
+        """
         raise_exception = bool(kwargs.pop("raise_exception", False))
         result: Any = None
         result = self._dispatch_plugin_modules(method, result, raise_exception, *args, **kwargs)
@@ -162,77 +190,178 @@ class StorageManager(metaclass=Singleton):
         return self._dispatch_system_modules(method, result, raise_exception, *args, **kwargs)
 
     # ------------------------------------------------------------------ #
-    # 储存对外面：与 StorageChain 包装方法 / FileManagerModule 方法同名，按方法名转发到 dispatch。
+    # 存储对外面：按方法名转发到 dispatch。
     # ------------------------------------------------------------------ #
 
     def save_config(self, *args, **kwargs) -> Any:
-        """保存存储配置。"""
+        """
+        保存指定存储的配置。
+
+        :param storage: 存储类型标识（schema）
+        :param conf: 配置内容
+        """
         return self.dispatch("save_config", *args, **kwargs)
 
     def reset_config(self, *args, **kwargs) -> Any:
-        """重置存储配置。"""
+        """
+        重置指定存储的配置。
+
+        :param storage: 存储类型标识（schema）
+        """
         return self.dispatch("reset_config", *args, **kwargs)
 
     def generate_qrcode(self, *args, **kwargs) -> Optional[dict]:
-        """生成登录二维码。"""
+        """
+        生成存储登录二维码（仅支持扫码登录的存储）。
+
+        :param storage: 存储类型标识（schema）
+        :return: (二维码数据, 提示信息)
+        """
         return self.dispatch("generate_qrcode", *args, **kwargs)
 
     def generate_auth_url(self, *args, **kwargs) -> Optional[str]:
-        """生成授权链接。"""
+        """
+        生成 OAuth2 授权链接（仅支持 OAuth2 的存储）。
+
+        :param storage: 存储类型标识（schema）
+        :return: (授权参数, 授权链接)
+        """
         return self.dispatch("generate_auth_url", *args, **kwargs)
 
     def check_login(self, *args, **kwargs) -> Optional[dict]:
-        """检查登录状态。"""
+        """
+        查询存储登录状态（如扫码/授权是否完成）。
+
+        :param storage: 存储类型标识（schema）
+        :return: 登录状态信息
+        """
         return self.dispatch("check_login", *args, **kwargs)
 
     def list_files(self, *args, **kwargs) -> Any:
-        """浏览目录文件。"""
+        """
+        浏览目录下的文件与子目录。
+
+        :param fileitem: 目录项
+        :param recursion: 是否递归列出子目录
+        :return: 文件/目录项列表
+        """
         return self.dispatch("list_files", *args, **kwargs)
 
     def any_files(self, *args, **kwargs) -> Optional[bool]:
-        """判断目录下是否存在指定扩展名的文件。"""
+        """
+        判断目录下是否存在指定扩展名的文件。
+
+        :param fileitem: 目录项
+        :param extensions: 扩展名列表，None 表示任意文件
+        :return: 是否存在
+        """
         return self.dispatch("any_files", *args, **kwargs)
 
     def create_folder(self, *args, **kwargs) -> Any:
-        """创建目录。"""
+        """
+        在指定父目录下创建子目录。
+
+        :param fileitem: 父目录项
+        :param name: 新目录名
+        :return: 新建的目录项
+        """
         return self.dispatch("create_folder", *args, **kwargs)
 
     def get_folder(self, *args, **kwargs) -> Any:
-        """获取目录（不存在则创建）。"""
+        """
+        获取目录项，不存在则创建。
+
+        :param storage: 存储类型标识（schema）
+        :param path: 目录路径
+        :return: 目录项
+        """
         return self.dispatch("get_folder", *args, **kwargs)
 
     def download_file(self, *args, **kwargs) -> Any:
-        """下载文件。"""
+        """
+        下载文件到本地。
+
+        :param fileitem: 文件项
+        :param path: 本地保存路径，None 表示临时目录
+        :return: 本地文件路径
+        """
         return self.dispatch("download_file", *args, **kwargs)
 
     def upload_file(self, *args, **kwargs) -> Any:
-        """上传文件。"""
+        """
+        上传本地文件到指定目录。
+
+        :param fileitem: 上传目标目录项
+        :param path: 本地文件路径
+        :param new_name: 上传后的文件名，None 表示沿用原名
+        :return: 上传后的文件项
+        """
         return self.dispatch("upload_file", *args, **kwargs)
 
     def delete_file(self, *args, **kwargs) -> Optional[bool]:
-        """删除文件/目录。"""
+        """
+        删除文件或目录。
+
+        :param fileitem: 文件/目录项
+        :return: 是否删除成功
+        """
         return self.dispatch("delete_file", *args, **kwargs)
 
     def rename_file(self, *args, **kwargs) -> Optional[bool]:
-        """重命名文件/目录。"""
+        """
+        重命名文件或目录。
+
+        :param fileitem: 文件/目录项
+        :param name: 新名称
+        :return: 是否重命名成功
+        """
         return self.dispatch("rename_file", *args, **kwargs)
 
     def get_file_item(self, *args, **kwargs) -> Any:
-        """按路径获取文件项。"""
+        """
+        按路径获取文件或目录项。
+
+        :param storage: 存储类型标识（schema）
+        :param path: 文件/目录路径
+        :return: 文件/目录项
+        """
         return self.dispatch("get_file_item", *args, **kwargs)
 
     def get_parent_item(self, *args, **kwargs) -> Any:
-        """获取父目录项。"""
+        """
+        获取文件/目录的父目录项。
+
+        :param fileitem: 文件/目录项
+        :return: 父目录项
+        """
         return self.dispatch("get_parent_item", *args, **kwargs)
 
     def snapshot_storage(self, *args, **kwargs) -> Any:
-        """存储快照。"""
+        """
+        对存储目录做快照（输出各层级文件信息，用于变更比对）。
+
+        :param storage: 存储类型标识（schema）
+        :param path: 快照根路径
+        :param last_snapshot_time: 上次快照时间，用于增量快照
+        :param max_depth: 最大递归深度
+        :return: 路径 -> 文件信息 的快照字典
+        """
         return self.dispatch("snapshot_storage", *args, **kwargs)
 
     def storage_usage(self, *args, **kwargs) -> Any:
-        """存储使用情况。"""
+        """
+        获取存储空间使用情况。
+
+        :param storage: 存储类型标识（schema）
+        :return: 存储使用信息
+        """
         return self.dispatch("storage_usage", *args, **kwargs)
 
     def support_transtype(self, *args, **kwargs) -> Any:
-        """存储支持的整理方式。"""
+        """
+        获取存储支持的整理方式（移动/复制/硬链接等）。
+
+        :param storage: 存储类型标识（schema）
+        :return: 支持的整理方式
+        """
         return self.dispatch("support_transtype", *args, **kwargs)


### PR DESCRIPTION
将 5 个门面（downloader/mediaserver/notification/storage/mediarecognize）的 docstring/注释统一为功能式说明。

## 改动
- **去除与方法无关的解释型叙述**：复刻 ChainBase.run_module / byte-equivalent drop-in / 字符串 ABI / get_module 劫持重灾区 / 仪式性双层派发 / 等价性测试 / 对照 X 域 等
- dispatch 内核与错误处理改写为「功能 + 参数 + 返回」式描述
- 类型化方法（下载器/媒服）补全 `:param:`/`:return:`
- `*args/**kwargs` 转发方法（通知/存储/识别）在 docstring 按契约写清各参数（INotification / IMediaRecognize / FileManagerModule 签名）——这些方法**有意保留** `*args/**kwargs`：它们有插件劫持面，原样转发参数才能让插件按原调用形态收参
- 包 `__init__` 文档同步去除复刻/ABI 叙述

## 验证
- **仅改注释**：剥离 docstring 后 5 文件 AST 与改前**逐字一致**，方法签名/派发逻辑零改动
- 全量 **1738 passed / 19 skipped**