### PR TITLE
refactor: auth 装配桥抽离 + 插件渠道能力声明收口

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -147,91 +147,28 @@ def _builtin_factor_steps(user) -> list:
 
 
 def _build_flow_service(request: Optional[Request] = None, *, issue_token: Optional[Any] = None):
-    """按全局步骤注册表（``all_auth_steps()``）+ SSO 重定向注册表实时装配多步登录服务（装配桥）。
+    """按全局步骤注册表 + SSO 重定向注册表实时装配多步登录服务（端点薄壳）。
 
-    - 凭证步 = 本地 ``PasswordStep`` + 注册表中 step_kind ∈ ``_CREDENTIAL_STEP_KINDS`` 的插件步（排除冒充内建 id 者）
-      + SSO 注册表（``redirect.registered_provider_ids()``）每个提供方包装的 ``RedirectStep``
-      （把 SSO 注册表桥接进统一流程；与 ``all_auth_steps()`` 的 redirect 步按 step_id 去重，
-      内建 / all_auth_steps 优先）；
-    - 第二因子步 = 该用户的 per-user 内建因子 + 注册表中 step_kind=="factor" 的插件步（applies_to 自行 per-user 过滤）。
+    装配主体在 ``app.service.auth.assembler.build_flow_service``；本壳把端点侧依赖（流程状态存储、
+    凭证 step_kind 集、受信内建 id 集、内建因子构造、回调 URI 构造、用户加载、缺省发 Token、日志器）
+    按模块全局名在**调用时**取并透传，确保测试对这些模块级名字的 monkeypatch 仍被读到。
 
-    ``issue_token`` 可注入覆盖（缺省 ``build_token_response`` 产 Token；SSO 薄桥经浏览器导航无法回 JSON，
-    故注入"铸一次性 ticket"以经 ``/auth/exchange`` 兑换）。复用同一批步骤/因子，SSO 的条件 MFA 与密码登录一致。
+    :param request: 当前请求（用于推导 SSO 回调 redirect_uri；非端点直调时可为 None）
+    :param issue_token: 成功后铸 Token 的可注入覆盖（缺省由装配桥用 ``build_token_response``）
+    :return: 装配完成的 ``FlowService``
     """
-    from app.core.auth import redirect as sso_redirect
-    from app.core.auth.flow_registry import get_auth_flow
-    from app.core.auth.steps import all_auth_steps
-    from app.service.auth.flow_service import FlowService
-    from app.service.auth.flow_steps import (
-        AuxiliaryCredentialStep, PasskeyLoginStep, PasswordStep, RedirectStep, make_identity_resolver)
-    from app.service.auth.provisioning import default_deps
-
-    deps = default_deps()
-    steps = all_auth_steps()
-
-    # 受信 id 集先于过滤器计算：「可直接携 user_id」的内建 id == 「插件不得冒充」的排除 id，由构造保证二者一致。
-    # frozenset 来源 _BUILTIN_CREDENTIAL_IDS 防意外 mutate。
-    trusted_step_ids = _BUILTIN_CREDENTIAL_IDS | ({"auxiliary"} if settings.AUXILIARY_AUTH_ENABLE else set())
-
-    # PasskeyLoginStep 为内建受信凭证步（opt-in，仅 flow="system:passkey" 选中时参与）：
-    # 解析本地 User 受信直落 user_id（其 step_id 已在 trusted_step_ids 内）。
-    credential_steps = [PasswordStep(), PasskeyLoginStep()]
-    for s in steps:
-        if getattr(s, "step_kind", None) not in _CREDENTIAL_STEP_KINDS:
-            continue
-        sid = getattr(s, "step_id", None)
-        if sid in trusted_step_ids:
-            # 插件声称受信内建 id（如 "auxiliary"）→ 拦截并告警；冒充者不纳入凭证步，
-            # 杜绝插件以受信 id 绕过 owner 分流护栏直接落 user_id（镜像 SSO shadow 告警逻辑）。
-            logger.warning(
-                f"插件凭证步 '{sid}' 声称受信内建 step_id，已拒绝注册："
-                f"插件不得冒充内建凭证步以绕过 owner 分流护栏"
-            )
-            continue
-        credential_steps.append(s)
-
-    # 媒体服务器辅助认证（AUXILIARY_AUTH_ENABLE）：以受信内建凭证步恢复（密码失败后 OR 回落）。
-    # 其建号走媒体服务器专属 provisioning（_process_auth_success），须纳入 trusted_step_ids 方被引擎接受。
-    if settings.AUXILIARY_AUTH_ENABLE:
-        credential_steps.append(AuxiliaryCredentialStep())
-
-    # 桥接 SSO 注册表为统一流程的 RedirectStep（自签 flow 绑定 state + /auth/flow/callback 回调）；
-    # 按 step_id 去重：已在内建 / all_auth_steps 出现者优先（绝不被 SSO 覆盖，防内建受信步被影子化）。
-    existing_ids = {getattr(s, "step_id", None) for s in credential_steps}
-    for pid in sso_redirect.registered_provider_ids():
-        if pid in existing_ids:
-            # all_auth_steps() 的某凭证步已占用此 step_id → 该 SSO provider 被影子化、不纳入统一流程，
-            # 告警以便运维侦测命名冲突。
-            logger.warning(
-                f"SSO provider '{pid}' 被同名凭证步影子化，未纳入统一登录流程；请检查 step_id 冲突")
-            continue
-        provider = sso_redirect.get_auth_provider(pid)
-        if provider is None:
-            continue
-        credential_steps.append(RedirectStep(
-            provider,
-            issue_state=sso_redirect.issue_state,
-            redirect_uri=lambda: _flow_callback_uri(request),
-            consume_state=sso_redirect.consume_state,
-            deps=deps))
-        existing_ids.add(pid)
-
-    plugin_factor_steps = [s for s in steps if getattr(s, "step_kind", None) == "factor"]
-
-    # 流程形状可插拔：若有插件注册了名为 "default" 的流程规格（如 N-of-M 强 MFA），用其组合策略；
-    # 否则沿用默认 AnyOf（任一因子，复现 v2 OR）。注册期 verify_flow_spec_contract 已拒绝"空真"规格，
-    # 杜绝插件以 default 规格 vacuous 绕过 MFA。
-    default_spec = get_auth_flow("default")
-    mfa_requirement = (lambda steps: default_spec.mfa_requirement(steps)) if default_spec else None
-    return FlowService(
+    from app.service.auth.assembler import build_flow_service
+    return build_flow_service(
+        request=request,
+        issue_token=issue_token,
         flow_store=_FLOW_STORE,
-        credential_steps=credential_steps,
-        factor_steps_for=lambda user: _builtin_factor_steps(user) + plugin_factor_steps,
+        credential_step_kinds=_CREDENTIAL_STEP_KINDS,
+        builtin_credential_ids=_BUILTIN_CREDENTIAL_IDS,
+        builtin_factor_steps=_builtin_factor_steps,
+        flow_callback_uri=_flow_callback_uri,
         load_user=lambda uid: User.get(db=None, rid=uid),
-        issue_token=issue_token or build_token_response,
-        mfa_requirement=mfa_requirement,
-        identity_resolver=make_identity_resolver(deps),
-        trusted_step_ids=trusted_step_ids,
+        default_issue_token=build_token_response,
+        logger=logger,
     )
 
 

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 import concurrent
 import concurrent.futures
+import dataclasses
 import importlib.util
 import inspect
 import os
@@ -367,47 +368,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             plugins_to_reload = set()
             local_plugins_to_sync = {}
             for _change_type, path_str in changes:
-                event_path = Path(path_str)
-
-                # 跳过 pycache 目录中的文件
-                if "__pycache__" in event_path.parts:
-                    continue
-
-                if event_path.name == "requirements.txt":
-                    candidate = self._get_local_plugin_candidate_from_path(event_path)
-                    if candidate:
-                        if candidate.get("compatible") is False:
-                            logger.info(
-                                f"检测到本地插件 {candidate.get('id')} 依赖文件变化，"
-                                f"但跳过处理：{candidate.get('skip_reason')}"
-                            )
-                            continue
-                        logger.warn(f"检测到本地插件 {candidate.get('id')} 依赖文件变化，请重新安装本地插件以安装依赖")
-                    continue
-
-                # 跳过非 .py 文件
-                if not event_path.name.endswith(".py"):
-                    continue
-
-                # 解析插件ID
-                runtime_pid = self._get_plugin_id_from_path(event_path)
-                local_candidate = self._get_local_plugin_candidate_from_path(event_path) if not runtime_pid else None
-                if runtime_pid:
-                    last_sync_time = self._recent_local_sync.get(runtime_pid)
-                    if last_sync_time and time.time() - last_sync_time < 2:
-                        continue
-                    # 运行目录变化只重载，不能反向触发本地同步。
-                    plugins_to_reload.add(runtime_pid)
-                elif local_candidate:
-                    if local_candidate.get("compatible") is False:
-                        package_version = local_candidate.get("package_version")
-                        source_root = f"plugins.{package_version}" if package_version else "plugins"
-                        logger.info(
-                            f"检测到本地插件 {local_candidate.get('id')} 文件变化，来源：{source_root}，"
-                            f"文件：{event_path}，但跳过同步：{local_candidate.get('skip_reason')}"
-                        )
-                        continue
-                    local_plugins_to_sync[local_candidate.get("id")] = (local_candidate, event_path)
+                self._collect_watch_change(Path(path_str), plugins_to_reload, local_plugins_to_sync)
 
             for pid, (candidate, event_path) in local_plugins_to_sync.items():
                 package_version = candidate.get("package_version")
@@ -424,6 +385,61 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                         self.reload_plugin(pid)
                     except Exception as e:
                         logger.error(f"插件 {pid} 热重载失败: {e}", exc_info=True)
+
+    def _collect_watch_change(self, event_path: Path, plugins_to_reload: set,
+                              local_plugins_to_sync: dict) -> None:
+        """
+        归类单个文件变化事件，按需登记重载或本地同步目标。
+
+        :param event_path: 变化的文件路径
+        :param plugins_to_reload: 待重载插件 id 集合（原地累加）
+        :param local_plugins_to_sync: 待同步本地插件 {id: (candidate, path)}（原地累加）
+        :return: 无
+        """
+        # 跳过 pycache 目录中的文件
+        if "__pycache__" in event_path.parts:
+            return
+
+        # 依赖文件变化：仅提示，不触发重载/同步
+        if event_path.name == "requirements.txt":
+            candidate = self._get_local_plugin_candidate_from_path(event_path)
+            if not candidate:
+                return
+            if candidate.get("compatible") is False:
+                logger.info(
+                    f"检测到本地插件 {candidate.get('id')} 依赖文件变化，"
+                    f"但跳过处理：{candidate.get('skip_reason')}"
+                )
+                return
+            logger.warn(f"检测到本地插件 {candidate.get('id')} 依赖文件变化，请重新安装本地插件以安装依赖")
+            return
+
+        # 跳过非 .py 文件
+        if not event_path.name.endswith(".py"):
+            return
+
+        # 运行目录变化：只重载，不能反向触发本地同步
+        runtime_pid = self._get_plugin_id_from_path(event_path)
+        if runtime_pid:
+            last_sync_time = self._recent_local_sync.get(runtime_pid)
+            if last_sync_time and time.time() - last_sync_time < 2:
+                return
+            plugins_to_reload.add(runtime_pid)
+            return
+
+        # 本地插件源变化：登记待同步
+        local_candidate = self._get_local_plugin_candidate_from_path(event_path)
+        if not local_candidate:
+            return
+        if local_candidate.get("compatible") is False:
+            package_version = local_candidate.get("package_version")
+            source_root = f"plugins.{package_version}" if package_version else "plugins"
+            logger.info(
+                f"检测到本地插件 {local_candidate.get('id')} 文件变化，来源：{source_root}，"
+                f"文件：{event_path}，但跳过同步：{local_candidate.get('skip_reason')}"
+            )
+            return
+        local_plugins_to_sync[local_candidate.get("id")] = (local_candidate, event_path)
 
     @staticmethod
     def _get_plugin_id_from_path(event_path: Path) -> Optional[str]:
@@ -650,63 +666,34 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     except Exception as err:
                         logger.error(f"注册插件 {plugin_id} 存储器 "
                                      f"{getattr(storage_cls, '__name__', storage_cls)} 出错：{str(err)}")
-        # 注册插件经 provides_channel_capabilities 声明的消息渠道能力矩阵
-        provided_caps = plugin_metadata.get_plugin_provided_channel_capabilities(self._running_plugins, pid)
-        if provided_caps:
-            from app.schemas.message import ChannelCapabilityManager
-            for plugin_id, caps_list in provided_caps.items():
-                for caps in caps_list:
-                    try:
-                        ChannelCapabilityManager.register_capabilities(
-                            getattr(caps, "channel", None), caps, owner=plugin_id)
-                    except Exception as err:
-                        logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
-        # 注册插件经 provides_auth_providers 声明的 SSO 登录提供方（按 provider_id 单索引、owner=plugin_id）：
-        # 与各契约域不同，登录提供方不进 ModuleManager/chain，而是注册到 app.core.auth.redirect 由 SSO 端点统一驱动。
-        provided_auth = plugin_metadata.get_plugin_provided_auth_providers(self._running_plugins, pid)
-        if provided_auth:
-            from app.core.auth.redirect import register_auth_provider
-            for plugin_id, providers in provided_auth.items():
-                for provider in providers:
-                    ok, reason = register_auth_provider(provider, owner=plugin_id)
-                    if not ok:
-                        logger.warning(f"注册插件 {plugin_id} 登录提供方 "
-                                       f"{getattr(provider, 'provider_id', provider)} 失败：{reason}")
-        # 注册插件经 provides_auth_flows 声明的自定义认证流程规格（owner=plugin_id）：
-        provided_flows = plugin_metadata.get_plugin_provided_auth_flows(self._running_plugins, pid)
-        if provided_flows:
-            from app.core.auth.flow_registry import register_auth_flow
-            for plugin_id, flows in provided_flows.items():
-                for spec in flows:
-                    ok, reason = register_auth_flow(spec, owner=plugin_id)
-                    if not ok:
-                        logger.warning(f"注册插件 {plugin_id} 认证流程 "
-                                       f"{getattr(spec, 'flow_id', spec)} 失败：{reason}")
-        # 注册插件经 provides_auth_steps 声明的【统一】认证步骤（owner=plugin_id，进全局步骤注册表）：
-        # 单 SPI 收口——装配桥（_build_flow_service）按 step_kind 切分后入多步流程。
-        provided_steps = plugin_metadata.get_plugin_provided_auth_steps(self._running_plugins, pid)
-        if provided_steps:
-            from app.core.auth.steps import register_auth_step
-            for plugin_id, steps in provided_steps.items():
-                for step in steps:
-                    ok, reason = register_auth_step(step, owner=plugin_id)
-                    if not ok:
-                        logger.warning(f"注册插件 {plugin_id} 认证步骤 "
-                                       f"{getattr(step, 'step_id', step)} 失败：{reason}")
-        # 注册插件经 provides_* 声明新增的各契约域模块（数据源/下载器/消息渠道/媒体服务器）：
+        # 注册插件经 provides_auth_* 声明的认证域实例（登录提供方 / 认证流程 / 认证步骤）：
+        # 不进 ModuleManager/chain，而是注册到 app.core.auth 各注册表（owner=plugin_id），由认证流程统一驱动。
+        from app.core.auth.flow_registry import register_auth_flow
+        from app.core.auth.redirect import register_auth_provider
+        from app.core.auth.steps import register_auth_step
+        for _get_provided, _register, _id_attr, _label in (
+            (plugin_metadata.get_plugin_provided_auth_providers, register_auth_provider, "provider_id", "登录提供方"),
+            (plugin_metadata.get_plugin_provided_auth_flows, register_auth_flow, "flow_id", "认证流程"),
+            (plugin_metadata.get_plugin_provided_auth_steps, register_auth_step, "step_id", "认证步骤"),
+        ):
+            self._register_auth_domain(pid, _get_provided, _register, _id_attr, _label)
+        # 注册插件经 provides_* 声明新增的各契约域模块（数据源/下载器/媒体服务器）：
         # 经各自契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 chain 分发。
         for _get_provided, _verify, _label in (
             (plugin_metadata.get_plugin_provided_data_sources, ModuleManager.verify_data_source_contract, "数据源"),
             (plugin_metadata.get_plugin_provided_downloaders, ModuleManager.verify_downloader_contract, "下载器"),
-            (plugin_metadata.get_plugin_provided_notifications, ModuleManager.verify_notification_contract, "消息渠道"),
             (plugin_metadata.get_plugin_provided_mediaservers, ModuleManager.verify_mediaserver_contract, "媒体服务器"),
         ):
             self._register_contract_domain(pid, _get_provided, _verify, _label)
+        # 注册插件经 provides_notifications 声明【新增】的消息渠道（Notification 域）：经契约校验注册模块外，
+        # 渠道模块自带的 get_channel_capabilities() 能力矩阵随注册一并登记（能力声明收口于渠道模块）。
+        self._register_notification_domain(pid)
 
     def _register_contract_domain(self, pid, get_provided, verify_contract, label: str):
         """
-        注册某契约域插件类的共用实现（数据源/下载器/消息渠道/媒体服务器）：聚合插件声明的类 →
+        注册某契约域插件类的共用实现（数据源/下载器/媒体服务器）：聚合插件声明的类 →
         经域契约校验（不通过仅警告拒绝、不影响其它）→ register_module(owner=plugin_id)。
+        消息渠道（Notification 域）另经 _register_notification_domain 处理（需附带能力矩阵登记）。
         """
         for plugin_id, classes in get_provided(self._running_plugins, pid).items():
             for cls in classes:
@@ -720,6 +707,71 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     ModuleManager().register_module(cls, owner=plugin_id)
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} {label} {_name} 出错：{str(err)}")
+
+    def _register_notification_domain(self, pid: Optional[str] = None) -> None:
+        """
+        注册插件经 provides_notifications 声明【新增】的消息渠道（Notification 域）：聚合插件声明的类 →
+        经消息渠道契约校验（不通过仅警告拒绝、不影响其它）→ register_module(owner=plugin_id) 进 chain 分发 →
+        读取渠道模块运行实例自带的 get_channel_capabilities() 能力矩阵一并登记到 ChannelCapabilityManager
+        （能力声明随渠道模块一处声明）。
+        """
+        for plugin_id, classes in plugin_metadata.get_plugin_provided_notifications(self._running_plugins, pid).items():
+            for cls in classes:
+                _name = getattr(cls, "__name__", cls)
+                ok, reasons = ModuleManager.verify_notification_contract(cls)
+                if not ok:
+                    logger.warning(f"插件 {plugin_id} 消息渠道 {_name} 未通过消息渠道契约校验，拒绝注册："
+                                   f"{'；'.join(reasons)}")
+                    continue
+                try:
+                    if not ModuleManager().register_module(cls, owner=plugin_id):
+                        continue
+                except Exception as err:
+                    logger.error(f"注册插件 {plugin_id} 消息渠道 {_name} 出错：{str(err)}")
+                    continue
+                self._register_channel_capabilities(plugin_id, cls)
+
+    @staticmethod
+    def _register_channel_capabilities(plugin_id: str, module_cls: type) -> None:
+        """
+        从已注册的消息渠道模块运行实例读取其自带 get_channel_capabilities() 能力矩阵，按 get_subtype_id()
+        的 channel id 登记到 ChannelCapabilityManager（owner=plugin_id）。模块未声明能力则跳过，走降级默认。
+        channel id 仅在模块 get_subtype_id() 一处声明，能力矩阵的 channel 字段以此为准盖章，避免两处对齐。
+        """
+        instance = ModuleManager().get_running_module(getattr(module_cls, "__name__", ""))
+        getter = getattr(instance, "get_channel_capabilities", None)
+        if not callable(getter):
+            return
+        try:
+            caps = getter()
+            if caps is None:
+                return
+            channel_id = instance.get_subtype_id()
+            if not channel_id:
+                return
+            from app.schemas.message import ChannelCapabilityManager
+            ChannelCapabilityManager.register_capabilities(
+                channel_id, dataclasses.replace(caps, channel=channel_id), owner=plugin_id)
+        except Exception as err:
+            logger.error(f"注册插件 {plugin_id} 渠道能力出错：{str(err)}")
+
+    def _register_auth_domain(self, pid, get_provided, register_fn, id_attr: str, label: str) -> None:
+        """
+        注册某认证域插件实例的共用实现（登录提供方 / 认证流程 / 认证步骤）：聚合插件声明的实例 →
+        经 register_fn 注册到对应核心注册表（owner=plugin_id）→ 失败仅警告、不影响其它。
+
+        :param pid: 目标插件 id；None 表示全部运行中插件
+        :param get_provided: plugin_metadata 中对应的聚合函数
+        :param register_fn: 核心注册表的注册函数，签名 (item, owner) -> (ok, reason)
+        :param id_attr: 用于日志的实例标识属性名（provider_id / flow_id / step_id）
+        :param label: 中文域名（用于日志）
+        :return: 无
+        """
+        for plugin_id, items in get_provided(self._running_plugins, pid).items():
+            for item in items:
+                ok, reason = register_fn(item, owner=plugin_id)
+                if not ok:
+                    logger.warning(f"注册插件 {plugin_id} {label} {getattr(item, id_attr, item)} 失败：{reason}")
 
     def _unregister_plugin_modules(self, plugin_ids: List[str]):
         """
@@ -1299,10 +1351,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # ID
         plugin.id = pid
         # 安装状态
-        if pid in installed_apps and plugin_static:
-            plugin.installed = True
-        else:
-            plugin.installed = False
+        plugin.installed = bool(pid in installed_apps and plugin_static)
         # 是否有新版本
         plugin.has_update = False
         if plugin_static:
@@ -1327,36 +1376,27 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         else:
             plugin.state = False
         # 是否有详情页面
-        plugin.has_page = False
-        if plugin_obj and hasattr(plugin_obj, "get_page"):
-            if ObjectUtils.check_method(plugin_obj.get_page):
-                plugin.has_page = True
-        # 公钥
-        if plugin_info.get("key"):
-            plugin.plugin_public_key = plugin_info.get("key")
+        plugin.has_page = bool(
+            plugin_obj and hasattr(plugin_obj, "get_page")
+            and ObjectUtils.check_method(plugin_obj.get_page))
         # 权限
         if not self.__set_and_check_auth_level(plugin=plugin, source=plugin_info):
             return None
-        # 名称
-        if plugin_info.get("name"):
-            plugin.plugin_name = plugin_info.get("name")
-        # 描述
-        if plugin_info.get("description"):
-            plugin.plugin_desc = plugin_info.get("description")
-        # 版本
-        if plugin_info.get("version"):
-            plugin.plugin_version = plugin_info.get("version")
-        # 图标
-        if plugin_info.get("icon"):
-            plugin.plugin_icon = plugin_info.get("icon")
+        # 市场字段 → Plugin 属性：仅当市场提供真值时覆盖，否则保留 schema 默认值
+        for field, attr in (
+            ("key", "plugin_public_key"),
+            ("name", "plugin_name"),
+            ("description", "plugin_desc"),
+            ("version", "plugin_version"),
+            ("icon", "plugin_icon"),
+            ("author", "plugin_author"),
+            ("history", "history"),
+        ):
+            value = plugin_info.get(field)
+            if value:
+                setattr(plugin, attr, value)
         # 标签
         plugin.plugin_label = self._normalize_plugin_label(plugin_info.get("labels"))
-        # 作者
-        if plugin_info.get("author"):
-            plugin.plugin_author = plugin_info.get("author")
-        # 更新历史
-        if plugin_info.get("history"):
-            plugin.history = plugin_info.get("history")
         # Release 能力位来自插件市场索引，用于前端展示和后端安装入口双重校验。
         plugin.release = bool(plugin_info.get("release"))
         # 仓库链接

--- a/app/helper/plugin_metadata.py
+++ b/app/helper/plugin_metadata.py
@@ -205,10 +205,6 @@ def get_plugin_provided_auth_providers(running_plugins, pid: Optional[str] = Non
     """聚合插件经 provides_auth_providers() 声明【新增】的 SSO 登录提供方实例，按 plugin_id 归集。"""
     return _get_plugin_provided(running_plugins, "provides_auth_providers", "注册登录提供方", pid)
 
-def get_plugin_provided_channel_capabilities(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
-    """聚合插件经 provides_channel_capabilities() 声明【新增】的消息渠道能力矩阵，按 plugin_id 归集。"""
-    return _get_plugin_provided(running_plugins, "provides_channel_capabilities", "注册渠道能力", pid)
-
 def get_plugin_provided_auth_flows(running_plugins, pid: Optional[str] = None) -> Dict[str, List[Any]]:
     """聚合插件经 provides_auth_flows() 声明【新增】的自定义流程规格实例，按 plugin_id 归集。"""
     return _get_plugin_provided(running_plugins, "provides_auth_flows", "注册认证流程", pid)

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -227,17 +227,6 @@ class _PluginBase(metaclass=ABCMeta):
         """
         return []
 
-    def provides_channel_capabilities(self) -> List[Any]:
-        """
-        声明本插件新增的消息渠道的能力矩阵（配合 provides_modules 新增消息渠道模块使用）。
-        返回 ChannelCapabilities 实例列表，每个实例的 channel 字段为该渠道的字符串 id
-        （无需扩展封闭 MessageChannel 枚举）。由框架注册到 ChannelCapabilityManager，
-        使插件渠道获得正确的按钮/Markdown/分段等能力声明（不声明则走降级默认）。默认不新增。
-
-        [ChannelCapabilities(channel="mychannel", capabilities={...}), ...]
-        """
-        return []
-
     def provides_data_sources(self) -> List[Type]:
         """
         声明本插件向模块层【新增】的数据源（媒体识别/信息源，MediaRecognize 域）类，
@@ -270,7 +259,8 @@ class _PluginBase(metaclass=ABCMeta):
         契约且 get_type()==ModuleType.Notification，并实现 post_message（其余 post_medias /
         post_torrents / delete_message / register_commands 等由 run_module 按方法名分发、按需实现）。
         子类型用 get_subtype_id() 返回字符串 id（无需扩展封闭 MessageChannel 枚举）；
-        渠道的按钮/Markdown/分段等能力矩阵另经 provides_channel_capabilities() 声明。默认不新增。
+        渠道的按钮/Markdown/分段等能力矩阵由渠道模块自带的 get_channel_capabilities() 声明（返回
+        ChannelCapabilities，其 channel 以 get_subtype_id() 为准盖章；不声明则走降级默认）。默认不新增。
 
         [MyNotificationClass, ...]
         """

--- a/app/service/auth/assembler.py
+++ b/app/service/auth/assembler.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""多步登录服务的装配桥：按全局步骤注册表与 SSO 重定向注册表实时拼装 ``FlowService``。
+
+凭证步、第二因子步、流程形状（MFA 组合策略）与外部依赖（流程状态存储、内建凭证 id 集合、
+内建因子构造、回调 URI 构造）全部由调用方注入，本模块只负责把它们组合成统一多步登录服务。
+"""
+from typing import Any, Callable, Optional
+
+from fastapi import Request
+
+from app.core.config import settings
+
+
+def build_flow_service(
+    *,
+    request: Optional[Request],
+    issue_token: Optional[Any],
+    flow_store: Any,
+    credential_step_kinds: set,
+    builtin_credential_ids: frozenset,
+    builtin_factor_steps: Callable[[Any], list],
+    flow_callback_uri: Callable[[Optional[Request]], str],
+    load_user: Callable[[Any], Any],
+    default_issue_token: Callable[[Any], Any],
+    logger: Any,
+):
+    """按全局步骤注册表（``all_auth_steps()``）+ SSO 重定向注册表实时装配多步登录服务（装配桥）。
+
+    - 凭证步 = 本地 ``PasswordStep`` + 注册表中 step_kind ∈ ``credential_step_kinds`` 的插件步（排除冒充内建 id 者）
+      + SSO 注册表（``redirect.registered_provider_ids()``）每个提供方包装的 ``RedirectStep``
+      （把 SSO 注册表桥接进统一流程；与 ``all_auth_steps()`` 的 redirect 步按 step_id 去重，
+      内建 / all_auth_steps 优先）；
+    - 第二因子步 = 该用户的 per-user 内建因子 + 注册表中 step_kind=="factor" 的插件步（applies_to 自行 per-user 过滤）。
+
+    :param request: 当前请求（用于推导 SSO 回调 redirect_uri；非端点直调时可为 None）
+    :param issue_token: 成功后铸 Token 的可注入覆盖（缺省用 ``build_token_response``；SSO 薄桥注入"铸一次性
+        ticket"以经 ``/auth/exchange`` 兑换，因浏览器导航无法回 JSON）
+    :param flow_store: 多步登录流程状态存储
+    :param credential_step_kinds: 归入凭证阶段（解析用户）的 step_kind 集合
+    :param builtin_credential_ids: 受信内建凭证 id 集合（可直携 user_id，且禁止插件冒充）
+    :param builtin_factor_steps: 给定 user 返回其 per-user 内建第二因子步列表的构造函数
+    :param flow_callback_uri: 给定 request 构造统一流程 SSO 回调 redirect_uri 的函数
+    :param load_user: 给定 user_id 加载本地用户的函数
+    :param default_issue_token: 缺省铸 Token 的函数（``issue_token`` 为空时使用）
+    :param logger: 装配期告警（凭证步冒充内建 id / SSO 影子化命名冲突）所用日志器
+    :return: 装配完成的 ``FlowService``
+    """
+    from app.core.auth import redirect as sso_redirect
+    from app.core.auth.flow_registry import get_auth_flow
+    from app.core.auth.steps import all_auth_steps
+    from app.service.auth.flow_service import FlowService
+    from app.service.auth.flow_steps import (
+        AuxiliaryCredentialStep, PasskeyLoginStep, PasswordStep, RedirectStep, make_identity_resolver)
+    from app.service.auth.provisioning import default_deps
+
+    deps = default_deps()
+    steps = all_auth_steps()
+
+    # 受信 id 集先于过滤器计算：「可直接携 user_id」的内建 id == 「插件不得冒充」的排除 id，由构造保证二者一致。
+    # frozenset 来源 builtin_credential_ids 防意外 mutate。
+    trusted_step_ids = builtin_credential_ids | ({"auxiliary"} if settings.AUXILIARY_AUTH_ENABLE else set())
+
+    # PasskeyLoginStep 为内建受信凭证步（opt-in，仅 flow="system:passkey" 选中时参与）：
+    # 解析本地 User 受信直落 user_id（其 step_id 已在 trusted_step_ids 内）。
+    credential_steps = [PasswordStep(), PasskeyLoginStep()]
+    for s in steps:
+        if getattr(s, "step_kind", None) not in credential_step_kinds:
+            continue
+        sid = getattr(s, "step_id", None)
+        if sid in trusted_step_ids:
+            # 插件声称受信内建 id（如 "auxiliary"）→ 拦截并告警；冒充者不纳入凭证步，
+            # 杜绝插件以受信 id 绕过 owner 分流护栏直接落 user_id（镜像 SSO shadow 告警逻辑）。
+            logger.warning(
+                f"插件凭证步 '{sid}' 声称受信内建 step_id，已拒绝注册："
+                f"插件不得冒充内建凭证步以绕过 owner 分流护栏"
+            )
+            continue
+        credential_steps.append(s)
+
+    # 媒体服务器辅助认证（AUXILIARY_AUTH_ENABLE）：以受信内建凭证步恢复（密码失败后 OR 回落）。
+    # 其建号走媒体服务器专属 provisioning（_process_auth_success），须纳入 trusted_step_ids 方被引擎接受。
+    if settings.AUXILIARY_AUTH_ENABLE:
+        credential_steps.append(AuxiliaryCredentialStep())
+
+    # 桥接 SSO 注册表为统一流程的 RedirectStep（自签 flow 绑定 state + /auth/flow/callback 回调）；
+    # 按 step_id 去重：已在内建 / all_auth_steps 出现者优先（绝不被 SSO 覆盖，防内建受信步被影子化）。
+    existing_ids = {getattr(s, "step_id", None) for s in credential_steps}
+    for pid in sso_redirect.registered_provider_ids():
+        if pid in existing_ids:
+            # all_auth_steps() 的某凭证步已占用此 step_id → 该 SSO provider 被影子化、不纳入统一流程，
+            # 告警以便运维侦测命名冲突。
+            logger.warning(
+                f"SSO provider '{pid}' 被同名凭证步影子化，未纳入统一登录流程；请检查 step_id 冲突")
+            continue
+        provider = sso_redirect.get_auth_provider(pid)
+        if provider is None:
+            continue
+        credential_steps.append(RedirectStep(
+            provider,
+            issue_state=sso_redirect.issue_state,
+            redirect_uri=lambda: flow_callback_uri(request),
+            consume_state=sso_redirect.consume_state,
+            deps=deps))
+        existing_ids.add(pid)
+
+    plugin_factor_steps = [s for s in steps if getattr(s, "step_kind", None) == "factor"]
+
+    # 流程形状可插拔：若有插件注册了名为 "default" 的流程规格（如 N-of-M 强 MFA），用其组合策略；
+    # 否则沿用默认 AnyOf（任一因子，复现 v2 OR）。注册期 verify_flow_spec_contract 已拒绝"空真"规格，
+    # 杜绝插件以 default 规格 vacuous 绕过 MFA。
+    default_spec = get_auth_flow("default")
+    mfa_requirement = (lambda steps: default_spec.mfa_requirement(steps)) if default_spec else None
+    return FlowService(
+        flow_store=flow_store,
+        credential_steps=credential_steps,
+        factor_steps_for=lambda user: builtin_factor_steps(user) + plugin_factor_steps,
+        load_user=load_user,
+        issue_token=issue_token or default_issue_token,
+        mfa_requirement=mfa_requirement,
+        identity_resolver=make_identity_resolver(deps),
+        trusted_step_ids=trusted_step_ids,
+    )

--- a/tests/test_channel_capability_open.py
+++ b/tests/test_channel_capability_open.py
@@ -1,40 +1,94 @@
 # -*- coding: utf-8 -*-
 """
-Q1-S6 回归测试：ChannelCapabilityManager 消息渠道能力矩阵开放注册。
+消息渠道能力矩阵开放注册回归。
 
 验证：
   1. register_capabilities(channel, caps, owner) 后，get_capabilities/supports_* 能查到插件渠道
      （按字符串 channel id 容错匹配，无需扩展封闭 MessageChannel 枚举）；
   2. unregister_capabilities(owner) 后插件渠道能力下线；
   3. 内建渠道（如 Telegram）能力不受影响；
-  4. PluginManager._register/_unregister_plugin_modules 接通 provides_channel_capabilities。
+  4. 能力声明收口进渠道模块：PluginManager 注册 provides_notifications 渠道模块时，自动读取其
+     get_channel_capabilities() 能力矩阵并登记，channel id 取自模块 get_subtype_id()（一处声明）；
+     卸载插件时能力一并下线；未声明能力的渠道模块走降级默认。
 """
 from unittest import TestCase
 
+from app.core.module import ModuleManager
 from app.helper.plugin_manager import PluginManager
+from app.modules import _ModuleBase
 from app.schemas.message import (
     ChannelCapabilityManager,
     ChannelCapabilities,
     ChannelCapability,
 )
-from app.schemas.types import MessageChannel
+from app.schemas.types import MessageChannel, ModuleType
 
 
 _OWNER = "test.plugin.q1s6"
 _CHANNEL = "mychannel"
 
 
-def _make_caps():
+def _make_caps(channel=_CHANNEL):
     return ChannelCapabilities(
-        channel=_CHANNEL,
+        channel=channel,
         capabilities={ChannelCapability.INLINE_BUTTONS, ChannelCapability.MARKDOWN},
         max_buttons_per_row=3,
     )
 
 
+class _ChannelModuleBase(_ModuleBase):
+    """实现 _ModuleBase 契约 + 消息渠道核心方法的测试用渠道模块基类。"""
+
+    def init_module(self) -> None:
+        pass
+
+    def init_setting(self):
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def test(self):
+        return True, ""
+
+    def post_message(self, *args, **kwargs):
+        return None
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        return ModuleType.Notification
+
+
+class _CapableChannel(_ChannelModuleBase):
+    """自带能力声明的插件渠道模块：get_subtype_id() 即唯一 channel id 声明处。"""
+
+    def get_subtype_id(self) -> str:
+        return _CHANNEL
+
+    def get_channel_capabilities(self):
+        return _make_caps(channel=_CHANNEL)
+
+
+class _MislabeledChannel(_ChannelModuleBase):
+    """能力声明里 channel 字段填错的渠道模块：框架应以 get_subtype_id() 为准登记。"""
+
+    def get_subtype_id(self) -> str:
+        return "rightchannel"
+
+    def get_channel_capabilities(self):
+        return _make_caps(channel="WRONGCHANNEL")
+
+
+class _PlainChannel(_ChannelModuleBase):
+    """不声明能力的插件渠道模块：注册成功，能力走降级默认。"""
+
+    def get_subtype_id(self) -> str:
+        return "plainchannel"
+
+
 class _FakeChannelPlugin:
-    def __init__(self, caps):
-        self._caps = caps
+    def __init__(self, module_cls):
+        self._module_cls = module_cls
 
     def get_state(self) -> bool:
         return True
@@ -42,17 +96,12 @@ class _FakeChannelPlugin:
     def get_name(self) -> str:
         return "FakeChannelPlugin"
 
-    def provides_modules(self):
-        return []
-
-    def provides_storages(self):
-        return []
-
-    def provides_channel_capabilities(self):
-        return [self._caps]
+    def provides_notifications(self):
+        return [self._module_cls]
 
 
-class ChannelCapabilityOpenTest(TestCase):
+class ChannelCapabilityManagerTest(TestCase):
+    """直连 ChannelCapabilityManager API 的回归（与插件注册路径无关）。"""
 
     def tearDown(self):
         ChannelCapabilityManager.unregister_capabilities(_OWNER)
@@ -81,16 +130,51 @@ class ChannelCapabilityOpenTest(TestCase):
         self.assertIs(ChannelCapabilityManager.get_capabilities(MessageChannel.Telegram), before)
         self.assertTrue(ChannelCapabilityManager.supports_buttons(MessageChannel.Telegram))
 
-    def test_plugin_manager_wires_capabilities(self):
+
+class ChannelCapabilityWiringTest(TestCase):
+    """能力声明收口进渠道模块：经 PluginManager 注册路径接通。"""
+
+    def _run_with_plugin(self, module_cls):
         pm = PluginManager()
         saved = dict(pm._running_plugins)
-        caps = _make_caps()
+        pm._running_plugins = {_OWNER: _FakeChannelPlugin(module_cls)}
         try:
-            pm._running_plugins = {_OWNER: _FakeChannelPlugin(caps)}
             pm._register_plugin_modules()
-            self.assertIs(ChannelCapabilityManager.get_capabilities(_CHANNEL), caps)
-            pm._unregister_plugin_modules([_OWNER])
-            self.assertIsNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
         finally:
             pm._running_plugins = saved
-            ChannelCapabilityManager.unregister_capabilities(_OWNER)
+        return pm
+
+    def _cleanup(self):
+        ChannelCapabilityManager.unregister_capabilities(_OWNER)
+        ModuleManager().unregister_modules(_OWNER)
+
+    def tearDown(self):
+        self._cleanup()
+
+    def test_capabilities_registered_from_module(self):
+        self._run_with_plugin(_CapableChannel)
+        self.assertIsNotNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
+        self.assertTrue(ChannelCapabilityManager.supports_buttons(_CHANNEL))
+        self.assertTrue(ChannelCapabilityManager.supports_markdown(_CHANNEL))
+        self.assertEqual(ChannelCapabilityManager.get_max_buttons_per_row(_CHANNEL), 3)
+
+    def test_channel_id_taken_from_module_subtype(self):
+        # 能力声明里 channel="WRONGCHANNEL"，但框架以 get_subtype_id()="rightchannel" 登记
+        self._run_with_plugin(_MislabeledChannel)
+        self.assertIsNotNone(ChannelCapabilityManager.get_capabilities("rightchannel"))
+        self.assertTrue(ChannelCapabilityManager.supports_buttons("rightchannel"))
+        self.assertIsNone(ChannelCapabilityManager.get_capabilities("WRONGCHANNEL"))
+
+    def test_unregister_removes_capabilities(self):
+        pm = self._run_with_plugin(_CapableChannel)
+        self.assertIsNotNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
+        pm._unregister_plugin_modules([_OWNER])
+        self.assertIsNone(ChannelCapabilityManager.get_capabilities(_CHANNEL))
+
+    def test_notification_without_capabilities_falls_back(self):
+        self._run_with_plugin(_PlainChannel)
+        # 渠道模块本身已注册进 ModuleManager
+        self.assertIn(_PlainChannel.__name__, ModuleManager().get_external_module_ids(_OWNER))
+        # 未声明能力 → 走降级默认（不支持按钮）
+        self.assertIsNone(ChannelCapabilityManager.get_capabilities("plainchannel"))
+        self.assertFalse(ChannelCapabilityManager.supports_buttons("plainchannel"))

--- a/tests/test_discover_recommend_registration.py
+++ b/tests/test_discover_recommend_registration.py
@@ -8,8 +8,7 @@
      「事件扩展源（ChainEventType）」，并按 api_path 去重（声明式优先、向后兼容事件）。
 
 与消息渠道/媒体服务器（模块类注册）不同，发现/推荐是【数据对象】注册（DiscoverMediaSource /
-RecommendMediaSource），仿 provides_channel_capabilities 范式，仅在 /source 端点聚合枚举，
-不进入 run_module 分发。
+RecommendMediaSource），仅在 /source 端点聚合枚举，不进入 run_module 分发。
 """
 from unittest import TestCase
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## 概述
本 PR 含两块独立重构：

### 1. auth 装配桥抽离
多步登录装配逻辑从端点 `app/api/endpoints/auth.py` 抽到新模块 `app/service/auth/assembler.py`
（`build_flow_service` 装配桥）；端点改为薄壳，注入流程状态存储 / 凭证 step_kind 集 / 受信内建 id 集 /
内建因子构造 / 回调 URI 构造等依赖后委托装配。降低端点复杂度、装配逻辑可独立测试。

### 2. 插件渠道能力声明收口
删除独立的 `provides_channel_capabilities` 钩子，渠道能力改由渠道模块自带 `get_channel_capabilities()`：
`PluginManager` 注册渠道模块后读取实例能力矩阵，按其 `get_subtype_id()` 盖章登记到
`ChannelCapabilityManager`（channel id 仅一处声明，消除原"模块与能力两处手工对齐 channel id"的隐患）。
同步删除 `plugin_metadata` 对应聚合器；内建渠道仍走 `message.py` 静态能力表，不受影响。

## 测试
- `tests/test_channel_capability_open.py` 改写到新 API（manager 直连 + 经 PluginManager 注册路径接通）
- 渠道能力及相邻注册回归全绿：channel_capability / notification_registration / plugin_metadata /
  spi_aggregator / discover_recommend / message_processing_status / feishu 等
- import 冒烟通过
