### PR TITLE
fix(auth): #51 /auth/flow/begin 补限流防口令暴破 [P0安全·非破坏·优先级1/3]

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -239,6 +239,20 @@ def _flow_http(result: dict, username: Optional[str], request: Request,
     return result
 
 
+def _check_flow_rate_limit(request: Request, username: Optional[str]) -> None:
+    """未认证口令校验端点防暴力破解（CWE-307）：按 (ip+username) 滑窗限流后放行，超阈值抛 429。
+
+    /flow/begin 与 /flow/advance 共用同一限流器实例（``_auth_advance_rate_limiter``）与异常类型
+    （``RateLimitExceededException``），策略与 /access-token 一致（10 次 / 60 秒），由本函数单一来源保证。
+    ``username`` 为空（纯枚举/SSO begin）时退化为按 ip 限流。"""
+    client_ip = request.client.host if request.client else "unknown"
+    rl_key = f"{client_ip}:{username}" if username else client_ip
+    try:
+        _auth_advance_rate_limiter.check(rl_key)
+    except RateLimitExceededException:
+        raise HTTPException(status_code=429, detail="尝试过于频繁，请稍后再试")
+
+
 @router.post("/flow/begin", summary="开始多步登录流程")
 def flow_begin(body: schemas.FlowBeginRequest, request: Request, response: Response = None) -> dict:
     """开始一条可组合、可多轮的登录流程。返回 ``status``：success（带 token）/ mfa_required /
@@ -247,7 +261,9 @@ def flow_begin(body: schemas.FlowBeginRequest, request: Request, response: Respo
     携带 ``flow="<provider_id>"`` 时定向到该 SSO/重定向步，直接下发跳转挑战（authorize_url），SSO 由此
     进入与密码/因子同一条统一流程；浏览器 302 至 IdP 后经 ``/auth/flow/callback`` 薄桥回灌推进。
 
+    入口按 (ip+username) 限流（与 /flow/advance、/access-token 同策略），防止口令暴力穷举（CWE-307）。
     成功时写入资源 Cookie（FastAPI 注入 ``response``；与 /access-token 一致）。"""
+    _check_flow_rate_limit(request, body.username)
     result = _build_flow_service(request).begin(body)
     return _flow_http(result, body.username, request, response)
 
@@ -257,13 +273,7 @@ def flow_advance(body: schemas.FlowAdvanceRequest, request: Request, response: R
     """凭 ``flow_token`` 推进下一步（提交因子码 / 挑战应答 / 后补凭证）。
 
     成功时写入资源 Cookie（FastAPI 注入 ``response``；与 /access-token 一致）。"""
-    client_ip = request.client.host if request.client else "unknown"
-    username = body.username or ""
-    rl_key = f"{client_ip}:{username}" if username else client_ip
-    try:
-        _auth_advance_rate_limiter.check(rl_key)
-    except RateLimitExceededException:
-        raise HTTPException(status_code=429, detail="尝试过于频繁，请稍后再试")
+    _check_flow_rate_limit(request, body.username)
     result = _build_flow_service().advance(body.flow_token, body)
     return _flow_http(result, body.username, request, response)
 

--- a/tests/test_sso_flow_unified.py
+++ b/tests/test_sso_flow_unified.py
@@ -286,3 +286,77 @@ def test_sso_callback_query_failure_carries_error():
     from app.api.endpoints.auth import sso_callback_query
 
     assert sso_callback_query({"status": "failure", "error": "invalid_state"}) == {"sso_error": "invalid_state"}
+
+
+# --------------------------------------------------------------------------- 限流：begin 防暴力破解（#51 / CWE-307）
+
+
+def test_flow_begin_rate_limited_returns_429(monkeypatch, no_emit):
+    """同一 (ip+username) 短窗口内超阈值 → /flow/begin 返回 HTTP 429（含友好提示）。
+
+    威胁: begin 缺限流则未认证口令校验端点（解析用户/校验口令）可被无限暴力穷举（CWE-307）。
+    """
+    from fastapi import HTTPException
+
+    from app.api.endpoints import auth as auth_module
+    from app.schemas import FlowBeginRequest
+    from app.utils.limit import KeyedWindowRateLimiter
+
+    tight = KeyedWindowRateLimiter(max_calls=2, window_seconds=60)
+    monkeypatch.setattr(auth_module, "_auth_advance_rate_limiter", tight)
+
+    class _FailSvc:
+        def begin(self, body):
+            return {"status": "failure", "error": "invalid_credentials"}
+
+    monkeypatch.setattr(auth_module, "_build_flow_service", lambda *a, **kw: _FailSvc())
+
+    body = FlowBeginRequest(username="brute", password="bad")
+
+    # 阈值内：放行后落到失败服务 → 401（限流未误伤正常失败路径）
+    for _ in range(2):
+        with pytest.raises(HTTPException) as exc:
+            auth_module.flow_begin(body, _build_request())
+        assert exc.value.status_code == 401
+
+    # 超阈值：在进入服务前即被限流拦截 → 429
+    with pytest.raises(HTTPException) as exc:
+        auth_module.flow_begin(body, _build_request())
+    assert exc.value.status_code == 429
+    assert "频繁" in exc.value.detail
+
+
+def test_flow_begin_and_advance_share_same_rate_limiter(monkeypatch, no_emit):
+    """begin 与 advance 复用同一限流器实例：begin 打满额度后，同 (ip+username) 的 advance 立即 429。
+
+    锁定规格“复用 advance 现有限流器实例、不新建不一致限流器”。
+    """
+    from fastapi import HTTPException
+
+    from app.api.endpoints import auth as auth_module
+    from app.schemas import FlowAdvanceRequest, FlowBeginRequest
+    from app.utils.limit import KeyedWindowRateLimiter
+
+    tight = KeyedWindowRateLimiter(max_calls=1, window_seconds=60)
+    monkeypatch.setattr(auth_module, "_auth_advance_rate_limiter", tight)
+
+    class _FailSvc:
+        def begin(self, body):
+            return {"status": "failure", "error": "invalid_credentials"}
+
+        def advance(self, flow_token, body):
+            return {"status": "failure", "error": "invalid_credentials"}
+
+    monkeypatch.setattr(auth_module, "_build_flow_service", lambda *a, **kw: _FailSvc())
+
+    # begin 消耗掉唯一额度（仍按失败路径返回 401，但已记一次）
+    with pytest.raises(HTTPException) as exc:
+        auth_module.flow_begin(FlowBeginRequest(username="brute", password="bad"), _build_request())
+    assert exc.value.status_code == 401
+
+    # 同 (ip+username) 的 advance 立即命中 429 —— 证明二者共用同一限流器实例
+    with pytest.raises(HTTPException) as exc:
+        auth_module.flow_advance(
+            FlowAdvanceRequest(flow_token="ft", username="brute", password="bad"), _build_request())
+    assert exc.value.status_code == 429
+    assert "频繁" in exc.value.detail


### PR DESCRIPTION
## 架构审计 3.A · #51（P0 安全，非破坏，优先级 1/3）

**问题**：`/auth/flow/begin` 是未认证口令校验端点却缺限流——兄弟端点 `/auth/flow/advance`、`/access-token` 都有 `(ip:username)` 滑窗限流（`KeyedWindowRateLimiter` 10 次/60s），唯独 begin 没有，可被无节流暴力穷举（CWE-307）。

**修复**
- 抽出单一来源 helper `_check_flow_rate_limit(request, username)`，复用既有 `_auth_advance_rate_limiter` 实例与 `RateLimitExceededException`（不新建限流器/异常）。
- `flow_begin` 入口调用它；`flow_advance` 改用同一 helper（DRY，两端口策略由构造保证一致）。
- `username` 为空时退化为按裸 IP 限流。

**测试**：`tests/test_sso_flow_unified.py` 新增「begin 超阈值返回 429」「begin/advance 复用同一限流器」；`pytest tests/test_sso_flow_unified.py tests/test_auth_security_regression.py` → **26 passed**。

**已知限制（沿用既有端点现状，未在本 PR 调整）**：限流器单进程内存态，多 worker 各进程独立计数；反代未透传真实 IP 时 `request.client` 退化为共享桶。

> 对抗式复核：PASS（无 must-fix）。已 rebase 至 origin/v3-python（含 PR #88 重构后的 auth.py，限流修复经三方合并语义正确落地）。