### PR TITLE
docs(db): SsoIdentity docstring 去「解耦」词面

### DIFF
--- a/app/db/models/ssoidentity.py
+++ b/app/db/models/ssoidentity.py
@@ -13,7 +13,7 @@ class SsoIdentity(Base):
     SSO 外部身份 ↔ 本地用户 绑定表。
 
     按稳定的 (provider_id, subject) 唯一映射到本地 user，使得：
-      - 外部用户改名（username 变）不丢号——解析以 subject 为主键，与可变用户名解耦；
+      - 外部用户改名（username 变）不丢号——身份解析以稳定的 subject 为准，不依赖可变的 username；
       - 支持账号关联（把一个外部身份绑定到已存在的本地用户）与多提供方并存。
     身份持久化属用户账号域（框架表），不随插件卸载而失，故不放插件 plugin_data。
     """


### PR DESCRIPTION
承接 v3 注释规范化（#81–#83）。`SsoIdentity` 类 docstring 本属功能性设计文档（说明稳定映射 / 改名不丢号 / 框架表定位），仅「与可变用户名解耦」一处用了「解耦」词面，平替为不丢语义的白话：

```
- 外部用户改名（username 变）不丢号——身份解析以稳定的 subject 为准，不依赖可变的 username；
```

**仅改注释**：剥离 docstring 后 AST 与改前逐字一致，字段/约束/逻辑零改动；py_compile 通过。

> 说明：本地共享检出当时停在外部并行任务（SA2 db 迁移）的未推送提交，故本改动从 origin/v3-python 切隔离 worktree 完成，未碰那份工作树。