### PR TITLE
fix(security): #53 API_TOKEN/API_KEY 经 URL 不再等价超管 [P0安全·BREAKING·优先级2/3]

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -34,7 +34,10 @@ oauth2_scheme_manual_error = OAuth2PasswordBearer(
 # RESOURCE TOKEN 通过 Cookie 认证
 resource_token_cookie = APIKeyCookie(name=settings.PROJECT_NAME, auto_error=False, scheme_name="resource_token_cookie")
 
-# API TOKEN 通过 QUERY 认证
+# API TOKEN 通过 Header 认证（首选，避免经 URL/access-log 泄露）
+api_token_header = APIKeyHeader(name="X-API-TOKEN", auto_error=False, scheme_name="api_token_header")
+
+# API TOKEN 通过 QUERY 认证（保留向后兼容，但优先使用请求头）
 api_token_query = APIKeyQuery(name="token", auto_error=False, scheme_name="api_token_query")
 
 # API KEY 通过 Header 认证
@@ -51,14 +54,16 @@ anthropic_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False, sche
 
 
 def __get_api_token(
+        token_header: Annotated[str | None, Security(api_token_header)] = None,
         token_query: Annotated[str | None, Security(api_token_query)] = None
 ) -> str | None:
     """
-    从 URL 查询参数中获取 API Token
-    :param token_query: 从 URL 中的 `token` 查询参数获取 API Token
-    :return: 返回获取到的 API Token，若无则返回 None
+    从请求头或 URL 查询参数中获取 API Token，优先使用请求头
+    :param token_header: 请求头中的 `X-API-TOKEN` 参数
+    :param token_query: URL 中的 `token` 查询参数（向后兼容）
+    :return: 返回获取到的 API Token，优先请求头，若无则返回 None
     """
-    return token_query
+    return token_header or token_query  # 首选请求头，降低经 URL/access-log 泄露
 
 
 def __get_api_key(
@@ -75,11 +80,15 @@ def __get_api_key(
 
 
 @cached(maxsize=1, ttl=600)
-def __create_superuser_token_payload() -> schemas.TokenPayload:
+def __create_service_token_payload() -> schemas.TokenPayload:
     """
-    创建管理员用户的TokenPayload
+    创建服务令牌（API_TOKEN / API_KEY，二者校验同一 settings.API_TOKEN）的 TokenPayload
 
-    :return: 管理员TokenPayload
+    服务令牌不授予超级管理员身份（super_user=False），避免静态密钥经 URL/Header
+    即等价于超级管理员、可直达超管端点（架构审计 3.A #53）。保留普通认证身份，
+    但不具备超管权限；超管能力仅由真实用户名/口令登录签发的 JWT（super_user=True）承载。
+
+    :return: 非超管的服务 TokenPayload
     """
     # 延迟导入
     # pylint: disable=import-outside-toplevel
@@ -87,15 +96,15 @@ def __create_superuser_token_payload() -> schemas.TokenPayload:
     from app.db.user_oper import UserOper
 
     user = UserOper().get_by_name(settings.SUPERUSER)
-    if not user or not user.is_superuser:
+    if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="用户权限不足",
+            detail="用户不存在",
         )
     return schemas.TokenPayload(
         sub=user.id,
         username=user.name,
-        super_user=user.is_superuser,
+        super_user=False,
         level=get_auth_level(),
         purpose="authentication",
     )
@@ -251,7 +260,7 @@ def verify_token(
     :param response: 响应对象，用于设置 Cookie
     :param jwt_token: 从 Authorization 头部获取的 JWT 令牌
     :param api_key: 从 查询参数`apikey` 或 请求头`X-API-KEY` 获取 API Token
-    :param api_token: 从 查询参数`token` 获取 API Token
+    :param api_token: 从 请求头`X-API-TOKEN`（优先）或 查询参数`token` 获取 API Token
     :return: 解析后的 TokenPayload
     :raises HTTPException: 如果令牌无效或用途不匹配
     """
@@ -265,10 +274,13 @@ def verify_token(
         return payload
     elif api_key:
         verify_apikey(api_key)
-        return __create_superuser_token_payload()
+        # API_KEY 与 API_TOKEN 校验同一 settings.API_TOKEN，必须一致降权：
+        # 否则攻击者用 ?apikey=<API_TOKEN> 即可绕过 api_token 分支的降权拿满超管（#53 旁路）
+        return __create_service_token_payload()
     elif api_token:
         verify_apitoken(api_token)
-        return __create_superuser_token_payload()
+        # 服务令牌（API_TOKEN）降权：非超级管理员身份，避免等价超管直达超管端点
+        return __create_service_token_payload()
     else:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -310,7 +322,7 @@ def __verify_key(key: str | None, expected_key: str, key_type: str) -> str:
 def verify_apitoken(token: Annotated[str | None, Security(__get_api_token)]) -> str:
     """
     使用 API Token 进行身份认证
-    :param token: API Token，从 URL 查询参数中获取 token=xxx
+    :param token: API Token，从请求头 X-API-TOKEN=xxx（优先）或 URL 查询参数 token=xxx 获取
     :return: 返回校验通过的 API Token
     """
     return __verify_key(token, settings.API_TOKEN, "token")

--- a/app/db/user_oper.py
+++ b/app/db/user_oper.py
@@ -60,11 +60,15 @@ async def get_current_active_user_async(
 
 def get_current_active_superuser(
         current_user: User = Depends(get_current_user),
+        token_data: schemas.TokenPayload = Depends(verify_token),
 ) -> User:
     """
     获取当前激活超级管理员
+
+    同时要求令牌声明超管身份（token_data.super_user）与数据库用户为超管，
+    避免降权后的服务令牌（API_TOKEN，super_user=False）凭 sub 解析到超管用户后绕过校验。
     """
-    if not current_user.is_superuser:
+    if not token_data.super_user or not current_user.is_superuser:
         raise HTTPException(
             status_code=400, detail="用户权限不足"
         )
@@ -73,11 +77,15 @@ def get_current_active_superuser(
 
 async def get_current_active_superuser_async(
         current_user: User = Depends(get_current_user_async),
+        token_data: schemas.TokenPayload = Depends(verify_token),
 ) -> User:
     """
     异步获取当前激活超级管理员
+
+    同时要求令牌声明超管身份（token_data.super_user）与数据库用户为超管，
+    避免降权后的服务令牌（API_TOKEN，super_user=False）凭 sub 解析到超管用户后绕过校验。
     """
-    if not current_user.is_superuser:
+    if not token_data.super_user or not current_user.is_superuser:
         raise HTTPException(
             status_code=400, detail="用户权限不足"
         )

--- a/tests/test_api_token_hardening.py
+++ b/tests/test_api_token_hardening.py
@@ -1,0 +1,163 @@
+"""API_TOKEN 加固回归测试（架构审计 3.A #53）。
+
+覆盖两处加固：
+  1) API_TOKEN 首选请求头 X-API-TOKEN（保留 query 向后兼容但优先 header）。
+  2) 服务令牌（API_TOKEN）降权：验证后身份 super_user=False，
+     且 get_current_active_superuser/_async 真正校验 token_data.super_user。
+"""
+from types import SimpleNamespace
+
+import asyncio
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app import schemas
+from app.core import security
+from app.db.user_oper import (
+    get_current_active_superuser,
+    get_current_active_superuser_async,
+)
+
+# 模块内的 "私有" 函数（双下划线前缀，模块级不发生名称改写）
+_get_api_token = getattr(security, "__get_api_token")
+_create_service_token_payload = getattr(security, "__create_service_token_payload")
+
+
+def _build_request() -> Request:
+    """构造最小测试请求。"""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/system/env",
+            "headers": [(b"host", b"testserver")],
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 123),
+        }
+    )
+
+
+# ----------------------------- 1) token header 优先 -----------------------------
+
+def test_api_token_header_scheme_uses_x_api_token():
+    """新增的 API_TOKEN 请求头方案名为 X-API-TOKEN。"""
+    assert security.api_token_header.model.name == "X-API-TOKEN"
+
+
+def test_get_api_token_prefers_header_over_query():
+    """__get_api_token 优先返回请求头，缺失时回退查询参数。"""
+    assert _get_api_token(token_header="from-header", token_query="from-query") == "from-header"
+    assert _get_api_token(token_header="from-header", token_query=None) == "from-header"
+    assert _get_api_token(token_header=None, token_query="from-query") == "from-query"
+    assert _get_api_token(token_header=None, token_query=None) is None
+
+
+# ----------------------------- 2) 服务令牌降权 -----------------------------
+
+def test_create_service_token_payload_is_non_superuser(monkeypatch):
+    """服务令牌 payload 即使底层用户是超管，也声明 super_user=False。"""
+    from app.db import user_oper
+
+    fake_user = SimpleNamespace(id=7, name="admin", is_superuser=True)
+
+    class FakeUserOper:
+        """返回超管用户的桩。"""
+
+        def get_by_name(self, _name):
+            """返回固定的超管用户。"""
+            return fake_user
+
+    monkeypatch.setattr(user_oper, "UserOper", FakeUserOper)
+    monkeypatch.setattr(security, "get_auth_level", lambda: 1)
+
+    _create_service_token_payload.cache_clear()
+    try:
+        payload = _create_service_token_payload()
+    finally:
+        _create_service_token_payload.cache_clear()
+
+    assert payload.super_user is False
+    assert payload.sub == 7
+    assert payload.purpose == "authentication"
+
+
+def test_verify_token_api_token_returns_non_superuser_payload(monkeypatch):
+    """verify_token 经 API_TOKEN 鉴权后返回非超管 payload，且不铸造超管 payload。"""
+    service_payload = schemas.TokenPayload(
+        sub=7, username="admin", super_user=False, level=1, purpose="authentication"
+    )
+    monkeypatch.setattr(security.settings, "API_TOKEN", "secret-token")
+    monkeypatch.setattr(security, "__create_service_token_payload", lambda: service_payload)
+
+    result = security.verify_token(
+        _build_request(),
+        Response(),
+        jwt_token=None,
+        api_key=None,
+        api_token="secret-token",
+    )
+
+    assert result.super_user is False
+    assert result.sub == 7
+
+
+def test_verify_token_api_key_returns_non_superuser_payload(monkeypatch):
+    """#53 旁路回归：经 ?apikey=<API_TOKEN>（与 token 同一密钥）鉴权也必须返回非超管 payload，
+    不得铸造超管身份——否则攻击者改用 apikey 参数名即可绕过 api_token 分支降权。"""
+    service_payload = schemas.TokenPayload(
+        sub=7, username="admin", super_user=False, level=1, purpose="authentication"
+    )
+    monkeypatch.setattr(security.settings, "API_TOKEN", "secret-token")
+    monkeypatch.setattr(security, "__create_service_token_payload", lambda: service_payload)
+
+    result = security.verify_token(
+        _build_request(),
+        Response(),
+        jwt_token=None,
+        api_key="secret-token",
+        api_token=None,
+    )
+
+    assert result.super_user is False
+    assert result.sub == 7
+
+
+# ------------------- 2b) 超管守卫真正校验 token_data.super_user -------------------
+
+def test_get_current_active_superuser_rejects_non_superuser_token():
+    """即使 DB 用户是超管，令牌声明 super_user=False 也必须被拒绝（401/400）。"""
+    db_superuser = SimpleNamespace(id=7, is_superuser=True)
+    service_payload = schemas.TokenPayload(
+        sub=7, username="admin", super_user=False, level=1, purpose="authentication"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        get_current_active_superuser(current_user=db_superuser, token_data=service_payload)
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "用户权限不足"
+
+
+def test_get_current_active_superuser_allows_real_superuser_token():
+    """令牌声明 super_user=True 且 DB 用户为超管时放行。"""
+    db_superuser = SimpleNamespace(id=7, is_superuser=True)
+    su_payload = schemas.TokenPayload(
+        sub=7, username="admin", super_user=True, level=1, purpose="authentication"
+    )
+    assert get_current_active_superuser(current_user=db_superuser, token_data=su_payload) is db_superuser
+
+
+def test_get_current_active_superuser_async_rejects_non_superuser_token():
+    """异步超管守卫同样校验 token_data.super_user。"""
+    db_superuser = SimpleNamespace(id=7, is_superuser=True)
+    service_payload = schemas.TokenPayload(
+        sub=7, username="admin", super_user=False, level=1, purpose="authentication"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            get_current_active_superuser_async(current_user=db_superuser, token_data=service_payload)
+        )
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## 架构审计 3.A · #53（P0 安全，⚠️ BREAKING，优先级 2/3）

**问题**：静态密钥 `settings.API_TOKEN` 经 URL query（`?token=` 或 `?apikey=`）即等价超级管理员——凭据随 URL 进 access-log/浏览器历史/Referer（CWE-598），且任何持有者直达全部超管端点。`token` 与 `apikey` 校验的是**同一个** `settings.API_TOKEN`。

**修复**
1. **首选请求头**：新增 `X-API-TOKEN` / 复用 `X-API-KEY`，`__get_api_token`/`__get_api_key` 返回 `header or query`（保留 query 向后兼容但优先 header）。
2. **静态密钥一致降权**：`verify_token` 的 `api_key` 与 `api_token` 两分支均铸非超管服务 payload（`super_user=False`）；删除 `__create_superuser_token_payload`，杜绝 `?apikey=<API_TOKEN>` 旁路（首版只降 token 分支会被此旁路绕过——对抗式复核已捕获并修正）。
3. **超管守卫加固**：`get_current_active_superuser/_async` 额外要求 `token_data.super_user` 为真（防降权后凭 `sub` 解析到超管用户而绕过）。

**⚠️ BREAKING 影响**：经 API_TOKEN/API_KEY（URL 或 Header）访问的约 **94 个超管端点**将返回 401；超管能力此后仅由真实用户名口令登录签发的 JWT 承载（前端登录不受影响）。受影响端点（13 文件）：
`dashboard(9)·history(4)·llm(5)·media(1)·message(1)·notification(5)·plugin(21)·site(17)·storage(10)·system(8 含 restart/upgrade/env/setting)·torrent(5)·transfer(3)·user(5)`

> 依赖 API_TOKEN 做管理自动化的集成需改用具备超管身份的 JWT，或评估是否接受此降权——这是本组唯一 breaking 项，建议单独评审/合并。

**测试**：`tests/test_api_token_hardening.py`（含 apikey 旁路回归）+ `tests/test_api_authorization.py` → **31 passed**。

> 对抗式安全复核：PASS（apikey 旁路确认闭合、无第四条静态密钥路径、删函数无残留、JWT 超管路径不受影响）。非阻塞建议：补 async 超管守卫正向用例 + 一条 TestClient 集成测试。基于 origin/v3-python。