### PR TITLE
docs: 规范化 v3 重构各文件注释，去除与功能无关的重构叙述

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -84,14 +84,14 @@ class ChainBase(metaclass=ABCMeta):
         杜绝位置传参歧义（原 __init__(self) 不接受位置参，无调用方受影响）。
         """
         self.modulemanager = modulemanager or ModuleManager()
-        # 下载器（Downloader 域）门面：下载器相关包装方法经此分发，取代 run_module 字符串 ABI。
+        # 下载器（Downloader 域）门面：下载器相关包装方法经此分发到各下载器后端。
         self.downloadermanager = downloadermanager or DownloaderManager()
-        # 媒体服务器（MediaServer 域）门面：媒服相关包装方法经此分发，取代 run_module 字符串 ABI。
+        # 媒体服务器（MediaServer 域）门面：媒服相关包装方法经此分发到各媒体服务器后端。
         self.mediaservermanager = mediaservermanager or MediaServerManager()
         self.notificationmanager = notificationmanager or NotificationManager()
-        # 媒体识别/数据源（MediaRecognize 域）门面：识别相关包装方法经此分发，取代 run_module 字符串 ABI。
+        # 媒体识别/数据源（MediaRecognize 域）门面：识别相关包装方法经此分发到各数据源后端。
         self.mediarecognizemanager = mediarecognizemanager or MediaRecognizeManager()
-        # 存储（Storage 域）门面：储存相关包装方法经此分发，取代 run_module → 唯一 FileManagerModule 的双层派发。
+        # 存储（Storage 域）门面：储存相关包装方法经此分发到存储后端。
         self.storagemanager = storagemanager or StorageManager()
         self.eventmanager = eventmanager or EventManager()
         self.messageoper = messageoper or MessageOper()

--- a/app/core/auth_level.py
+++ b/app/core/auth_level.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-站点认证等级注入式 seam：解耦 core -> helper.sites。
+站点认证等级提供者（provider）：供 core 层（security / auth_bridge）读取站点认证等级。
 
-SitesHelper 是资源包拉取的编译模块（app/helper/sites.*.so），属于 helper 层。
-core 层（security / auth_bridge）原先直接 import SitesHelper 仅为读取 `auth_level`，
-形成 core -> helper 的反向依赖。此 seam 把"读取站点认证等级"抽象为可注入的 provider：
+具体实现（SitesHelper，编译模块 app/helper/sites.*.so）由组合根在启动时注入，core 自身不直接依赖 helper：
 
   - 由组合根（app/startup/lifecycle.py）注入 `lambda: SitesHelper().auth_level`；
   - 未注册时返回未认证默认等级（least privilege），与全新 SitesHelper().auth_level 一致；
-  - 本模块零外部依赖（仅 typing），不反向依赖 helper。
-
-与 app/core/meta/config_source.py（S1）同属注入式 seam 技术。
+  - 本模块仅依赖 typing。
 """
 from typing import Callable, Optional
 

--- a/app/core/module/__init__.py
+++ b/app/core/module/__init__.py
@@ -2,14 +2,14 @@
 """
 app.core.module 包：模块管理（manager）/ 动态加载（loader）/ 契约校验（contract）。
 
-稳定公共 API（保持 from app.core.module import X 零改动；历史上为单文件 app/core/module.py）：
+稳定公共 API（保持 from app.core.module import X 零改动）：
   - ModuleManager        模块管理器（注册/生命周期），见 .manager
   - ModuleType           模块类型枚举（再导出自 app.schemas.types）
   - verify_*_contract     契约校验家族（module/data_source/downloader/notification/mediaserver），见 .contract
 
 公共名按需懒加载（PEP 562 __getattr__）。关键不变量：``import app.core.module.loader`` 不应触发
 manager 的重依赖（config/event/singleton…）——动态加载工具 ModuleHelper 被 filemanager/indexer/
-workflow 等在 import 期使用，必须可单独 import 而不拖入模块管理器依赖图（S3 解耦成果）。故此 __init__
+workflow 等在 import 期使用，必须可单独 import 而不拖入模块管理器依赖图。故此 __init__
 不在模块顶层 import 任何子模块，仅在属性首次访问时按需解析。
 """
 from typing import TYPE_CHECKING

--- a/app/core/module/contract.py
+++ b/app/core/module/contract.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-模块契约校验家族（从 ModuleManager 抽出为独立模块）。
+模块契约校验家族。
 
-与 manager/loader 解耦：仅依赖标准库 inspect 与 ModuleType 枚举，_ModuleBase 走 lazy import 防环。
+仅依赖标准库 inspect 与 ModuleType 枚举，_ModuleBase 走 lazy import 避免循环依赖。
 verify_module_contract 为 _ModuleBase 基类契约的核心判定；各域 verify_*_contract 在其上叠加
-get_type 与核心方法要求，共用 _verify_typed_contract。ModuleManager 仍以静态方法别名再导出全部函数，
+get_type 与核心方法要求，共用 _verify_typed_contract。ModuleManager 以静态方法别名再导出全部函数，
 故 ModuleManager.verify_*_contract 调用方零改动。
 """
 import inspect

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -1,14 +1,8 @@
-"""兼容垫片（S9）：`PluginManager` 已迁出 core，落户 `app.helper.plugin_manager`。
+"""兼容垫片：`PluginManager` 现位于 `app.helper.plugin_manager`。
 
-迁移动机（审计 P1）：原 `app/core/plugin.py` 是一个 2026 行的 god-object，既不该
-留在 core（core 应是下层，不应内含插件市场/安装/热重载这类高层编排），又通过
-`PluginDataOper`/`SystemConfigOper` 顶层反向依赖 db（core→db 反向边）。迁至 helper 层后，
-helper→{core,db,utils} 均为合法层序，core 的 god-object 气味与最后 2 条 core→db 边一并消除。
-
-本垫片仅为**防御性向后兼容**：保留历史上可能存在的 `from app.core.plugin import PluginManager`
-写法（仓内市场插件 0 引用，全部内部导入方已改指新路径）。采用 PEP 562 模块级
-`__getattr__` **惰性**解析，使「导入 app.core.plugin」本身不在 import-time 拉起 helper —
-守护 core↔helper 解环里程碑（core 顶层零 helper 反向依赖）。
+保留 `from app.core.plugin import PluginManager` 的旧写法（仓内已无引用，仅作防御性兼容）。
+采用 PEP 562 模块级 `__getattr__` 惰性解析，使「导入 app.core.plugin」本身不在 import 期拉起 helper，
+避免 core 顶层产生对 helper 的依赖。
 """
 from typing import TYPE_CHECKING
 

--- a/app/core/plugin_reporter.py
+++ b/app/core/plugin_reporter.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-插件安装上报注入式 seam：解耦 core/plugin -> helper.server。
+插件安装上报器（reporter）：core/plugin 在插件安装成功后经此上报安装统计。
 
-core/plugin 在插件安装成功后上报安装统计,原先直接调用
-MoviePilotServerHelper.install_plugin_reg（helper 层,依赖 db / http / 外部 MP 统计服务器）,
-形成 core -> helper 的反向依赖。此 seam 把"上报插件安装"抽象为可注入 reporter：
+具体实现（MoviePilotServerHelper.install_plugin_reg，依赖 db / http / 外部 MP 统计服务器）由组合根在
+启动时注入，core 自身不直接依赖 helper：
 
   - 由组合根（app/startup/lifecycle.py）注入 MoviePilotServerHelper.install_plugin_reg;
   - 未注册时为 no-op（与 settings.PLUGIN_STATISTIC_SHARE=False 时跳过上报的语义一致,
     且上报本就是 fire-and-forget,调用方忽略返回值）;
-  - 本模块零外部依赖（仅 typing），不反向依赖 helper。
-
-与 app/core/auth_level.py（S1b）、app/core/meta/config_source.py（S1）同属注入式 seam。
+  - 本模块仅依赖 typing。
 """
 from typing import Any, Callable, Optional
 

--- a/app/core/plugin_source.py
+++ b/app/core/plugin_source.py
@@ -1,21 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-插件来源(plugin source)注入式 seam：解耦 core/plugin -> helper.plugin。
+插件来源（plugin source）提供者：core/plugin 经此获取插件来源对象（PluginHelper：插件市场拉取 /
+安装 / 依赖管理 / 本地仓库发现）。
 
-PluginHelper（app/helper/plugin.py，2488 行：插件市场拉取 / 安装 / 依赖管理 / 本地仓库发现）
-是 helper 层重类。core/plugin 原先在模块顶层 `from app.helper.plugin import PluginHelper`
-并在 9 处直接调用,构成 core -> helper 的**顶层** import 反向依赖（import 期层级耦合）。
-
-此 seam 把"获取插件来源对象"抽象为可注入函数：
-  - 默认懒加载返回真实 PluginHelper 单例 —— 行为与原先字节一致,但把对 helper 的引用从
-    模块顶层 import **降级为函数内惰性 import**,从而消除顶层反向边(与 event.py 中惰性
-    导入 helper.message 同属"惰性即无 import 期环"的处理);
-  - 可经 set_plugin_source_provider 注入替代实现,为未来 Rust / 进程外插件宿主预留接入点
-    （strangler-fig 的插件来源边界）。
-
-注:这是 S5 的收尾刀(S5a 已先剥离无状态 URL 工具至 app.utils.plugin_repo)。
-本 seam 故意不在组合根注册 provider —— 默认值本身即生产行为,YAGNI:待第二实现(Rust 宿主)
-出现时再注册替代 provider。
+  - 默认懒加载返回真实 PluginHelper 单例（函数内惰性 import，使 core 顶层不依赖 helper）；
+  - 可经 set_plugin_source_provider 注入替代实现（为未来 Rust / 进程外插件宿主预留接入点）；
+  - 默认未在组合根注册 provider——默认值即生产行为，待出现第二实现时再注册替代 provider。
 """
 from typing import Any, Callable, Optional
 

--- a/app/helper/plugin_cloner.py
+++ b/app/helper/plugin_cloner.py
@@ -1,11 +1,8 @@
-"""插件分身的纯文件/AST 改写工具（S9b：自 PluginManager god-object 抽出）。
+"""插件分身的纯文件/AST 改写工具。
 
-PluginManager.clone_plugin 仍是有状态编排器（读 _plugins/_running_plugins、写
-SystemConfigOper、reload_plugin），但其中**无状态**的文件改写逻辑——改写 __init__.py
-的类名/插件元信息、改写联邦插件前端 JS/CSS、重命名联邦资源——是纯文件 + 正则操作，
-与 PluginManager 实例状态零耦合，故抽到本独立模块为模块级函数。clone_plugin 负责解析
-原类名（_plugins 读取留在 PluginManager）并把 original_class_name/clone_class_name 作为
-参数传入。函数体逐字自原 PluginManager._modify_* 方法迁出，行为字节级不变。
+无状态的文件改写逻辑——改写 __init__.py 的类名/插件元信息、改写联邦插件前端 JS/CSS、重命名联邦资源——
+为纯文件 + 正则操作，均为模块级函数。由 PluginManager.clone_plugin 解析原类名后，把
+original_class_name/clone_class_name 作为参数传入。
 """
 import re
 from pathlib import Path

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -1,11 +1,9 @@
-"""插件元数据只读聚合访问器（S9c：自 PluginManager god-object 抽出）。
+"""插件元数据只读聚合访问器。
 
-这些访问器只读地遍历运行态插件字典（running_plugins）、调用各插件实例的 get_xxx 钩子
-方法并聚合结果，对 PluginManager 实例状态的唯一耦合就是 running_plugins 这一个字典。
-故抽到本独立模块为模块级函数（首参 running_plugins）；PluginManager 保留一行委托门面，
-使 api/agent/command/scheduler/chain 等大量调用方 PluginManager().get_plugin_xxx() 零改动。
-函数体逐字自原 PluginManager.get_plugin_* 方法迁出（仅 self._running_plugins → running_plugins），
-内部 dict() 快照语义不变，行为字节级一致。
+只读地遍历运行态插件字典（running_plugins）、调用各插件实例的 get_xxx 钩子方法并聚合结果，
+对 PluginManager 实例状态的唯一耦合是 running_plugins 这一个字典。均为模块级函数（首参 running_plugins）；
+PluginManager 保留委托门面，使 api/agent/command/scheduler/chain 等调用方 PluginManager().get_plugin_xxx()
+调用方式不变。
 """
 import inspect
 import posixpath

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -255,20 +255,14 @@ class IDownloader(Protocol):
     """
     下载器（Downloader 域）行为接口契约。
 
-    这是下载器领域的稳定行为接口（对照存储域的 StorageBase）：声明门面
-    app.helper.downloader.DownloaderManager 统一对外暴露、并按方法名分发到各后端的
-    下载器操作面。采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足
-    契约，无需显式继承，避免与 _ModuleBase(ABCMeta)/ServiceBase(Generic) 的元类冲突，
-    亦保证对既有 Qbittorrent/Transmission/Rtorrent 模块零改动即结构兼容。
+    声明下载器后端需实现的操作面，由 app.managers.downloader.DownloaderManager 统一对外暴露并按方法名
+    分发到各后端。采用结构化类型（Protocol）：后端实现同名同义方法即满足契约，无需显式继承（亦避免与
+    _ModuleBase/ServiceBase 的元类冲突），对既有 Qbittorrent/Transmission/Rtorrent 模块零改动即兼容。
+    `@runtime_checkable` 允许用 isinstance 在运行期校验方法是否存在（不校验签名）。
 
-    `@runtime_checkable` 使 isinstance(obj, IDownloader) 可在运行期校验"是否实现了这些方法名"
-    （注意 Protocol 的 isinstance 只校验方法存在性，不校验签名）。
-
-    约定（与 ChainBase 下载器包装方法签名一致）：
-    - 多实例路由：downloader 参数为具体下载器配置名（config_name）；为 None 时由后端广播到其
-      全部启用实例，门面再跨后端按"列表 extend / 非列表取首个非 None"合并。
-    - torrent_files 统一返回 List[DownloaderFile]（rtorrent 当前仍返回 List[Dict]，属待归一化的
-      P0.5 后端修复项，见 app/modules/rtorrent/__init__.py 的 TODO，本接口声明目标类型）。
+    约定：
+    - downloader 参数为具体下载器配置名，None 表示后端面向其全部启用实例，再跨后端按列表合并 / 取首个非空汇总。
+    - torrent_files 统一返回 List[DownloaderFile]。
     """
 
     def download(
@@ -507,22 +501,15 @@ class IMediaServer(Protocol):
     """
     媒体服务器（MediaServer 域）行为接口契约。
 
-    对照下载器域的 IDownloader / 存储域的 StorageBase：声明门面
-    app.managers.mediaserver.MediaServerManager 统一对外暴露、并按方法名分发到各后端的
-    媒体服务器操作面。采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足
-    契约，无需显式继承，避免与 _ModuleBase(ABCMeta)/ServiceBase(Generic) 的元类冲突，对既有
-    Emby/Jellyfin/Plex/TrimeMedia/Ugreen/ZSpace 模块零改动即结构兼容。
+    声明媒体服务器后端需实现的操作面，由 app.managers.mediaserver.MediaServerManager 统一对外暴露并按
+    方法名分发到各后端。采用结构化类型（Protocol）：后端实现同名同义方法即满足契约，无需显式继承，对既有
+    Emby/Jellyfin/Plex/TrimeMedia/Ugreen/ZSpace 模块零改动即兼容。
 
-    约定（与 ChainBase/MediaServerChain 媒服包装方法签名一致）：
-    - 多实例路由：server 参数为具体媒体服务器配置名（config_name）；为 None 时由后端广播到其
-      全部启用实例，门面再按"列表 extend / 非列表取首个非 None"跨后端合并。
-    - 签名漂移收敛：各后端 server 必填性 / username 形参 / **kwargs 存在差异（见各模块），门面在此
-      统一为最宽松 canonical 签名（server: Optional[str]）；后端要么声明该形参、要么有 **kwargs
-      吸收（不致 TypeError），故按 kwarg 分发对全部后端兼容、与 run_module 行为完全一致。注意：以
-      **kwargs 吸收某形参的后端（如 Plex/TrimeMedia/Ugreen 对 username）会静默忽略该值——此为既有
-      run_module 行为，门面如实保留、不引入差异。
-    - mediaserver_image_cookies 仅部分后端实现（TrimeMedia/Ugreen），按方法名分发自然只命中实现者
-      （类比下载器域 rtorrent 早期缺方法），未实现者不参与。
+    约定：
+    - server 参数为具体媒体服务器配置名，None 表示后端面向其全部启用实例，再跨后端按列表合并 / 取首个非空汇总。
+    - 各后端 server 必填性 / username 形参不一，接口统一为最宽松签名（server: Optional[str]）；部分后端
+      （如 Plex/TrimeMedia/Ugreen 对 username）以 **kwargs 吸收并静默忽略该形参。
+    - mediaserver_image_cookies 仅部分后端（TrimeMedia/Ugreen）实现，未实现者不参与分发。
     """
 
     def media_exists(self, mediainfo: "MediaInfo", itemid: Optional[str] = None,
@@ -564,16 +551,14 @@ class INotification(Protocol):
     """
     消息通知（Notification 域）行为接口契约。
 
-    对照下载器域的 IDownloader / 媒服域的 IMediaServer / 存储域的 StorageBase：声明门面
-    app.managers.notification.NotificationManager 统一对外暴露、并按方法名分发到各通知后端
-    （内建 Telegram/WeChat/Slack/Discord/VoceChat/... 及插件经 provides_notifications() 注册的
-    渠道）的消息操作面。采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足
-    契约，无需显式继承，对既有通知模块零改动即结构兼容。
+    声明通知后端需实现的消息操作面，由 app.managers.notification.NotificationManager 统一对外暴露并按
+    方法名分发到各通知渠道（内建 Telegram/WeChat/Slack/Discord/VoceChat/... 及插件经
+    provides_notifications() 注册的渠道）。采用结构化类型（Protocol）：后端实现同名同义方法即满足契约，
+    无需显式继承。
 
-    派发语义（与 run_module 完全一致）：通知是**广播域**——post_* 类方法对所有启用渠道广播（返回
-    None、不短路合并），各渠道方法内部经 check_message 自行按渠道/来源/类型过滤是否处理；
-    delete_message/edit_message 返回非空值（bool/响应字典），按"取首个非空"语义短路。后端按需实现
-    子集（如部分渠道不支持编辑/删除），按方法名分发自然只命中实现者。
+    通知为广播域：post_* 方法返回 None、不短路，对所有启用渠道广播（各渠道内部经 check_message 自行按
+    渠道/来源/类型过滤）；delete_message/edit_message 返回非空值（bool/响应字典），按取首个非空短路。
+    后端按需实现子集，按方法名分发只命中实现者。
     """
 
     def post_message(self, message: "Notification", **kwargs) -> None: ...
@@ -603,15 +588,13 @@ class IMediaRecognize(Protocol):
     """
     媒体识别 / 数据源（MediaRecognize 域）行为接口契约。
 
-    对照下载器 IDownloader / 媒服 IMediaServer / 通知 INotification / 存储 StorageBase：声明门面
-    app.managers.mediarecognize.MediaRecognizeManager 统一对外暴露、并按方法名分发到各数据源后端
-    （内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经 provides_data_sources() 注册的源）的识别操作面。
-    采用 **结构化类型（Protocol）** 而非 ABC——后端只要实现同名同义方法即满足契约，无需显式继承。
+    声明数据源后端需实现的识别操作面，由 app.managers.mediarecognize.MediaRecognizeManager 统一对外暴露
+    并按方法名分发到各数据源（内建 TheMovieDb/Douban/Bangumi/TheTvDb 及插件经 provides_data_sources()
+    注册的源）。采用结构化类型（Protocol）：后端实现同名同义方法即满足契约，无需显式继承。
 
-    派发语义——**管道（pipeline）**：recognize_media 等方法的返回值在源之间流转、逐源精化；search_* 列表
-    方法跨源 extend 合并；首个非空非列表结果短路。后端按需实现子集（如 Bangumi 缺 obtain_images、
-    TheTvDb 仅实现 tvdb_info），按方法名分发自然只命中实现者——故下列方法均非强制实现。
-    异步变体（async_*）与同步同义，门面经 async_dispatch 分发。
+    识别为管道域：recognize_media 等方法的结果在数据源之间流转、逐源精化；search_* 列表方法跨源合并；
+    首个非空非列表结果短路。后端按需实现子集（如 Bangumi 缺 obtain_images、TheTvDb 仅实现 tvdb_info），
+    按方法名分发只命中实现者，故下列方法均非强制实现；异步变体（async_*）与同步同义。
     """
 
     def recognize_media(self, meta: "MetaBase" = None, mtype: "MediaType" = None,

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -45,8 +45,8 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
     作为 Downloader 域后端，由门面 app.managers.downloader.DownloaderManager 统一分发调用。
 
     .. deprecated::
-        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
-        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的旧路径仍可用但计划在后续版本废弃；
+        新代码请改用 DownloaderManager 门面的类型化方法。
     """
 
     def init_module(self) -> None:

--- a/app/modules/rtorrent/__init__.py
+++ b/app/modules/rtorrent/__init__.py
@@ -30,8 +30,8 @@ class RtorrentModule(_ModuleBase, _DownloaderBase[Rtorrent]):
     get_torrent_trackers() 已实现（经 xmlrpc t.multicall 取 tracker url），与 qb/tr 对齐无能力缺口。
 
     .. deprecated::
-        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
-        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的旧路径仍可用但计划在后续版本废弃；
+        新代码请改用 DownloaderManager 门面的类型化方法。
     """
 
     def init_module(self) -> None:

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -36,8 +36,8 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
     作为 Downloader 域后端，由门面 app.managers.downloader.DownloaderManager 统一分发调用。
 
     .. deprecated::
-        经 ChainBase.run_module("download"/"list_torrents"/…) 的字符串 ABI 分发为 v2 兼容路径，
-        仍可用但计划在后续版本废弃；新代码请改用 DownloaderManager 门面的类型化方法。
+        经 ChainBase.run_module("download"/"list_torrents"/…) 的旧路径仍可用但计划在后续版本废弃；
+        新代码请改用 DownloaderManager 门面的类型化方法。
     """
 
     def init_module(self) -> None:

--- a/app/startup/lifecycle.py
+++ b/app/startup/lifecycle.py
@@ -68,11 +68,11 @@ async def lifespan(app: FastAPI):
     print("Starting up...")
     # 存储当前循环
     global_vars.set_loop(asyncio.get_event_loop())
-    # 将 core/meta 的用户自定义识别配置接到持久化存储（core/meta 本身不依赖 app.db）
+    # 将 core/meta 的用户自定义识别配置接到持久化存储
     set_meta_config_provider(lambda key: SystemConfigOper().get(key))
-    # 注入站点认证等级提供者（解耦 core -> helper.sites）
+    # 注入站点认证等级提供者
     set_auth_level_provider(lambda: SitesHelper().auth_level)
-    # 注入插件安装上报器（解耦 core/plugin -> helper.server）
+    # 注入插件安装上报器
     set_plugin_install_reporter(MoviePilotServerHelper.install_plugin_reg)
     # 初始化路由
     init_routers(app)


### PR DESCRIPTION
承接门面注释规范化（#81），把 v3 解耦 / 三层重构期间在其它文件引入的解释型 / 历史叙述统一去除、改为功能式描述。

## 改动（14 文件，仅注释/docstring）
- **app/modules/__init__.py**：4 个 Protocol docstring 去「对照 X 域 / 签名漂移收敛 / 与 run_module 一致 / 类比 / 待修复 TODO」，并修正 `IDownloader` 陈旧路径 `app.helper.downloader`→`app.managers.downloader`
- **app/chain/__init__.py**：4 行门面注释去「取代 run_module 字符串 ABI / 双层派发」
- **下载器后端 qb/tr/rt**：deprecated 块去「字符串 ABI 分发为 v2 兼容路径」措辞（保留废弃指引）
- **app/core/module/{__init__,contract}.py**：去「历史上为单文件 / S3 解耦成果 / 从 ModuleManager 抽出」
- **app/core/plugin.py**：兼容垫片去「S9 / 审计 P1 / god-object / 迁移动机」史，保留垫片功能说明
- **app/core/{auth_level,plugin_reporter,plugin_source}.py**：注入 provider 文档保留功能描述（用途 / 注入点 / 默认），去「解耦 core→helper / 反向依赖 / Sxx 步骤 / 行号 / strangler-fig」
- **app/startup/lifecycle.py**：注入注释去「（解耦 core→helper.x）」括注
- **app/helper/{plugin_metadata,plugin_cloner}.py**：去「S9b/S9c god-object 抽出 / 逐字迁出字节级一致」

## 验证
- **仅改注释**：剥离 docstring 后 14 文件 AST 与改前**逐字一致**，逻辑零改动
- 全量 **1738 passed / 19 skipped**

> 注：`app/plugins/**`（外置第三方插件）及 sso/metainfo/torrent 等处的「解耦/对照/历史」为功能性用词巧合，非重构叙述，未改动。