### PR TITLE
refactor(dispatch): 统一分发内核 + 事件广播并发加固(HIGH) + 对抗审查校正

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -11,7 +11,7 @@ from app.core.config import settings
 from app.core.context import MediaInfo
 from app.core.event import eventmanager
 from app.core.metainfo import MetaInfo
-from app.core.security import verify_token, verify_apitoken
+from app.core.security import verify_token, verify_apitoken, compare_secret
 from app.db import get_async_db, get_db
 from app.db.models.subscribe import Subscribe
 from app.db.models.subscribehistory import SubscribeHistory
@@ -372,7 +372,7 @@ async def seerr_subscribe(
     """
     Jellyseerr/Overseerr网络勾子通知订阅
     """
-    if not authorization or authorization != settings.API_TOKEN:
+    if not compare_secret(authorization, settings.API_TOKEN):
         raise HTTPException(
             status_code=400,
             detail="授权失败",

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import pickle
 import traceback
 from abc import ABCMeta
@@ -8,8 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Any, Tuple, List, Set, Union, Dict
 
-from fastapi.concurrency import run_in_threadpool
-
+from app.core import dispatch
 from app.core.cache import FileCache, AsyncFileCache, fresh, async_fresh
 from app.core.config import settings
 from app.core.context import Context, MediaInfo, SubtitleInfo, TorrentInfo
@@ -50,7 +48,6 @@ from app.schemas.types import (
     EventType,
     MessageChannel,
 )
-from app.utils.object import ObjectUtils
 
 
 class ChainBase(metaclass=ABCMeta):
@@ -252,12 +249,9 @@ class ChainBase(metaclass=ABCMeta):
     @staticmethod
     def __is_valid_empty(ret):
         """
-        判断结果是否为空
+        判断结果是否为空：元组需全部为 None，其余按 is None 判断。
         """
-        if isinstance(ret, tuple):
-            return all(value is None for value in ret)
-        else:
-            return ret is None
+        return dispatch.is_valid_empty(ret)
 
     def __handle_plugin_error(
             self, err: Exception, plugin_id: str, plugin_name: str, method: str, **kwargs
@@ -323,177 +317,110 @@ class ChainBase(metaclass=ABCMeta):
             raise err
         logger.info(f"{source_type} {source_id}.{method} 已限流，跳过执行：{str(err)}")
 
+    def __plugin_entries(self, method: str):
+        """
+        生成插件钩子面的后端三元组 (plugin_id, plugin_name, func)：取各插件经 get_module 注册的同名方法。
+        """
+        for plugin, module_dict in self.pluginmanager.get_plugin_modules().items():
+            plugin_id, plugin_name = plugin
+            if method not in module_dict:
+                continue
+            func = module_dict[method]
+            if not func:
+                continue
+            yield plugin_id, plugin_name, func
+
+    def __system_entries(self, method: str):
+        """
+        生成系统后端面的后端三元组 (module_id, module_name, func)：按优先级（get_priority 升序）取各运行模块的同名方法。
+        """
+        for module in sorted(
+                self.modulemanager.get_running_modules(method),
+                key=lambda x: x.get_priority(),
+        ):
+            module_id = module.__class__.__name__
+            try:
+                module_name = module.get_name()
+            except Exception as err:
+                logger.debug(f"获取模块名称出错：{str(err)}")
+                module_name = module_id
+            yield module_id, module_name, getattr(module, method)
+
     def __execute_plugin_modules(
             self, method: str, result: Any, *args, **kwargs
     ) -> Any:
         """
-        执行插件模块
+        执行插件模块（插件钩子面，不做 check_signature 精化）。kwargs 原样转发给插件方法。
         """
-        for plugin, module_dict in self.pluginmanager.get_plugin_modules().items():
-            plugin_id, plugin_name = plugin
-            if method in module_dict:
-                func = module_dict[method]
-                if func:
-                    try:
-                        logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
-                        if self.__is_valid_empty(result):
-                            # 返回None，第一次执行或者需继续执行下一模块
-                            result = func(*args, **kwargs)
-                        elif isinstance(result, list):
-                            # 返回为列表，有多个模块运行结果时进行合并
-                            temp = func(*args, **kwargs)
-                            if isinstance(temp, list):
-                                result.extend(temp)
-                        else:
-                            break
-                    except RateLimitExceededException as err:
-                        self.__handle_rate_limit_error(
-                            err, "插件", plugin_id, method, **kwargs
-                        )
-                    except Exception as err:
-                        self.__handle_plugin_error(
-                            err, plugin_id, plugin_name, method, **kwargs
-                        )
-        return result
+        return dispatch.execute_modules(
+            self.__plugin_entries(method), method, result, *args,
+            pipeline=False,
+            log_each=lambda name, m: logger.info(f"请求插件 {name} 执行：{m} ..."),
+            on_rate_limit=lambda err, ident, name, m: self.__handle_rate_limit_error(
+                err, "插件", ident, m, **kwargs
+            ),
+            on_error=lambda err, ident, name, m: self.__handle_plugin_error(
+                err, ident, name, m, **kwargs
+            ),
+            **kwargs,
+        )
 
     async def __async_execute_plugin_modules(
             self, method: str, result: Any, *args, **kwargs
     ) -> Any:
         """
-        异步执行插件模块
+        异步执行插件模块（插件钩子面，不做 check_signature 精化）。kwargs 原样转发给插件方法。
         """
-        for plugin, module_dict in self.pluginmanager.get_plugin_modules().items():
-            plugin_id, plugin_name = plugin
-            if method in module_dict:
-                func = module_dict[method]
-                if func:
-                    try:
-                        logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
-                        if self.__is_valid_empty(result):
-                            # 返回None，第一次执行或者需继续执行下一模块
-                            if inspect.iscoroutinefunction(func):
-                                result = await func(*args, **kwargs)
-                            else:
-                                # 插件同步函数在异步环境中运行，避免阻塞
-                                result = await run_in_threadpool(func, *args, **kwargs)
-                        elif isinstance(result, list):
-                            # 返回为列表，有多个模块运行结果时进行合并
-                            if inspect.iscoroutinefunction(func):
-                                temp = await func(*args, **kwargs)
-                            else:
-                                # 插件同步函数在异步环境中运行，避免阻塞
-                                temp = await run_in_threadpool(func, *args, **kwargs)
-                            if isinstance(temp, list):
-                                result.extend(temp)
-                        else:
-                            break
-                    except RateLimitExceededException as err:
-                        self.__handle_rate_limit_error(
-                            err, "插件", plugin_id, method, **kwargs
-                        )
-                    except Exception as err:
-                        self.__handle_plugin_error(
-                            err, plugin_id, plugin_name, method, **kwargs
-                        )
-        return result
+        return await dispatch.async_execute_modules(
+            self.__plugin_entries(method), method, result, *args,
+            pipeline=False,
+            log_each=lambda name, m: logger.info(f"请求插件 {name} 执行：{m} ..."),
+            on_rate_limit=lambda err, ident, name, m: self.__handle_rate_limit_error(
+                err, "插件", ident, m, **kwargs
+            ),
+            on_error=lambda err, ident, name, m: self.__handle_plugin_error(
+                err, ident, name, m, **kwargs
+            ),
+            **kwargs,
+        )
 
     def __execute_system_modules(
             self, method: str, result: Any, *args, **kwargs
     ) -> Any:
         """
-        执行系统模块
+        执行系统模块（系统后端面，启用 check_signature 管道精化）。kwargs 原样转发给系统方法。
         """
         logger.debug(f"请求系统模块执行：{method} ...")
-        for module in sorted(
-                self.modulemanager.get_running_modules(method),
-                key=lambda x: x.get_priority(),
-        ):
-            module_id = module.__class__.__name__
-            try:
-                module_name = module.get_name()
-            except Exception as err:
-                logger.debug(f"获取模块名称出错：{str(err)}")
-                module_name = module_id
-            try:
-                func = getattr(module, method)
-                if self.__is_valid_empty(result):
-                    # 返回None，第一次执行或者需继续执行下一模块
-                    result = func(*args, **kwargs)
-                elif ObjectUtils.check_signature(func, result):
-                    # 返回结果与方法签名一致，将结果传入
-                    result = func(result)
-                elif isinstance(result, list):
-                    # 返回为列表，有多个模块运行结果时进行合并
-                    temp = func(*args, **kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    # 中止继续执行
-                    break
-            except RateLimitExceededException as err:
-                self.__handle_rate_limit_error(
-                    err, "模块", module_id, method, **kwargs
-                )
-            except Exception as err:
-                logger.error(traceback.format_exc())
-                self.__handle_system_error(
-                    err, module_id, module_name, method, **kwargs
-                )
-        return result
+        return dispatch.execute_modules(
+            self.__system_entries(method), method, result, *args,
+            pipeline=True,
+            on_rate_limit=lambda err, ident, name, m: self.__handle_rate_limit_error(
+                err, "模块", ident, m, **kwargs
+            ),
+            on_error=lambda err, ident, name, m: self.__handle_system_error(
+                err, ident, name, m, **kwargs
+            ),
+            **kwargs,
+        )
 
     async def __async_execute_system_modules(
             self, method: str, result: Any, *args, **kwargs
     ) -> Any:
         """
-        异步执行系统模块
+        异步执行系统模块（系统后端面，启用 check_signature 管道精化）。kwargs 原样转发给系统方法。
         """
         logger.debug(f"请求系统模块执行：{method} ...")
-        for module in sorted(
-                self.modulemanager.get_running_modules(method),
-                key=lambda x: x.get_priority(),
-        ):
-            module_id = module.__class__.__name__
-            try:
-                module_name = module.get_name()
-            except Exception as err:
-                logger.debug(f"获取模块名称出错：{str(err)}")
-                module_name = module_id
-            try:
-                func = getattr(module, method)
-                if self.__is_valid_empty(result):
-                    # 返回None，第一次执行或者需继续执行下一模块
-                    if inspect.iscoroutinefunction(func):
-                        result = await func(*args, **kwargs)
-                    else:
-                        # 系统同步模块在异步路径里也必须切到线程池，避免阻塞共享事件循环。
-                        result = await run_in_threadpool(func, *args, **kwargs)
-                elif ObjectUtils.check_signature(func, result):
-                    # 返回结果与方法签名一致，将结果传入
-                    if inspect.iscoroutinefunction(func):
-                        result = await func(result)
-                    else:
-                        result = await run_in_threadpool(func, result)
-                elif isinstance(result, list):
-                    # 返回为列表，有多个模块运行结果时进行合并
-                    if inspect.iscoroutinefunction(func):
-                        temp = await func(*args, **kwargs)
-                    else:
-                        temp = await run_in_threadpool(func, *args, **kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    # 中止继续执行
-                    break
-            except RateLimitExceededException as err:
-                self.__handle_rate_limit_error(
-                    err, "模块", module_id, method, **kwargs
-                )
-            except Exception as err:
-                logger.error(traceback.format_exc())
-                self.__handle_system_error(
-                    err, module_id, module_name, method, **kwargs
-                )
-        return result
+        return await dispatch.async_execute_modules(
+            self.__system_entries(method), method, result, *args,
+            pipeline=True,
+            on_rate_limit=lambda err, ident, name, m: self.__handle_rate_limit_error(
+                err, "模块", ident, m, **kwargs
+            ),
+            on_error=lambda err, ident, name, m: self.__handle_system_error(
+                err, ident, name, m, **kwargs
+            ),
+            **kwargs,
+        )
 
     def run_module(self, method: str, *args, **kwargs) -> Any:
         """

--- a/app/core/dispatch.py
+++ b/app/core/dispatch.py
@@ -1,0 +1,128 @@
+"""
+按方法名分发到多后端的共享内核：遍历后端、按合并规则累积结果、隔离单后端的错误与限流。
+
+供 ChainBase（metaclass=ABCMeta）与门面管理器（ManagerBase 系，metaclass=Singleton）以组合委托方式
+复用，规避两者元类冲突。内核对转发给后端的 kwargs 内容无主张：是否携带 raise_exception 等控制位由
+调用方决定，内核原样 func(*args, **kwargs) 转发。
+"""
+import inspect
+from collections.abc import Callable, Iterable
+from typing import Any, Optional, Tuple
+
+from fastapi.concurrency import run_in_threadpool
+
+from app.schemas.exception import RateLimitExceededException
+from app.utils.object import ObjectUtils
+
+# 后端三元组：(ident 后端标识, name 显示名, func 待调用方法)
+Entry = Tuple[str, str, Callable]
+
+
+def is_valid_empty(ret: Any) -> bool:
+    """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
+    if isinstance(ret, tuple):
+        return all(value is None for value in ret)
+    return ret is None
+
+
+def execute_modules(
+        entries: Iterable[Entry],
+        method: str,
+        result: Any,
+        *args,
+        pipeline: bool,
+        on_rate_limit: Callable,
+        on_error: Callable,
+        log_each: Optional[Callable] = None,
+        **kwargs,
+) -> Any:
+    """
+    同步依次遍历后端并按合并规则累积结果。
+
+    合并规则：当前结果为空（None / 全 None 元组）取后端返回值；pipeline 为真且命中 check_signature 时
+    把结果作为下一后端入参透传（逐源精化）；为列表时跨后端 extend；为非空标量时短路停止。单个后端异常
+    被隔离后继续其余后端，限流安静跳过；回调可在控制位为真时抛出以透传首个异常。
+
+    :param entries: 后端三元组序列 (ident, name, func)
+    :param method: 方法名（用于日志与回调）
+    :param result: 已累积的结果（首次分发传 None）
+    :param pipeline: 为真启用 check_signature 精化分支（系统后端面），为假关闭（插件钩子面）
+    :param on_rate_limit: 限流回调 (err, ident, name, method)
+    :param on_error: 错误回调 (err, ident, name, method)
+    :param log_each: 可选，每个后端调用前触发 (name, method)
+    :return: 累积后的结果
+    """
+    for ident, name, func in entries:
+        try:
+            if log_each is not None:
+                log_each(name, method)
+            if is_valid_empty(result):
+                result = func(*args, **kwargs)
+            elif pipeline and ObjectUtils.check_signature(func, result):
+                result = func(result)
+            elif isinstance(result, list):
+                temp = func(*args, **kwargs)
+                if isinstance(temp, list):
+                    result.extend(temp)
+            else:
+                break
+        except RateLimitExceededException as err:
+            on_rate_limit(err, ident, name, method)
+        except Exception as err:
+            on_error(err, ident, name, method)
+    return result
+
+
+async def async_execute_modules(
+        entries: Iterable[Entry],
+        method: str,
+        result: Any,
+        *args,
+        pipeline: bool,
+        on_rate_limit: Callable,
+        on_error: Callable,
+        log_each: Optional[Callable] = None,
+        **kwargs,
+) -> Any:
+    """
+    异步依次遍历后端并按合并规则累积结果：同步后端方法经线程池执行避免阻塞事件循环，async 后端直接 await。
+
+    参数、合并规则、错误与限流隔离均同 execute_modules。
+
+    :param entries: 后端三元组序列 (ident, name, func)
+    :param method: 方法名（用于日志与回调）
+    :param result: 已累积的结果（首次分发传 None）
+    :param pipeline: 为真启用 check_signature 精化分支（系统后端面），为假关闭（插件钩子面）
+    :param on_rate_limit: 限流回调 (err, ident, name, method)
+    :param on_error: 错误回调 (err, ident, name, method)
+    :param log_each: 可选，每个后端调用前触发 (name, method)
+    :return: 累积后的结果
+    """
+    for ident, name, func in entries:
+        try:
+            if log_each is not None:
+                log_each(name, method)
+            if is_valid_empty(result):
+                if inspect.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = await run_in_threadpool(func, *args, **kwargs)
+            elif pipeline and ObjectUtils.check_signature(func, result):
+                if inspect.iscoroutinefunction(func):
+                    result = await func(result)
+                else:
+                    result = await run_in_threadpool(func, result)
+            elif isinstance(result, list):
+                if inspect.iscoroutinefunction(func):
+                    temp = await func(*args, **kwargs)
+                else:
+                    temp = await run_in_threadpool(func, *args, **kwargs)
+                if isinstance(temp, list):
+                    result.extend(temp)
+            else:
+                break
+        except RateLimitExceededException as err:
+            on_rate_limit(err, ident, name, method)
+        except Exception as err:
+            on_error(err, ident, name, method)
+    return result

--- a/app/core/event/manager.py
+++ b/app/core/event/manager.py
@@ -336,13 +336,15 @@ class EventManager(metaclass=Singleton):
         同步方式调度链式事件，按优先级顺序逐个调用事件处理器，并记录每个处理器的处理时间
         :param event: 要调度的事件对象
         """
-        handlers = self.__chain_subscribers.get(event.event_type, {})
-        if not handlers:
+        # 在锁内快照订阅者后再过滤/迭代，避免与运行时 add/remove_event_listener 并发改字典。
+        with self.__lock:
+            handler_items = list(self.__chain_subscribers.get(event.event_type, {}).items())
+        if not handler_items:
             logger.debug(f"No handlers found for chain event: {event}")
             return False
 
         # 过滤出启用的处理器
-        enabled_handlers = {handler_id: (priority, handler) for handler_id, (priority, handler) in handlers.items()
+        enabled_handlers = {handler_id: (priority, handler) for handler_id, (priority, handler) in handler_items
                             if self.__is_handler_enabled(handler)}
 
         if not enabled_handlers:
@@ -365,13 +367,15 @@ class EventManager(metaclass=Singleton):
         异步方式调度链式事件，按优先级顺序逐个调用事件处理器，并记录每个处理器的处理时间
         :param event: 要调度的事件对象
         """
-        handlers = self.__chain_subscribers.get(event.event_type, {})
-        if not handlers:
+        # 在锁内快照订阅者后再过滤/迭代，避免与运行时 add/remove_event_listener 并发改字典。
+        with self.__lock:
+            handler_items = list(self.__chain_subscribers.get(event.event_type, {}).items())
+        if not handler_items:
             logger.debug(f"No handlers found for chain event: {event}")
             return False
 
         # 过滤出启用的处理器
-        enabled_handlers = {handler_id: (priority, handler) for handler_id, (priority, handler) in handlers.items()
+        enabled_handlers = {handler_id: (priority, handler) for handler_id, (priority, handler) in handler_items
                             if self.__is_handler_enabled(handler)}
 
         if not enabled_handlers:
@@ -394,12 +398,16 @@ class EventManager(metaclass=Singleton):
         异步方式调度广播事件，通过线程池逐个调用事件处理器
         :param event: 要调度的事件对象
         """
-        handlers = self.__broadcast_subscribers.get(event.event_type, {})
-        if not handlers:
+        # 在锁内快照订阅者后再迭代：广播在消费者线程进行，期间插件启停/热重载会经
+        # add_event_listener/remove_event_listener 并发改同一字典，直接迭代活字典会抛
+        # RuntimeError: dictionary changed size during iteration，逃出消费者循环致广播停摆。
+        with self.__lock:
+            handler_items = list(self.__broadcast_subscribers.get(event.event_type, {}).items())
+        if not handler_items:
             logger.debug(f"No handlers found for broadcast event: {event}")
             return
         # 为每个处理器提供独立的事件实例，防止某个处理器对 event_data 的修改影响其他处理器
-        for handler_id, handler in handlers.items():
+        for handler_id, handler in handler_items:
             # 仅浅拷贝顶层字典，避免不必要的深拷贝开销；这样可以隔离键级别的替换/赋值
             if isinstance(event.event_data, dict):
                 event_data_copy = event.event_data.copy()
@@ -646,6 +654,9 @@ class EventManager(metaclass=Singleton):
             except Empty:
                 rate_limiter.current_wait = rate_limiter.current_wait * random.uniform(1, 1 + jitter_factor)
                 rate_limiter.trigger_limit()
+            except Exception as e:
+                # 纵深防御：单次广播分发异常不得杀死消费者线程导致广播永久停摆。
+                logger.error(f"广播事件处理出错：{str(e)} - {traceback.format_exc()}")
 
     @staticmethod
     def __log_event_lifecycle(event: Event, stage: str):

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -290,6 +290,19 @@ def verify_resource_token(
     return __verify_token(token=resource_token, purpose="resource")
 
 
+def compare_secret(provided: str | None, expected: str | None) -> bool:
+    """
+    常量时间比较密钥/令牌，防计时侧信道攻击（CWE-208）。
+
+    :param provided: 请求侧提供的密钥/令牌
+    :param expected: 系统配置中的期望值
+    :return: 二者非空且逐字节相等时返回 True；任一为空（None/空串）返回 False
+    """
+    if not provided or not expected:
+        return False
+    return hmac.compare_digest(provided.encode(), expected.encode())
+
+
 def __verify_key(key: str | None, expected_key: str, key_type: str) -> str:
     """
     通用的 API Key 或 Token 验证函数
@@ -299,7 +312,7 @@ def __verify_key(key: str | None, expected_key: str, key_type: str) -> str:
     :return: 返回校验通过的 API Key 或 Token
     :raises HTTPException: 如果校验不通过，抛出 401 错误
     """
-    if not key or key != expected_key:
+    if not compare_secret(key, expected_key):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"{key_type} 校验不通过"

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -668,15 +668,20 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                                      f"{getattr(storage_cls, '__name__', storage_cls)} 出错：{str(err)}")
         # 注册插件经 provides_auth_* 声明的认证域实例（登录提供方 / 认证流程 / 认证步骤）：
         # 不进 ModuleManager/chain，而是注册到 app.core.auth 各注册表（owner=plugin_id），由认证流程统一驱动。
-        from app.core.auth.flow_registry import register_auth_flow
-        from app.core.auth.redirect import register_auth_provider
-        from app.core.auth.steps import register_auth_step
-        for _get_provided, _register, _id_attr, _label in (
-            (plugin_metadata.get_plugin_provided_auth_providers, register_auth_provider, "provider_id", "登录提供方"),
-            (plugin_metadata.get_plugin_provided_auth_flows, register_auth_flow, "flow_id", "认证流程"),
-            (plugin_metadata.get_plugin_provided_auth_steps, register_auth_step, "step_id", "认证步骤"),
-        ):
-            self._register_auth_domain(pid, _get_provided, _register, _id_attr, _label)
+        # auth 域注册整体隔离：import 或注册失败仅记录日志，不得波及后续契约域/通知域注册
+        # （与 _unregister_plugin_modules 的逐项 try 对称，避免单域故障放大为全插件注册失败）。
+        try:
+            from app.core.auth.flow_registry import register_auth_flow
+            from app.core.auth.redirect import register_auth_provider
+            from app.core.auth.steps import register_auth_step
+            for _get_provided, _register, _id_attr, _label in (
+                (plugin_metadata.get_plugin_provided_auth_providers, register_auth_provider, "provider_id", "登录提供方"),
+                (plugin_metadata.get_plugin_provided_auth_flows, register_auth_flow, "flow_id", "认证流程"),
+                (plugin_metadata.get_plugin_provided_auth_steps, register_auth_step, "step_id", "认证步骤"),
+            ):
+                self._register_auth_domain(pid, _get_provided, _register, _id_attr, _label)
+        except Exception as err:
+            logger.error(f"注册插件 {pid} 认证域出错（不影响其它域）：{str(err)}")
         # 注册插件经 provides_* 声明新增的各契约域模块（数据源/下载器/媒体服务器）：
         # 经各自契约校验通过后注册到 ModuleManager（owner=plugin_id），参与 chain 分发。
         for _get_provided, _verify, _label in (
@@ -725,6 +730,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     continue
                 try:
                     if not ModuleManager().register_module(cls, owner=plugin_id):
+                        logger.debug(f"插件 {plugin_id} 消息渠道 {_name} register_module 未激活，跳过能力矩阵登记")
                         continue
                 except Exception as err:
                     logger.error(f"注册插件 {plugin_id} 消息渠道 {_name} 出错：{str(err)}")
@@ -741,6 +747,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         instance = ModuleManager().get_running_module(getattr(module_cls, "__name__", ""))
         getter = getattr(instance, "get_channel_capabilities", None)
         if not callable(getter):
+            logger.debug(f"插件 {plugin_id} 消息渠道 {getattr(module_cls, '__name__', module_cls)} "
+                         f"未提供 get_channel_capabilities，跳过能力登记（走降级默认）")
             return
         try:
             caps = getter()

--- a/app/managers/base.py
+++ b/app/managers/base.py
@@ -1,16 +1,13 @@
-import inspect
 import traceback
 from typing import Any
 
-from fastapi.concurrency import run_in_threadpool
-
+from app.core import dispatch
 from app.core.event import eventmanager
 from app.core.module import ModuleManager
 from app.helper.message import MessageHelper
 from app.log import logger
 from app.schemas.exception import RateLimitExceededException
 from app.schemas.types import EventType
-from app.utils.object import ObjectUtils
 from app.utils.singleton import Singleton
 
 
@@ -20,9 +17,8 @@ class ManagerBase(metaclass=Singleton):
     以及仅面向系统后端的单步分发入口 _dispatch。
 
     门面管理器（Managers）按方法名把领域操作分发到各后端模块，被 ChainBase 直接调用。各域门面
-    （downloader/mediaserver/notification/storage/mediarecognize）原先各自复刻同一套分发/错误处理逻辑；
-    本基类把它们收敛为单一实现，子类只声明对外的类型化方法并转发到 _dispatch（单面）或 dispatch（两步，
-    见 PluginDispatchManager）。
+    （downloader/mediaserver/notification/storage/mediarecognize）的遍历/合并/隔离逻辑统一收敛到
+    app.core.dispatch；本基类与子类只构造后端三元组与错误回调后委托内核。
 
     合并规则（各域一致）：当前结果为空（None / 全 None 元组）取后端返回值；可作为下一后端入参时经
     check_signature 透传（管道域逐源精化）；为列表时跨后端 extend；为非空标量时短路停止。
@@ -46,9 +42,7 @@ class ManagerBase(metaclass=Singleton):
     @staticmethod
     def _is_valid_empty(ret: Any) -> bool:
         """判断分发结果是否为空：元组需全部为 None，其余按 is None 判断。"""
-        if isinstance(ret, tuple):
-            return all(value is None for value in ret)
-        return ret is None
+        return dispatch.is_valid_empty(ret)
 
     def _handle_system_error(self, err: Exception, module_id: str, module_name: str,
                              method: str, raise_exception: bool) -> None:
@@ -96,19 +90,10 @@ class ManagerBase(metaclass=Singleton):
     # 系统后端面（同步）
     # ------------------------------------------------------------------ #
 
-    def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
-                                 *args, **kwargs) -> Any:
+    def _system_entries(self, method: str):
         """
-        按优先级（get_priority 升序）依次调用各系统后端模块的同名方法，按合并规则累积结果。
-
-        单个后端异常被隔离后继续其余后端；限流安静跳过；raise_exception=True 时透传首个异常。
-
-        :param method: 方法名
-        :param result: 已累积的结果（单步分发传 None）
-        :param raise_exception: 出错时是否抛出
-        :return: 累积后的结果
+        生成系统后端面的后端三元组 (module_id, module_name, func)：按优先级（get_priority 升序）取各运行模块的同名方法。
         """
-        logger.debug(f"请求系统模块执行：{method} ...")
         for module in sorted(
                 self._modulemanager.get_running_modules(method),
                 key=lambda x: x.get_priority(),
@@ -119,24 +104,33 @@ class ManagerBase(metaclass=Singleton):
             except Exception as err:
                 logger.debug(f"获取模块名称出错：{str(err)}")
                 module_name = module_id
-            try:
-                func = getattr(module, method)
-                if self._is_valid_empty(result):
-                    result = func(*args, **kwargs)
-                elif ObjectUtils.check_signature(func, result):
-                    result = func(result)
-                elif isinstance(result, list):
-                    temp = func(*args, **kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    break
-            except RateLimitExceededException as err:
-                # 限流先于通用异常捕获：安静跳过、不告警。
-                self._handle_rate_limit_error(err, "模块", module_id, method, raise_exception)
-            except Exception as err:
-                self._handle_system_error(err, module_id, module_name, method, raise_exception)
-        return result
+            yield module_id, module_name, getattr(module, method)
+
+    def _dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """
+        按优先级依次调用各系统后端模块的同名方法，按合并规则累积结果（启用 check_signature 管道精化）。
+
+        单个后端异常被隔离后继续其余后端；限流安静跳过；raise_exception=True 时透传首个异常。
+        系统后端方法无 raise_exception 形参，故 kwargs 不携带该控制位。
+
+        :param method: 方法名
+        :param result: 已累积的结果（单步分发传 None）
+        :param raise_exception: 出错时是否抛出
+        :return: 累积后的结果
+        """
+        logger.debug(f"请求系统模块执行：{method} ...")
+        return dispatch.execute_modules(
+            self._system_entries(method), method, result, *args,
+            pipeline=True,
+            on_rate_limit=lambda err, ident, name, m: self._handle_rate_limit_error(
+                err, "模块", ident, m, raise_exception
+            ),
+            on_error=lambda err, ident, name, m: self._handle_system_error(
+                err, ident, name, m, raise_exception
+            ),
+            **kwargs,
+        )
 
     # ------------------------------------------------------------------ #
     # 单步分发（仅系统后端面）：downloader / mediaserver 域
@@ -185,20 +179,12 @@ class PluginDispatchManager(ManagerBase):
             },
         )
 
-    def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
-                                 *args, **kwargs) -> Any:
+    def _plugin_entries(self, method: str):
         """
-        依次调用各已启用插件注册的同名方法，按合并规则累积结果。
-
-        :param method: 方法名
-        :param result: 已累积的结果，用于判定空值合并 / 列表合并 / 短路
-        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法（插件可据此决定内部异常是否上抛）
-        :return: 累积后的结果
+        生成插件钩子面的后端三元组 (plugin_id, plugin_name, func)：取各已启用插件注册的同名方法。
         """
         # 延迟导入，避免包初始化期的循环依赖（同时是测试的 patch 目标）。
         from app.helper.plugin_manager import PluginManager
-        # raise_exception 随调用透传给插件方法；系统后端面则不透传。
-        plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
         for plugin, module_dict in PluginManager().get_plugin_modules().items():
             plugin_id, plugin_name = plugin
             if method not in module_dict:
@@ -206,21 +192,33 @@ class PluginDispatchManager(ManagerBase):
             func = module_dict[method]
             if not func:
                 continue
-            try:
-                logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
-                if self._is_valid_empty(result):
-                    result = func(*args, **plugin_kwargs)
-                elif isinstance(result, list):
-                    temp = func(*args, **plugin_kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    break
-            except RateLimitExceededException as err:
-                self._handle_rate_limit_error(err, "插件", plugin_id, method, raise_exception)
-            except Exception as err:
-                self._handle_plugin_error(err, plugin_id, plugin_name, method, raise_exception)
-        return result
+            yield plugin_id, plugin_name, func
+
+    def _dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
+                                 *args, **kwargs) -> Any:
+        """
+        依次调用各已启用插件注册的同名方法，按合并规则累积结果（不做 check_signature 精化）。
+
+        raise_exception 随调用透传给插件方法（插件可据此决定内部异常是否上抛）；系统后端面则不透传。
+
+        :param method: 方法名
+        :param result: 已累积的结果，用于判定空值合并 / 列表合并 / 短路
+        :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
+        :return: 累积后的结果
+        """
+        plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
+        return dispatch.execute_modules(
+            self._plugin_entries(method), method, result, *args,
+            pipeline=False,
+            log_each=lambda name, m: logger.info(f"请求插件 {name} 执行：{m} ..."),
+            on_rate_limit=lambda err, ident, name, m: self._handle_rate_limit_error(
+                err, "插件", ident, m, raise_exception
+            ),
+            on_error=lambda err, ident, name, m: self._handle_plugin_error(
+                err, ident, name, m, raise_exception
+            ),
+            **plugin_kwargs,
+        )
 
     def dispatch(self, method: str, *args, **kwargs) -> Any:
         """
@@ -248,7 +246,7 @@ class AsyncDispatchMixin:
     一并继承）。
 
     依赖宿主类（PluginDispatchManager/ManagerBase）提供的：_is_valid_empty、_handle_rate_limit_error、
-    _handle_plugin_error、_handle_system_error、_modulemanager。
+    _handle_plugin_error、_handle_system_error、_plugin_entries、_system_entries。
     """
 
     async def _async_dispatch_plugin_modules(self, method: str, result: Any, raise_exception: bool,
@@ -261,42 +259,26 @@ class AsyncDispatchMixin:
         :param raise_exception: 出错时是否抛出；同时随调用透传给插件方法
         :return: 累积后的结果
         """
-        from app.helper.plugin_manager import PluginManager
         plugin_kwargs = {**kwargs, "raise_exception": raise_exception}
-        for plugin, module_dict in PluginManager().get_plugin_modules().items():
-            plugin_id, plugin_name = plugin
-            if method not in module_dict:
-                continue
-            func = module_dict[method]
-            if not func:
-                continue
-            try:
-                logger.info(f"请求插件 {plugin_name} 执行：{method} ...")
-                if self._is_valid_empty(result):
-                    if inspect.iscoroutinefunction(func):
-                        result = await func(*args, **plugin_kwargs)
-                    else:
-                        result = await run_in_threadpool(func, *args, **plugin_kwargs)
-                elif isinstance(result, list):
-                    if inspect.iscoroutinefunction(func):
-                        temp = await func(*args, **plugin_kwargs)
-                    else:
-                        temp = await run_in_threadpool(func, *args, **plugin_kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    break
-            except RateLimitExceededException as err:
-                self._handle_rate_limit_error(err, "插件", plugin_id, method, raise_exception)
-            except Exception as err:
-                self._handle_plugin_error(err, plugin_id, plugin_name, method, raise_exception)
-        return result
+        return await dispatch.async_execute_modules(
+            self._plugin_entries(method), method, result, *args,
+            pipeline=False,
+            log_each=lambda name, m: logger.info(f"请求插件 {name} 执行：{m} ..."),
+            on_rate_limit=lambda err, ident, name, m: self._handle_rate_limit_error(
+                err, "插件", ident, m, raise_exception
+            ),
+            on_error=lambda err, ident, name, m: self._handle_plugin_error(
+                err, ident, name, m, raise_exception
+            ),
+            **plugin_kwargs,
+        )
 
     async def _async_dispatch_system_modules(self, method: str, result: Any, raise_exception: bool,
                                              *args, **kwargs) -> Any:
         """
-        异步按优先级（get_priority 升序）依次调用各系统后端模块的同名方法（同步方法经线程池执行），
-        按合并规则累积结果（识别为管道域：结果可作为下一后端入参时经 check_signature 透传，逐源精化）。
+        异步按优先级依次调用各系统后端模块的同名方法（同步方法经线程池执行），按合并规则累积结果
+        （管道域：结果可作为下一后端入参时经 check_signature 透传，逐源精化）。系统后端方法无
+        raise_exception 形参，故 kwargs 不携带该控制位。
 
         :param method: 方法名
         :param result: 已累积的结果
@@ -304,42 +286,17 @@ class AsyncDispatchMixin:
         :return: 累积后的结果
         """
         logger.debug(f"请求系统模块执行：{method} ...")
-        for module in sorted(
-                self._modulemanager.get_running_modules(method),
-                key=lambda x: x.get_priority(),
-        ):
-            module_id = module.__class__.__name__
-            try:
-                module_name = module.get_name()
-            except Exception as err:
-                logger.debug(f"获取模块名称出错：{str(err)}")
-                module_name = module_id
-            try:
-                func = getattr(module, method)
-                if self._is_valid_empty(result):
-                    if inspect.iscoroutinefunction(func):
-                        result = await func(*args, **kwargs)
-                    else:
-                        result = await run_in_threadpool(func, *args, **kwargs)
-                elif ObjectUtils.check_signature(func, result):
-                    if inspect.iscoroutinefunction(func):
-                        result = await func(result)
-                    else:
-                        result = await run_in_threadpool(func, result)
-                elif isinstance(result, list):
-                    if inspect.iscoroutinefunction(func):
-                        temp = await func(*args, **kwargs)
-                    else:
-                        temp = await run_in_threadpool(func, *args, **kwargs)
-                    if isinstance(temp, list):
-                        result.extend(temp)
-                else:
-                    break
-            except RateLimitExceededException as err:
-                self._handle_rate_limit_error(err, "模块", module_id, method, raise_exception)
-            except Exception as err:
-                self._handle_system_error(err, module_id, module_name, method, raise_exception)
-        return result
+        return await dispatch.async_execute_modules(
+            self._system_entries(method), method, result, *args,
+            pipeline=True,
+            on_rate_limit=lambda err, ident, name, m: self._handle_rate_limit_error(
+                err, "模块", ident, m, raise_exception
+            ),
+            on_error=lambda err, ident, name, m: self._handle_system_error(
+                err, ident, name, m, raise_exception
+            ),
+            **kwargs,
+        )
 
     async def async_dispatch(self, method: str, *args, **kwargs) -> Any:
         """

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
 
 # 模块默认优先级：数字越小优先级越高。未显式声明优先级的模块统一回退到此值，
 # 避免 get_priority() 返回 None 在排序/比较时引发 TypeError。
-DEFAULT_MODULE_PRIORITY: int = 100
+# 取值约束：必须大于所有内建模块声明的优先级（当前最大为 qqbot=10），以保证“未声明者恒排最后”。
+DEFAULT_MODULE_PRIORITY: int = 9999
 
 
 class _ModuleBase(ConfigReloadMixin, metaclass=ABCMeta):

--- a/app/service/anthropic.py
+++ b/app/service/anthropic.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from app import schemas
 from app.core.config import settings
+from app.core.security import compare_secret
 
 
 def anthropic_error_response(
@@ -26,7 +27,7 @@ def anthropic_error_response(
 
 
 def check_auth(api_key: Optional[str]) -> Optional[JSONResponse]:
-    if not api_key or api_key != settings.API_TOKEN:
+    if not compare_secret(api_key, settings.API_TOKEN):
         return anthropic_error_response(
             "invalid x-api-key",
             401,

--- a/app/service/openai.py
+++ b/app/service/openai.py
@@ -13,6 +13,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from app import schemas
 from app.core.config import settings
+from app.core.security import compare_secret
 
 
 def sse_payload(data: dict) -> str:
@@ -48,7 +49,7 @@ def check_auth(
             error_type="authentication_error",
             code="invalid_api_key",
         )
-    if credentials.credentials != settings.API_TOKEN:
+    if not compare_secret(credentials.credentials, settings.API_TOKEN):
         return error_response(
             "Invalid bearer token.",
             401,

--- a/tests/test_dispatch_kernel_unify.py
+++ b/tests/test_dispatch_kernel_unify.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+"""
+统一分发内核 app.core.dispatch 回归测试。
+
+覆盖：
+- is_valid_empty 空值判定；
+- 合并规则（空→取值、list→extend、非空标量→短路、系统面 check_signature 管道精化、插件面不精化）；
+- 错误隔离（单后端异常被隔离、其余续跑）与回调透传首个异常；
+- 限流（RateLimitExceededException 走 on_rate_limit、不进 on_error）；
+- kwargs 原样转发（内核对 kwargs 内容无主张）；
+- sync 与 async 两版关键路径；
+- **唯一真实差异：raise_exception 透传系统后端** —— ChainBase 路径系统后端 func 收到 raise_exception，
+  ManagerBase._dispatch 路径系统后端 func 不收到（pop 掉，否则 TypeError）。
+"""
+import asyncio
+import unittest
+from unittest.mock import Mock
+
+from app.core import dispatch
+from app.chain import ChainBase
+from app.managers import DownloaderManager
+from app.schemas import RateLimitExceededException
+
+
+def _noop(*_args, **_kwargs):
+    """空回调。"""
+    return None
+
+
+def _reraise(err, *_args, **_kwargs):
+    """重抛回调：模拟 raise_exception=True 时错误处理回调透传异常。"""
+    raise err
+
+
+class _RecordingModule:
+    """记录每次调用所收 kwargs 的系统后端桩。"""
+
+    def __init__(self, name="rec", priority=1, ret="ok"):
+        self._name = name
+        self._priority = priority
+        self._ret = ret
+        self.received = []
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return self._priority
+
+    def probe(self, *args, **kwargs):
+        self.received.append(dict(kwargs))
+        return self._ret
+
+
+class _StrictModule:
+    """形参严格（不接受 raise_exception）的系统后端桩，用于验证 pop 的必要性。"""
+
+    def __init__(self, name="strict"):
+        self._name = name
+        self.calls = 0
+
+    def get_name(self):
+        return self._name
+
+    def get_priority(self):
+        return 1
+
+    def probe(self):
+        self.calls += 1
+        return "ok"
+
+
+# --------------------------------------------------------------------------- #
+# is_valid_empty
+# --------------------------------------------------------------------------- #
+class TestIsValidEmpty(unittest.TestCase):
+
+    def test_none_is_empty(self):
+        self.assertTrue(dispatch.is_valid_empty(None))
+
+    def test_all_none_tuple_is_empty(self):
+        self.assertTrue(dispatch.is_valid_empty((None, None)))
+
+    def test_partial_none_tuple_is_not_empty(self):
+        self.assertFalse(dispatch.is_valid_empty(("got", None)))
+
+    def test_falsy_scalars_are_not_empty(self):
+        self.assertFalse(dispatch.is_valid_empty(0))
+        self.assertFalse(dispatch.is_valid_empty(False))
+        self.assertFalse(dispatch.is_valid_empty([]))
+        self.assertFalse(dispatch.is_valid_empty(""))
+
+
+# --------------------------------------------------------------------------- #
+# 合并规则（同步）
+# --------------------------------------------------------------------------- #
+class TestSyncMergeRules(unittest.TestCase):
+
+    def _run(self, entries, *, pipeline, **kwargs):
+        return dispatch.execute_modules(
+            entries, "probe", None, pipeline=pipeline,
+            on_rate_limit=_noop, on_error=_noop, **kwargs,
+        )
+
+    def test_empty_takes_value(self):
+        entries = [("a", "A", lambda *a, **k: None), ("b", "B", lambda *a, **k: "val")]
+        self.assertEqual(self._run(entries, pipeline=False), "val")
+
+    def test_list_extends_across_backends(self):
+        entries = [("a", "A", lambda *a, **k: [1, 2]), ("b", "B", lambda *a, **k: [3])]
+        self.assertEqual(self._run(entries, pipeline=False), [1, 2, 3])
+
+    def test_non_empty_scalar_short_circuits(self):
+        seen = []
+
+        def second(*a, **k):
+            seen.append(True)
+            return [9]
+
+        entries = [("a", "A", lambda *a, **k: True), ("b", "B", second)]
+        self.assertIs(self._run(entries, pipeline=False), True)
+        self.assertEqual(seen, [])  # 短路：第二个后端不被调用
+
+    def test_system_pipeline_refines_result(self):
+        def first(*a, **k):
+            return "raw"
+
+        def refine(x: str):
+            return x + "-refined"
+
+        entries = [("a", "A", first), ("b", "B", refine)]
+        self.assertEqual(self._run(entries, pipeline=True), "raw-refined")
+
+    def test_plugin_face_does_not_refine(self):
+        def first(*a, **k):
+            return "raw"
+
+        def refine(x: str):
+            return x + "-refined"
+
+        # pipeline=False：非空标量直接短路，不走 check_signature 精化
+        entries = [("a", "A", first), ("b", "B", refine)]
+        self.assertEqual(self._run(entries, pipeline=False), "raw")
+
+    def test_log_each_called_before_each_backend(self):
+        logged = []
+        entries = [("a", "A", lambda *a, **k: None), ("b", "B", lambda *a, **k: "v")]
+        dispatch.execute_modules(
+            entries, "probe", None, pipeline=False,
+            on_rate_limit=_noop, on_error=_noop,
+            log_each=lambda name, m: logged.append((name, m)),
+        )
+        self.assertEqual(logged, [("A", "probe"), ("B", "probe")])
+
+    def test_kwargs_forwarded_verbatim(self):
+        received = []
+
+        def first(*a, **k):
+            received.append(dict(k))
+            return None
+
+        def second(*a, **k):
+            received.append(dict(k))
+            return "v"
+
+        entries = [("a", "A", first), ("b", "B", second)]
+        dispatch.execute_modules(
+            entries, "probe", None, pipeline=False,
+            on_rate_limit=_noop, on_error=_noop,
+            foo="bar", raise_exception=True,
+        )
+        self.assertEqual(received[0], {"foo": "bar", "raise_exception": True})
+
+
+# --------------------------------------------------------------------------- #
+# 错误隔离 / 限流（同步）
+# --------------------------------------------------------------------------- #
+class TestSyncErrorAndRateLimit(unittest.TestCase):
+
+    def test_error_isolated_and_others_continue(self):
+        errors = []
+
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+
+        def ok(*a, **k):
+            return "value"
+
+        entries = [("a", "A", boom), ("b", "B", ok)]
+        out = dispatch.execute_modules(
+            entries, "probe", None, pipeline=True,
+            on_rate_limit=_noop,
+            on_error=lambda e, i, n, m: errors.append((i, n, type(e))),
+        )
+        self.assertEqual(out, "value")
+        self.assertEqual(errors, [("a", "A", RuntimeError)])
+
+    def test_on_error_may_propagate_first_exception(self):
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+
+        entries = [("a", "A", boom), ("b", "B", lambda *a, **k: "value")]
+        with self.assertRaises(RuntimeError):
+            dispatch.execute_modules(
+                entries, "probe", None, pipeline=True,
+                on_rate_limit=_noop, on_error=_reraise,
+            )
+
+    def test_rate_limit_skipped_not_treated_as_error(self):
+        rate_limited = []
+        errors = []
+
+        def limited(*a, **k):
+            raise RateLimitExceededException("rl")
+
+        def ok(*a, **k):
+            return "value"
+
+        entries = [("a", "A", limited), ("b", "B", ok)]
+        out = dispatch.execute_modules(
+            entries, "probe", None, pipeline=True,
+            on_rate_limit=lambda e, i, n, m: rate_limited.append(i),
+            on_error=lambda e, i, n, m: errors.append(i),
+        )
+        self.assertEqual(out, "value")
+        self.assertEqual(rate_limited, ["a"])
+        self.assertEqual(errors, [])
+
+
+# --------------------------------------------------------------------------- #
+# 异步关键路径
+# --------------------------------------------------------------------------- #
+class TestAsyncKernel(unittest.TestCase):
+
+    def test_async_mixes_sync_threadpool_and_async_await(self):
+        async def afunc(*a, **k):
+            return "async-val"
+
+        def sfunc(*a, **k):
+            return None
+
+        async def runner():
+            entries = [("a", "A", sfunc), ("b", "B", afunc)]
+            return await dispatch.async_execute_modules(
+                entries, "probe", None, pipeline=False,
+                on_rate_limit=_noop, on_error=_noop,
+            )
+
+        self.assertEqual(asyncio.run(runner()), "async-val")
+
+    def test_async_list_extend(self):
+        async def afirst(*a, **k):
+            return [1]
+
+        def ssecond(*a, **k):
+            return [2, 3]
+
+        async def runner():
+            entries = [("a", "A", afirst), ("b", "B", ssecond)]
+            return await dispatch.async_execute_modules(
+                entries, "probe", None, pipeline=False,
+                on_rate_limit=_noop, on_error=_noop,
+            )
+
+        self.assertEqual(asyncio.run(runner()), [1, 2, 3])
+
+    def test_async_pipeline_refines(self):
+        def first(*a, **k):
+            return "raw"
+
+        async def refine(x: str):
+            return x + "-refined"
+
+        async def runner():
+            entries = [("a", "A", first), ("b", "B", refine)]
+            return await dispatch.async_execute_modules(
+                entries, "probe", None, pipeline=True,
+                on_rate_limit=_noop, on_error=_noop,
+            )
+
+        self.assertEqual(asyncio.run(runner()), "raw-refined")
+
+    def test_async_error_isolated(self):
+        errors = []
+
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+
+        async def ok(*a, **k):
+            return "value"
+
+        async def runner():
+            entries = [("a", "A", boom), ("b", "B", ok)]
+            return await dispatch.async_execute_modules(
+                entries, "probe", None, pipeline=True,
+                on_rate_limit=_noop,
+                on_error=lambda e, i, n, m: errors.append(i),
+            )
+
+        self.assertEqual(asyncio.run(runner()), "value")
+        self.assertEqual(errors, ["a"])
+
+    def test_async_rate_limit_skipped(self):
+        rate_limited = []
+        errors = []
+
+        async def limited(*a, **k):
+            raise RateLimitExceededException("rl")
+
+        def ok(*a, **k):
+            return "value"
+
+        async def runner():
+            entries = [("a", "A", limited), ("b", "B", ok)]
+            return await dispatch.async_execute_modules(
+                entries, "probe", None, pipeline=True,
+                on_rate_limit=lambda e, i, n, m: rate_limited.append(i),
+                on_error=lambda e, i, n, m: errors.append(i),
+            )
+
+        self.assertEqual(asyncio.run(runner()), "value")
+        self.assertEqual(rate_limited, ["a"])
+        self.assertEqual(errors, [])
+
+
+# --------------------------------------------------------------------------- #
+# raise_exception 透传系统后端：唯一真实差异（最关键）
+# --------------------------------------------------------------------------- #
+class TestRaiseExceptionPassthroughDifference(unittest.TestCase):
+    """
+    ChainBase.run_module 从不 pop raise_exception → 随 **kwargs 透传给系统后端 func（by-design，
+    chain 领域方法经签名消费）。ManagerBase._dispatch pop 掉 raise_exception → 系统后端 func 不收到
+    （门面后端无此形参，带上会 TypeError）。
+    """
+
+    def _make_chain(self, backend):
+        chain = ChainBase()
+        chain.pluginmanager = Mock()
+        chain.pluginmanager.get_plugin_modules.return_value = {}
+        chain.modulemanager = Mock()
+        chain.modulemanager.get_running_modules.return_value = [backend]
+        chain.messagehelper = Mock()
+        chain.eventmanager = Mock()
+        return chain
+
+    def _make_downloader(self, backend):
+        dm = DownloaderManager()
+        orig = dm._modulemanager
+        dm._modulemanager = Mock()
+        dm._modulemanager.get_running_modules.return_value = [backend]
+        return dm, orig
+
+    def test_chain_system_backend_receives_raise_exception(self):
+        backend = _RecordingModule("chain-sys")
+        chain = self._make_chain(backend)
+
+        chain.run_module("probe", raise_exception=True)
+
+        self.assertEqual(len(backend.received), 1)
+        self.assertIn("raise_exception", backend.received[0])
+        self.assertTrue(backend.received[0]["raise_exception"])
+
+    def test_manager_system_backend_does_not_receive_raise_exception(self):
+        backend = _RecordingModule("mgr-sys")
+        dm, orig = self._make_downloader(backend)
+        try:
+            dm._dispatch("probe", raise_exception=True)
+        finally:
+            dm._modulemanager = orig
+
+        self.assertEqual(len(backend.received), 1)
+        self.assertNotIn("raise_exception", backend.received[0])
+
+    def test_async_chain_system_backend_receives_raise_exception(self):
+        backend = _RecordingModule("chain-async-sys")
+        chain = self._make_chain(backend)
+
+        asyncio.run(chain.async_run_module("probe", raise_exception=True))
+
+        self.assertEqual(len(backend.received), 1)
+        self.assertTrue(backend.received[0]["raise_exception"])
+
+    def test_strict_backend_ok_on_manager_but_typeerror_on_chain(self):
+        # 门面 pop raise_exception → 严格形参后端可被调用
+        backend_m = _StrictModule("mgr")
+        dm, orig = self._make_downloader(backend_m)
+        try:
+            self.assertEqual(dm._dispatch("probe", raise_exception=True), "ok")
+        finally:
+            dm._modulemanager = orig
+        self.assertEqual(backend_m.calls, 1)
+
+        # chain 透传 raise_exception → 严格形参后端 TypeError，且 raise_exception=True 时上抛
+        backend_c = _StrictModule("chain")
+        chain = self._make_chain(backend_c)
+        with self.assertRaises(TypeError):
+            chain.run_module("probe", raise_exception=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_broadcast_concurrency.py
+++ b/tests/test_event_broadcast_concurrency.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+回归测试：广播事件分发的并发安全（架构审计 HIGH）。
+
+背景：``add_event_listener`` / ``remove_event_listener`` 在 ``self.__lock`` 保护下增删订阅者字典，
+但 ``__dispatch_broadcast_event`` 旧实现**不持锁**直接迭代活字典 ``__broadcast_subscribers[etype].items()``。
+运行时插件启停 / 热重载会在广播进行中并发改同一字典，触发
+``RuntimeError: dictionary changed size during iteration``，逃出 ``__broadcast_consumer_loop``
+（其 except 只捕 ``Empty``）→ 消费者线程死亡 → 广播永久停摆。
+
+修复：
+1. 广播分发在锁内对订阅者快照后再迭代（链式分发同样收口）。
+2. 消费者循环对分发异常做兜底，单次异常不得杀死消费者线程。
+"""
+import threading
+import types
+from queue import PriorityQueue
+
+from app.core.event.manager import EventManager
+from app.core.event.models import Event
+from app.schemas.types import EventType
+
+_ETYPE = EventType.PluginAction  # 广播类事件（非 ChainEventType）
+
+
+def _make_handler(name):
+    def _handler(event):  # pragma: no cover - 不会被真正执行（executor 被替身拦截）
+        return name
+    _handler.__qualname__ = f"_FakeBroadcast.{name}"
+    return _handler
+
+
+def test_broadcast_dispatch_snapshots_subscribers_under_mutation(monkeypatch):
+    """广播迭代期间并发往同一事件字典插入处理器，不应抛 RuntimeError，原处理器仍被提交。"""
+    em = EventManager()
+    subs = em._EventManager__broadcast_subscribers
+    saved = subs.get(_ETYPE)
+    subs[_ETYPE] = {"h1": _make_handler("h1"), "h2": _make_handler("h2")}
+    try:
+        submitted = []
+
+        def fake_submit(func, *args):
+            # 首次提交时模拟“运行时插件注册”：往正在被迭代的字典插入新键。
+            if not submitted:
+                subs[_ETYPE]["injected"] = _make_handler("injected")
+            submitted.append(func)
+
+        monkeypatch.setattr(em, "_EventManager__executor",
+                            types.SimpleNamespace(submit=fake_submit))
+
+        # 旧代码在此抛 RuntimeError: dictionary changed size during iteration
+        em._EventManager__dispatch_broadcast_event(Event(_ETYPE))
+
+        # 两个原始处理器都应被提交（快照在变更前已固定）
+        assert len(submitted) >= 2
+    finally:
+        if saved is None:
+            subs.pop(_ETYPE, None)
+        else:
+            subs[_ETYPE] = saved
+
+
+def test_consumer_loop_survives_dispatch_exception(monkeypatch):
+    """单次广播分发抛异常不得逃出消费者循环；后续事件仍被处理。"""
+    em = EventManager()
+
+    local_queue = PriorityQueue()
+    local_queue.put((10, Event(_ETYPE)))
+    local_queue.put((20, Event(_ETYPE)))
+    local_event = threading.Event()
+    local_event.set()
+
+    monkeypatch.setattr(em, "_EventManager__event_queue", local_queue)
+    monkeypatch.setattr(em, "_EventManager__event", local_event)
+
+    dispatched = []
+
+    def fake_dispatch(event):
+        dispatched.append(event)
+        if len(dispatched) == 1:
+            raise RuntimeError("dictionary changed size during iteration")
+        # 第二个事件处理完后退出循环
+        local_event.clear()
+
+    monkeypatch.setattr(em, "_EventManager__dispatch_broadcast_event", fake_dispatch)
+
+    # 旧代码：第一个事件的 RuntimeError 会逃出 while 循环（消费者线程死亡）
+    em._EventManager__broadcast_consumer_loop()
+
+    assert len(dispatched) == 2

--- a/tests/test_module_default_priority.py
+++ b/tests/test_module_default_priority.py
@@ -4,7 +4,8 @@
 
 背景（架构审计 #25）：get_priority() 旧实现为 ``pass`` → 返回 None，未显式声明优先级的模块在
 按优先级排序/比较时会触发 ``TypeError: '<' not supported between 'int' and 'NoneType'``。
-修复为回退到模块级常量 DEFAULT_MODULE_PRIORITY=100。
+修复为回退到模块级常量 DEFAULT_MODULE_PRIORITY=9999（须大于所有内建模块声明的优先级，
+当前最大为 qqbot=10，保证“未声明者恒排最后”）。
 
 注意：修复刻意未采用 ``x.get_priority() or 0`` 写法——那会把 6 个合法 priority=0 的内建模块
 误改为 0 之外的语义（0 为假值会被 ``or`` 吞掉）。本测试同时守护"合法 0 不被改写"这一不变式。
@@ -13,9 +14,11 @@ from app.modules import DEFAULT_MODULE_PRIORITY, _ModuleBase
 from app.schemas.types import ModuleType
 
 
-def test_default_priority_constant_is_int_100():
-    assert DEFAULT_MODULE_PRIORITY == 100
+def test_default_priority_constant_is_int_sentinel():
+    assert DEFAULT_MODULE_PRIORITY == 9999
     assert isinstance(DEFAULT_MODULE_PRIORITY, int)
+    # 守护取值约束：必须大于所有内建模块声明的优先级（当前最大 10）
+    assert DEFAULT_MODULE_PRIORITY > 10
 
 
 def test_base_get_priority_returns_int_not_none():
@@ -73,3 +76,40 @@ def test_legitimate_zero_priority_preserved():
             return 0
 
     assert _ZeroPriorityModule().get_priority() == 0
+
+
+def test_mixed_priority_sort_order():
+    """混排排序：显式 priority=0 的模块排在回退到默认值(9999)的模块之前。
+
+    这是 get_priority 修复要保证的核心不变式——分发内核各处均按 sorted(key=get_priority) 调度。
+    """
+
+    class _Base(_ModuleBase):
+        def init_module(self) -> None:
+            pass
+
+        def init_setting(self):
+            return None
+
+        def stop(self) -> None:
+            pass
+
+        def test(self):
+            return True, ""
+
+        @staticmethod
+        def get_type() -> ModuleType:
+            return ModuleType.Other
+
+    class _ZeroModule(_Base):
+        @staticmethod
+        def get_priority() -> int:
+            return 0
+
+    class _DefaultModule(_Base):
+        pass
+
+    zero, default = _ZeroModule(), _DefaultModule()
+    ordered = sorted([default, zero], key=lambda x: x.get_priority())
+    assert ordered[0] is zero
+    assert ordered[1] is default


### PR DESCRIPTION
## 概述

基于对 v3-python 近期已合并修复（#88 装配桥/渠道能力、#89 begin 限流、#91 速赢）的**对抗式复核**，本 PR 交付一项架构债收敛（统一两套分发内核）+ 一个并发 **HIGH** 修复 + 数项审查校正。基于当前 `v3-python`，全量 **1980 passed / 1 skipped / 0 failed**。

## 变更（3 提交）

### 1. `fix(event)` 广播/链式分发锁内快照 + 消费者兜底（HIGH）
`__dispatch_broadcast_event` 原**不持锁**直接迭代活字典 `__broadcast_subscribers[etype].items()`，而 `add/remove_event_listener` 在 `self.__lock` 下运行时增删同一字典（插件启停/热重载）。并发会触发 `RuntimeError: dictionary changed size during iteration`，逃出仅捕 `Empty` 的 `__broadcast_consumer_loop` → 消费者线程死亡 → 广播永久停摆。
- 广播与链式分发均改为**锁内 `list(...)` 快照后再迭代**（链式原推导式窗口更小但一并收口）。
- 消费者循环新增 `except Exception` 兜底，单次分发异常不再杀死消费者线程。
- 新增 `tests/test_event_broadcast_concurrency.py`（2 例，RED→GREEN）。

### 2. `fix(security/plugin)` 对抗审查校正
- **CWE-208 计时侧信道**：新增 `security.compare_secret`（`hmac.compare_digest`），统一替换 4 处明文 `!=` token 比较（`security.__verify_key`、`anthropic`/`openai` `check_auth`、`subscribe` `/seerr` webhook）。
- 模块默认优先级哨兵 `100→9999` + 取值约束注释，补混排排序集成测试（锁定 `priority=0` 恒先于默认值）。
- `plugin_manager` auth 域注册整体 `try` 隔离（原无条件 import 会让单域故障中断**全部**插件注册，且与 `_unregister` 不对称）+ 渠道能力静默跳过补 `debug` 诊断日志。

### 3. `refactor(dispatch)` 统一两套分发内核（架构债 #32+#24+#60）
`ChainBase`（广播：插件面+系统面）与门面 `Managers`（单面/两步）原各自复刻同一套"按方法名遍历后端→合并规则累积→隔离错误/限流"逻辑（叠加 sync/async 双轨）。
- 抽出单一真源 `app/core/dispatch.py`（**模块级函数**，规避 `ABCMeta` vs `Singleton` 元类冲突），两侧改为**组合委托**的薄包装：`chain/__init__.py` −73 行、`managers/base.py` −43 行。
- 合并规则逐字保持（空→取/系统面 `check_signature` 精化/list→extend/非空标量→短路）。
- **精确保留 by-design 差异**：chain 向系统后端透传 `raise_exception`（领域方法经签名消费），门面 `pop` 不透传——有铁证测试（严格形参后端：门面返 `ok` / chain 抛 `TypeError`）。
- 顺带消除 chain 系统面双重日志。
- 新增 `tests/test_dispatch_kernel_unify.py`（23 例：合并规则/错误隔离/限流/sync+async/透传差异）。

## 测试计划
- [x] 全量 `pytest tests/`：**1980 passed / 1 skipped / 0 failed**
- [x] `test_dispatch_kernel_unify.py`（23 例，含 `raise_exception` 透传差异非空断言）
- [x] `test_event_broadcast_concurrency.py`（2 例）
- [x] 既有 `test_*_facade.py` 门面==run_module 等价测试不变通过

## 与 #90 的关系
本 PR 的计时侧信道修复触及 `security.__verify_key` 与 `anthropic`/`openai`/`subscribe`，与 OPEN 的 **#90**（API_TOKEN 降权，改 `__get_api_token`/服务 token payload）位于不同函数，无逻辑冲突，合并顺序无关。#90 的 BREAKING 降权由其自身承载，**本 PR 无破坏性变更**。

## 遗留待办（不在本 PR，建议另开）
- XFF/`proxy_headers` 限流盲区（Docker+反代下 `client.host` 塌缩，全栈 systemic）
- `/access-token` 与 flow 两独立限流器 → 同 `ip:username` 预算 20/60s 而非 10
- `@cached` 服务 token 在 SUPERUSER 停用后的 de-auth 窗口
- 插件 `_plugins/_running_plugins` 跨线程锁（#37）、热重载只刷新一半（#36）、分发吞异常无法区分错误/空（#15，needs-scoping）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
