### PR TITLE
fix(core): #39+#25+#1 事件错误名/模块默认优先级/Agent 主循环 [bugfix·优先级3/3]

### DIFF
--- a/app/core/event/manager.py
+++ b/app/core/event/manager.py
@@ -467,7 +467,7 @@ class EventManager(metaclass=Singleton):
             try:
                 method(event)
             except Exception as e:
-                self.__handle_event_error(event=event, module_name=plugin.name,
+                self.__handle_event_error(event=event, module_name=plugin.get_name(),
                                           class_name=class_name, method_name=method_name, e=e)
         elif class_name in module_manager.get_module_ids():
             # 模块处理器
@@ -544,7 +544,7 @@ class EventManager(metaclass=Singleton):
                 # 插件同步函数在异步环境中运行，避免阻塞
                 await run_in_threadpool(method, event)
         except Exception as e:
-            self.__handle_event_error(event=event, module_name=plugin.name,
+            self.__handle_event_error(event=event, module_name=plugin.get_name(),
                                       class_name=class_name, method_name=method_name, e=e)
 
     async def __invoke_module_method_async(self, handler: Any, class_name: str, method_name: str, event: Event):

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
     from app.schemas.types import TorrentStatus
 
 
+# 模块默认优先级：数字越小优先级越高。未显式声明优先级的模块统一回退到此值，
+# 避免 get_priority() 返回 None 在排序/比较时引发 TypeError。
+DEFAULT_MODULE_PRIORITY: int = 100
+
+
 class _ModuleBase(ConfigReloadMixin, metaclass=ABCMeta):
     """
     模块基类，实现对应方法，在有需要时会被自动调用，返回None代表不启用该模块，将继续执行下一模块
@@ -83,7 +88,7 @@ class _ModuleBase(ConfigReloadMixin, metaclass=ABCMeta):
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效
         """
-        pass
+        return DEFAULT_MODULE_PRIORITY
 
     @abstractmethod
     def stop(self) -> None:

--- a/app/startup/agent_initializer.py
+++ b/app/startup/agent_initializer.py
@@ -1,8 +1,7 @@
 import asyncio
-import threading
 
 from app.agent import agent_manager
-from app.core.config import settings
+from app.core.config import settings, global_vars
 from app.log import logger
 
 
@@ -53,34 +52,21 @@ agent_initializer = AgentInitializer()
 
 def init_agent():
     """
-    初始化AI智能体（同步版本，用于在后台线程中运行）
+    初始化AI智能体（同步入口，将初始化协程调度到主事件循环中执行）
+
+    早前实现为每次启动新建守护线程 + 临时事件循环来 run_until_complete，
+    导致 Agent 的后台任务（会话 worker / 空闲清理）绑定在随线程结束即关闭的
+    临时循环上，与关停时 stop_agent 所在的主循环不是同一个，关停无法取消这些任务。
+    改为复用项目既有约定 asyncio.run_coroutine_threadsafe(coro, global_vars.loop)，
+    使 Agent 后台任务与关停同处主循环。
     """
     try:
         if not settings.AI_AGENT_ENABLE:
             logger.info("AI智能体功能未启用")
             return True
 
-        # 在新的事件循环中初始化AI智能体管理器
-        def run_init():
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                success = loop.run_until_complete(agent_initializer.initialize())
-                if success:
-                    logger.info("AI智能体管理器初始化成功")
-                else:
-                    logger.error("AI智能体管理器初始化失败")
-                return success
-            except Exception as err:
-                logger.error(f"AI智能体管理器初始化失败: {err}")
-                return False
-            finally:
-                loop.close()
-
-        # 在后台线程中初始化
-        init_thread = threading.Thread(target=run_init, daemon=True)
-        init_thread.start()
-
+        # 调度到主事件循环初始化（fire-and-forget；initialize 内部已记录成功/失败并吞掉异常）
+        asyncio.run_coroutine_threadsafe(agent_initializer.initialize(), global_vars.loop)
         return True
 
     except Exception as e:

--- a/tests/test_agent_initializer_loop.py
+++ b/tests/test_agent_initializer_loop.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+回归测试：init_agent 将初始化协程调度到主事件循环，不再起守护线程 + 临时事件循环。
+
+背景（架构审计 #1）：旧实现每次启动新建守护线程并在其内 ``new_event_loop().run_until_complete``，
+Agent 的后台任务（会话 worker / 空闲清理）会绑定在随线程退出即关闭的临时循环上，与关停时
+stop_agent 所在的主循环不是同一个，导致关停无法取消这些后台任务。
+修复：复用项目既有约定 ``asyncio.run_coroutine_threadsafe(coro, global_vars.loop)``，
+使后台任务与关停同处主循环。仅 AI_AGENT_ENABLE=True 时触发调度。
+"""
+from app.core.config import global_vars
+from app.startup import agent_initializer as ai_mod
+
+
+def test_no_threading_import_left():
+    """守护"删守护线程"：模块不应再引入 threading。"""
+    assert not hasattr(ai_mod, "threading")
+
+
+def test_init_agent_schedules_on_main_loop(monkeypatch):
+    sentinel_loop = object()
+    captured = {}
+
+    def fake_rcts(coro, loop):
+        captured["coro"] = coro
+        captured["loop"] = loop
+        coro.close()  # 仅捕获，不实际运行，关闭以免 "never awaited" 警告
+        return object()
+
+    monkeypatch.setattr("asyncio.run_coroutine_threadsafe", fake_rcts)
+    monkeypatch.setattr(global_vars, "CURRENT_EVENT_LOOP", sentinel_loop)
+    monkeypatch.setattr(ai_mod.settings, "AI_AGENT_ENABLE", True)
+
+    result = ai_mod.init_agent()
+
+    assert result is True
+    # 调度发生在 global_vars 主循环上，而非临时新建的循环
+    assert captured["loop"] is sentinel_loop
+    assert "coro" in captured
+
+
+def test_init_agent_skips_when_disabled(monkeypatch):
+    called = {"scheduled": False}
+
+    def fake_rcts(coro, loop):
+        called["scheduled"] = True
+        coro.close()
+        return object()
+
+    monkeypatch.setattr("asyncio.run_coroutine_threadsafe", fake_rcts)
+    monkeypatch.setattr(ai_mod.settings, "AI_AGENT_ENABLE", False)
+
+    result = ai_mod.init_agent()
+
+    assert result is True
+    assert called["scheduled"] is False

--- a/tests/test_event_error_plugin_name.py
+++ b/tests/test_event_error_plugin_name.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+回归测试：插件事件处理抛错时，错误上报使用 plugin.get_name() 而非 plugin.name。
+
+背景（架构审计 #39）：_PluginBase 没有 ``name`` 属性（仅 ``plugin_name`` + ``get_name()``）。
+事件管理器旧代码在 except 分支用 ``plugin.name`` 取模块名，会在错误处理器内部二次抛出
+AttributeError，把插件真正的业务异常吞掉、且无法发出系统错误通知。
+修复：``module_name=plugin.get_name()``（与 _ModuleBase/全局处理器分支一致）。
+
+覆盖同步分支（manager.py 约 :470）与异步分支（约 :547）两处。
+"""
+import asyncio
+
+import pytest
+
+from app.core.event.manager import EventManager
+from app.core.event.models import Event
+from app.helper.plugin_manager import PluginManager
+from app.plugins import _PluginBase
+from app.schemas.types import EventType
+
+_PLUGIN_ID = "_RaisingEventPlugin"
+_DISPLAY_NAME = "可读插件名"
+
+
+class _RaisingEventPlugin:
+    """模拟一个 running 插件：仅有 plugin_name/get_name，没有 name 属性，事件方法必抛错。"""
+
+    plugin_name = _DISPLAY_NAME
+
+    def get_name(self) -> str:
+        return self.plugin_name
+
+    def do_event(self, event):  # __qualname__ == "_RaisingEventPlugin.do_event"
+        raise RuntimeError("插件业务异常")
+
+
+def test_plugin_base_has_no_name_attribute():
+    """守护前提：_PluginBase 提供 get_name 而非 name；否则本修复无意义。"""
+    assert hasattr(_PluginBase, "get_name")
+    assert not hasattr(_PluginBase, "name")
+    plugin = _RaisingEventPlugin()
+    assert plugin.get_name() == _DISPLAY_NAME
+    assert not hasattr(plugin, "name")
+
+
+@pytest.fixture
+def patched_managers(monkeypatch):
+    """把假插件登记进 PluginManager 单例，并捕获 __handle_event_error 的 module_name。"""
+    em = EventManager()
+    pm = PluginManager()
+    plugin = _RaisingEventPlugin()
+
+    monkeypatch.setattr(pm, "get_plugin_ids", lambda: [_PLUGIN_ID])
+    monkeypatch.setattr(pm, "_running_plugins", {_PLUGIN_ID: plugin})
+
+    captured = {}
+
+    def _capture(event, module_name, class_name, method_name, e):
+        captured["module_name"] = module_name
+        captured["error"] = e
+
+    # __handle_event_error 为名称改写的私有方法
+    monkeypatch.setattr(em, "_EventManager__handle_event_error", _capture)
+    return em, pm, captured
+
+
+def test_sync_invoke_reports_get_name_without_attribute_error(patched_managers):
+    em, _pm, captured = patched_managers
+    event = Event(EventType.PluginAction)
+    handler = _RaisingEventPlugin.do_event  # __qualname__ -> "_RaisingEventPlugin.do_event"
+
+    # 不应抛出（旧代码会在 except 内因 plugin.name 二次 AttributeError）
+    em._EventManager__invoke_handler_by_type_sync(handler, event)
+
+    assert captured["module_name"] == _DISPLAY_NAME
+    assert isinstance(captured["error"], RuntimeError)
+
+
+def test_async_invoke_reports_get_name_without_attribute_error(patched_managers):
+    em, pm, captured = patched_managers
+    event = Event(EventType.PluginAction)
+
+    asyncio.run(
+        em._EventManager__invoke_plugin_method_async(pm, _PLUGIN_ID, "do_event", event)
+    )
+
+    assert captured["module_name"] == _DISPLAY_NAME
+    assert isinstance(captured["error"], RuntimeError)

--- a/tests/test_module_default_priority.py
+++ b/tests/test_module_default_priority.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+回归测试：_ModuleBase.get_priority() 默认返回 int（DEFAULT_MODULE_PRIORITY），不再返回 None。
+
+背景（架构审计 #25）：get_priority() 旧实现为 ``pass`` → 返回 None，未显式声明优先级的模块在
+按优先级排序/比较时会触发 ``TypeError: '<' not supported between 'int' and 'NoneType'``。
+修复为回退到模块级常量 DEFAULT_MODULE_PRIORITY=100。
+
+注意：修复刻意未采用 ``x.get_priority() or 0`` 写法——那会把 6 个合法 priority=0 的内建模块
+误改为 0 之外的语义（0 为假值会被 ``or`` 吞掉）。本测试同时守护"合法 0 不被改写"这一不变式。
+"""
+from app.modules import DEFAULT_MODULE_PRIORITY, _ModuleBase
+from app.schemas.types import ModuleType
+
+
+def test_default_priority_constant_is_int_100():
+    assert DEFAULT_MODULE_PRIORITY == 100
+    assert isinstance(DEFAULT_MODULE_PRIORITY, int)
+
+
+def test_base_get_priority_returns_int_not_none():
+    priority = _ModuleBase.get_priority()
+    assert priority is not None
+    assert isinstance(priority, int)
+    assert priority == DEFAULT_MODULE_PRIORITY
+
+
+def test_subclass_without_override_inherits_default():
+    """未重写 get_priority 的子类回退到默认优先级（实例与类调用一致）。"""
+
+    class _NoPriorityModule(_ModuleBase):
+        def init_module(self) -> None:
+            pass
+
+        def init_setting(self):
+            return None
+
+        def stop(self) -> None:
+            pass
+
+        def test(self):
+            return True, ""
+
+        @staticmethod
+        def get_type() -> ModuleType:
+            return ModuleType.Other
+
+    assert _NoPriorityModule().get_priority() == DEFAULT_MODULE_PRIORITY
+
+
+def test_legitimate_zero_priority_preserved():
+    """显式声明 priority=0 的模块不被回退/吞掉——守护"勿用 or 0"的修复约束。"""
+
+    class _ZeroPriorityModule(_ModuleBase):
+        def init_module(self) -> None:
+            pass
+
+        def init_setting(self):
+            return None
+
+        def stop(self) -> None:
+            pass
+
+        def test(self):
+            return True, ""
+
+        @staticmethod
+        def get_type() -> ModuleType:
+            return ModuleType.Other
+
+        @staticmethod
+        def get_priority() -> int:
+            return 0
+
+    assert _ZeroPriorityModule().get_priority() == 0


### PR DESCRIPTION
## 架构审计 3.A · #39 + #25 + #1（中危 bugfix，优先级 3/3）

三处独立非破坏修复：

- **#39 事件错误上报**（`app/core/event/manager.py`）：`module_name=plugin.name` → `plugin.get_name()`。基类 `_PluginBase` 无 `name` 属性，旧代码在 except 内二次抛 `AttributeError`，吞掉插件真实错误的上报。
- **#25 模块默认优先级**（`app/modules/__init__.py`）：新增 `DEFAULT_MODULE_PRIORITY = 100`，`get_priority()` 默认返回它而非 `None`，修复按优先级 `sorted()` 时 `None` 与 int 比较抛 `TypeError`；刻意不用 `or 0` 以保留 6 个合法 `priority=0` 的内建模块。
- **#1 Agent 后台任务**（`app/startup/agent_initializer.py`）：删守护线程 + 一次性事件循环，改 `asyncio.run_coroutine_threadsafe(initialize, global_vars.loop)`（项目已有先例），使后台任务与关停 `stop_agent` 同处主循环以便正常取消。仅 `AI_AGENT_ENABLE=True` 触发。

**测试**：新增 3 个测试文件 10 用例 + 邻接回归 9 → **19 passed**。

> 对抗式复核：PASS（无 new bug/regression）。基于 origin/v3-python。