### PR TITLE
fix(arch): P1 技术债 — 插件并发整体替换/热重载内聚绑定/会话原子化/识别严格模式/WAL连接级

### DIFF
--- a/app/agent/tools/impl/_plugin_tool_utils.py
+++ b/app/agent/tools/impl/_plugin_tool_utils.py
@@ -68,17 +68,10 @@ def build_preview_payload(value: Any, max_chars: Optional[int]) -> tuple[bool, i
 def reload_plugin_runtime(plugin_id: str) -> None:
     """
     重载插件并重新注册其命令、定时任务和 API。
-    """
-    # 这些依赖只在真正执行重载时才导入，避免普通查询工具引入不必要的初始化开销。
-    from app.api.endpoints.plugin import register_plugin_api
-    from app.command import Command
-    from app.scheduler import Scheduler
 
-    plugin_manager = PluginManager()
-    plugin_manager.reload_plugin(plugin_id)
-    Scheduler().update_plugin_job(plugin_id)
-    Command().init_commands(plugin_id)
-    register_plugin_api(plugin_id)
+    绑定刷新（调度/命令/API 路由）已内聚于 PluginManager.reload_plugin，此处无需再外层补刷。
+    """
+    PluginManager().reload_plugin(plugin_id)
 
 
 def summarize_plugin(plugin: Any) -> dict[str, Any]:
@@ -284,7 +277,7 @@ async def uninstall_plugin_runtime(plugin_id: str) -> dict[str, Any]:
         if plugin_base_dir.exists():
             try:
                 shutil.rmtree(plugin_base_dir)
-                plugin_manager.plugins.pop(plugin_id, None)
+                plugin_manager.remove_plugin_class(plugin_id)
                 clone_files_removed = True
             except Exception:
                 clone_files_removed = False

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -428,10 +428,8 @@ def reload_plugin(
     """
     重新加载插件
     """
-    # 重新加载插件
+    # 重新加载插件（PluginManager.reload_plugin 已内聚重建调度/命令/API 路由绑定）
     PluginManager().reload_plugin(plugin_id)
-    # 注册插件服务
-    register_plugin(plugin_id)
     return schemas.Response(success=True)
 
 
@@ -882,7 +880,7 @@ def uninstall_plugin(
         if plugin_base_dir.exists():
             try:
                 shutil.rmtree(plugin_base_dir)
-                plugin_manager.plugins.pop(plugin_id, None)
+                plugin_manager.remove_plugin_class(plugin_id)
             except Exception as e:
                 logger.error(f"删除插件分身目录 {plugin_base_dir} 失败: {str(e)}")
     # 从插件文件夹中移除该插件

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -528,6 +528,7 @@ class ChainBase(metaclass=ABCMeta):
             episode_group: Optional[str] = None,
             cache: bool = True,
             share_meta: MetaBase = None,
+            raise_exception: bool = False,
     ) -> Optional[MediaInfo]:
         """
         识别媒体信息，不含Fanart图片
@@ -539,6 +540,8 @@ class ChainBase(metaclass=ABCMeta):
         :param bangumiid: BangumiID
         :param episode_group: 剧集组
         :param cache:    是否使用缓存
+        :param raise_exception: 严格模式，为真时后端瞬时异常（TMDB/网络等）上抛而非吞为
+                                "未识别到"的 None；默认 False 保持原有静默语义
         :return: 识别的媒体信息，包括剧集信息
         """
         # 识别用名中含指定信息情形
@@ -555,6 +558,8 @@ class ChainBase(metaclass=ABCMeta):
         elif not mtype and meta and meta.type in [MediaType.TV, MediaType.MOVIE]:
             mtype = meta.type
         share_query_meta = share_meta or meta
+        # 仅严格模式才注入分发控制位，默认路径不携带该 kwarg，后端收到的参数与原先逐字节一致
+        _strict = {"raise_exception": True} if raise_exception else {}
         with fresh(not cache):
             mediainfo = self.run_module(
                 "recognize_media",
@@ -565,6 +570,7 @@ class ChainBase(metaclass=ABCMeta):
                 bangumiid=bangumiid,
                 episode_group=episode_group,
                 cache=cache,
+                **_strict,
             )
         if mediainfo:
             if not mediainfo.recognize_cache_hit:
@@ -596,6 +602,7 @@ class ChainBase(metaclass=ABCMeta):
                         bangumiid=shared_params.get("bangumiid"),
                         episode_group=episode_group,
                         cache=cache,
+                        **_strict,
                     )
                 if mediainfo:
                     self._update_local_recognize_cache(shared_cache_meta, mediainfo)
@@ -612,6 +619,7 @@ class ChainBase(metaclass=ABCMeta):
             episode_group: Optional[str] = None,
             cache: bool = True,
             share_meta: MetaBase = None,
+            raise_exception: bool = False,
     ) -> Optional[MediaInfo]:
         """
         识别媒体信息，不含Fanart图片（异步版本）
@@ -623,6 +631,8 @@ class ChainBase(metaclass=ABCMeta):
         :param bangumiid: BangumiID
         :param episode_group: 剧集组
         :param cache:    是否使用缓存
+        :param raise_exception: 严格模式，为真时后端瞬时异常（TMDB/网络等）上抛而非吞为
+                                "未识别到"的 None；默认 False 保持原有静默语义
         :return: 识别的媒体信息，包括剧集信息
         """
         # 识别用名中含指定信息情形
@@ -639,6 +649,8 @@ class ChainBase(metaclass=ABCMeta):
         elif not mtype and meta and meta.type in [MediaType.TV, MediaType.MOVIE]:
             mtype = meta.type
         share_query_meta = share_meta or meta
+        # 仅严格模式才注入分发控制位，默认路径不携带该 kwarg，后端收到的参数与原先逐字节一致
+        _strict = {"raise_exception": True} if raise_exception else {}
         async with async_fresh(not cache):
             mediainfo = await self.async_run_module(
                 "async_recognize_media",
@@ -649,6 +661,7 @@ class ChainBase(metaclass=ABCMeta):
                 bangumiid=bangumiid,
                 episode_group=episode_group,
                 cache=cache,
+                **_strict,
             )
         if mediainfo:
             if not mediainfo.recognize_cache_hit:
@@ -680,6 +693,7 @@ class ChainBase(metaclass=ABCMeta):
                         bangumiid=shared_params.get("bangumiid"),
                         episode_group=episode_group,
                         cache=cache,
+                        **_strict,
                     )
                 if mediainfo:
                     await self._async_update_local_recognize_cache(shared_cache_meta, mediainfo)

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,7 +1,7 @@
-import asyncio
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Generator, List, Optional, Self, Tuple, AsyncGenerator, Union
 
-from sqlalchemy import NullPool, QueuePool, and_, create_engine, inspect, text, select, delete, Integer, \
+from sqlalchemy import NullPool, QueuePool, and_, create_engine, event, inspect, select, delete, Integer, \
     Sequence, Identity
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, declared_attr, mapped_column, scoped_session, sessionmaker
@@ -32,6 +32,31 @@ def _get_database_engine(is_async: bool = False):
         return _get_postgresql_engine(is_async)
     else:
         return _get_sqlite_engine(is_async)
+
+
+def _register_sqlite_journal_mode(engine) -> None:
+    """
+    为 SQLite 引擎按连接设置 journal_mode（WAL/DELETE）。
+
+    经 SQLAlchemy connect 事件在每个 DBAPI 连接建立时执行 PRAGMA，取代在模块 import 期
+    主动建连执行 PRAGMA（同步路径）或 asyncio.run() 起停事件循环（异步路径）的副作用。
+    异步引擎须传入其底层同步引擎（AsyncEngine.sync_engine），connect 事件注册于该同步引擎。
+
+    :param engine: 同步 Engine 或异步引擎的 sync_engine
+    """
+    _journal_mode = "WAL" if settings.DB_WAL_ENABLE else "DELETE"
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_journal_mode(dbapi_connection, _connection_record):  # noqa
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f"PRAGMA journal_mode={_journal_mode};")
+        except Exception as err:
+            # 设置失败仅告警并放行该连接：监听器抛出会令连接池拒绝所有连接、使数据库整体不可用，
+            # 故宁可以默认 journal_mode 退化运行，也不让 PRAGMA 失败演变为全局连接失败
+            print(f"Failed to set SQLite journal_mode={_journal_mode}: {err}")
+        finally:
+            cursor.close()
 
 
 def _get_sqlite_engine(is_async: bool = False):
@@ -72,11 +97,8 @@ def _get_sqlite_engine(is_async: bool = False):
         # 创建数据库引擎
         engine = create_engine(**_db_kwargs)
 
-        # 设置WAL模式
-        _journal_mode = "WAL" if settings.DB_WAL_ENABLE else "DELETE"
-        with engine.connect() as connection:
-            current_mode = connection.execute(text(f"PRAGMA journal_mode={_journal_mode};")).scalar()
-            print(f"SQLite database journal mode set to: {current_mode}")
+        # 经 connect 事件按连接设置 journal_mode，避免在模块 import 期对引擎产生建连副作用
+        _register_sqlite_journal_mode(engine)
 
         return engine
     else:
@@ -92,22 +114,9 @@ def _get_sqlite_engine(is_async: bool = False):
         # 创建异步数据库引擎
         async_engine = create_async_engine(**_db_kwargs)
 
-        # 设置WAL模式
-        _journal_mode = "WAL" if settings.DB_WAL_ENABLE else "DELETE"
-
-        async def set_async_wal_mode():
-            """
-            设置异步引擎的WAL模式
-            """
-            async with async_engine.connect() as _connection:
-                result = await _connection.execute(text(f"PRAGMA journal_mode={_journal_mode};"))
-                _current_mode = result.scalar()
-                print(f"Async SQLite database journal mode set to: {_current_mode}")
-
-        try:
-            asyncio.run(set_async_wal_mode())
-        except Exception as e:
-            print(f"Failed to set async SQLite WAL mode: {e}")
+        # 经底层同步引擎的 connect 事件按连接设置 journal_mode，
+        # 取代 import 期 asyncio.run() 起停事件循环的副作用
+        _register_sqlite_journal_mode(async_engine.sync_engine)
 
         return async_engine
 
@@ -226,6 +235,63 @@ async def close_database():
         print(f"Error while disposing database connections: {err}")
 
 
+@contextmanager
+def atomic_session() -> Generator[Session, None, None]:
+    """
+    原子会话上下文：把多步写入收敛进单一事务，统一提交或回滚。
+
+    会话打上 `_atomic_managed` 标记，块内将其作为 `db=` 传给 @db_update 装饰的写操作时，
+    各层不再各自提交/回滚，改由本上下文在块结束时统一 commit、异常时整体 rollback。
+    会话取 `expire_on_commit=False`，块结束提交后对象属性不过期，便于块后继续读取。
+
+    用法::
+
+        with atomic_session() as db:
+            obj_a.update(db, {...})
+            obj_b.update(db, {...})
+        # 两步写入在此作为单一事务提交，任一步抛错则整体回滚
+
+    :yield: 托管事务的同步 Session
+    """
+    session = SessionFactory(expire_on_commit=False)
+    session.info["_atomic_managed"] = True
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+@asynccontextmanager
+async def async_atomic_session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    异步原子会话上下文：把多步异步写入收敛进单一事务，统一提交或回滚。
+
+    语义与 atomic_session 一致，配合 @async_db_update 装饰的写操作使用。
+
+    用法::
+
+        async with async_atomic_session() as db:
+            await obj_a.async_update(db, {...})
+            await obj_b.async_update(db, {...})
+
+    :yield: 托管事务的 AsyncSession
+    """
+    session = AsyncSessionFactory(expire_on_commit=False)
+    session.info["_atomic_managed"] = True
+    try:
+        yield session
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+    finally:
+        await session.close()
+
+
 def _get_args_db(args: tuple, kwargs: dict) -> Optional[Session]:
     """
     从参数中获取数据库Session对象
@@ -307,14 +373,19 @@ def db_update(func):
             _close_db = True
             # 更新参数中的数据库会话
             args, kwargs = _update_args_db(args, kwargs, db)
+        # 外部传入且处于 atomic_session 托管事务内的会话：本层仅参与、不提交/回滚/关闭，
+        # 由 atomic_session 统一收尾，从而把多步写入收敛进单一事务（见 atomic_session）。
+        _managed = (not _close_db) and bool(db.info.get("_atomic_managed"))
         try:
             # 执行函数
             result = func(*args, **kwargs)
-            # 提交事务
-            db.commit()
+            # 提交事务（托管事务下交由 atomic_session 统一提交）
+            if not _managed:
+                db.commit()
         except Exception as err:
-            # 回滚事务
-            db.rollback()
+            # 回滚事务（托管事务下交由 atomic_session 统一回滚）
+            if not _managed:
+                db.rollback()
             raise err
         finally:
             # 关闭数据库会话
@@ -342,14 +413,19 @@ def async_db_update(func):
             _close_db = True
             # 更新参数中的异步数据库会话
             args, kwargs = _update_args_async_db(args, kwargs, db)
+        # 外部传入且处于 async_atomic_session 托管事务内的会话：本层仅参与、不提交/回滚/关闭，
+        # 由 async_atomic_session 统一收尾，从而把多步写入收敛进单一事务。
+        _managed = (not _close_db) and bool(db.info.get("_atomic_managed"))
         try:
             # 执行函数
             result = await func(*args, **kwargs)
-            # 提交事务
-            await db.commit()
+            # 提交事务（托管事务下交由 async_atomic_session 统一提交）
+            if not _managed:
+                await db.commit()
         except Exception as err:
-            # 回滚事务
-            await db.rollback()
+            # 回滚事务（托管事务下交由 async_atomic_session 统一回滚）
+            if not _managed:
+                await db.rollback()
             raise err
         finally:
             # 关闭数据库会话

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -62,6 +62,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 插件智能体工具注册表缓存，插件启停或配置生效时主动失效。
         self._plugin_agent_tools_cache: Dict[str, List[Dict[str, Any]]] = {}
         self._plugin_agent_tools_cache_lock = threading.Lock()
+        # 保护 _plugins / _running_plugins 的可重入锁：热重载监控线程与请求线程会并发读写这两张表，
+        # 写入与遍历读取均须持锁，避免“dictionary changed size during iteration”及读到半更新态。
+        self._plugins_lock = threading.RLock()
         # 开发者模式监测插件修改
         if settings.DEV or settings.PLUGIN_AUTO_RELOAD:
             self.__start_monitor()
@@ -99,18 +102,22 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             try:
                 # 判断插件是否满足认证要求，如不满足则不进行实例化
                 if not self.__set_and_check_auth_level(plugin=plugin):
-                    # 如果是插件热更新实例，这里则进行替换
-                    if plugin_id in self._plugins:
-                        self._plugins[plugin_id] = plugin
+                    # 如果是插件热更新实例，这里则进行替换（check-then-act 须在锁内原子完成，
+                    # 否则与并发 stop() 存在 TOCTOU：检查与替换之间被摘除会复活已下线插件）
+                    with self._plugins_lock:
+                        if plugin_id in self._plugins:
+                            self._plugins = {**self._plugins, plugin_id: plugin}
                     continue
-                # 存储Class
-                self._plugins[plugin_id] = plugin
+                # 存储Class（整体替换式写入：并发读侧遍历的是替换前的完整字典，无需读侧加锁）
+                with self._plugins_lock:
+                    self._plugins = {**self._plugins, plugin_id: plugin}
                 # 生成实例
                 plugin_obj = plugin()
                 # 生效插件配置
                 plugin_obj.init_plugin(self.get_plugin_config(plugin_id))
-                # 存储运行实例
-                self._running_plugins[plugin_id] = plugin_obj
+                # 存储运行实例（整体替换式写入）
+                with self._plugins_lock:
+                    self._running_plugins = {**self._running_plugins, plugin_id: plugin_obj}
                 logger.info(f"加载插件：{plugin_id} 版本：{plugin_obj.plugin_version}")
                 # 启用的插件才设置事件注册状态可用
                 if plugin_obj.get_state():
@@ -179,7 +186,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 plugins = {pid: plugin_obj}
         else:
             logger.info("正在停止所有插件...")
-            plugins = self._running_plugins
+            # 锁内快照后遍历，避免与热重载并发写竞争
+            plugins = self._running_snapshot()
         for plugin_id, plugin in plugins.items():
             eventmanager.disable_event_handler(type(plugin))
             self.__stop_plugin(plugin)
@@ -191,15 +199,17 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         self._unregister_plugin_modules(stopped_ids)
         # 清空对象
         if pid:
-            # 清空指定插件
-            self._plugins.pop(pid, None)
-            self._running_plugins.pop(pid, None)
+            # 清空指定插件（整体替换式写入，读侧免锁遍历安全）
+            with self._plugins_lock:
+                self._plugins = {k: v for k, v in self._plugins.items() if k != pid}
+                self._running_plugins = {k: v for k, v in self._running_plugins.items() if k != pid}
             # 清除插件模块缓存，包括所有子模块
             self._clear_plugin_modules(pid)
         else:
             # 清空
-            self._plugins = {}
-            self._running_plugins = {}
+            with self._plugins_lock:
+                self._plugins = {}
+                self._running_plugins = {}
             # 清除所有插件模块缓存
             self._clear_plugin_modules()
         self.clear_plugin_agent_tools_cache()
@@ -278,11 +288,30 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
         return plugins
 
+    def _running_snapshot(self) -> Dict[str, Any]:
+        """
+        运行态插件字典的锁内浅拷贝快照，供需遍历的只读路径使用，避免与热重载并发写竞争。
+        :return: {plugin_id: 运行实例} 的浅拷贝
+        """
+        with self._plugins_lock:
+            return dict(self._running_plugins)
+
+    def _plugins_snapshot(self) -> Dict[str, Any]:
+        """
+        插件类字典的锁内浅拷贝快照，供需遍历的只读路径使用，避免与热重载并发写竞争。
+        :return: {plugin_id: 插件类} 的浅拷贝
+        """
+        with self._plugins_lock:
+            return dict(self._plugins)
+
     @property
     def running_plugins(self) -> Dict[str, Any]:
         """
         获取运行态插件列表
         :return: 运行态插件列表
+
+        注意：返回内部字典的实时引用（既有调用方依赖对其直接 .get()/.pop() 操作），
+        需遍历且要求线程安全的内部路径请改用 _running_snapshot()。
         """
         return self._running_plugins
 
@@ -291,6 +320,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         获取插件列表
         :return: 插件列表
+
+        注意：返回内部字典的实时引用（既有调用方依赖对其直接 .get()/.pop() 操作），
+        需遍历且要求线程安全的内部路径请改用 _plugins_snapshot()。
         """
         return self._plugins
 
@@ -580,6 +612,17 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         except Exception as e:
             logger.warn(f"停止插件 {plugin.get_name()} 时发生错误: {str(e)}")
 
+    def remove_plugin_class(self, plugin_id: str) -> None:
+        """
+        从插件类表中移除指定插件（整体替换式写入，锁内完成）。
+
+        供卸载分身等需在 stop() 之外单独摘除类引用的场景使用，替代对 plugins 属性的就地 .pop()，
+        与 start()/stop() 的整体替换写入保持一致，确保并发读侧遍历安全。
+        :param plugin_id: 插件ID
+        """
+        with self._plugins_lock:
+            self._plugins = {k: v for k, v in self._plugins.items() if k != plugin_id}
+
     def remove_plugin(self, plugin_id: str):
         """
         从内存中移除一个插件
@@ -595,15 +638,26 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
     def reload_plugin(self, plugin_id: str):
         """
-        将一个插件重新加载到内存
+        将一个插件重新加载到内存，并内聚地重建其调度服务、菜单命令与 API 路由。
+
+        热重载须先下线（stop 内含模块/事件处理器下线）、再上线（start 内含模块/事件处理器上线），
+        随后同步重建调度/命令/路由绑定——否则文件监控、插件分身等“直接调用 reload_plugin”的路径
+        会残留指向旧实例的过期定时任务/命令/路由（仅 API、agent 工具两条路径先前在外层补刷）。
+        register_plugin 为幂等（先摘后建/replace_existing），与外层可能的重复调用叠加亦安全。
         :param plugin_id: 插件ID
         """
-        # 先移除插件实例
+        # 先移除插件实例（含模块、事件处理器下线）
         self.stop(plugin_id)
-        # 重新加载
+        # 重新加载（含模块、事件处理器上线）
         self.start(plugin_id)
-        # 广播事件
-        eventmanager.send_event(EventType.PluginReload, data={"plugin_id": plugin_id})
+        # 同步重建调度服务/菜单命令/API 路由（惰性导入，避免 helper 顶层产生对 api/调度/命令层的依赖边）
+        try:
+            from app.api.endpoints.plugin import register_plugin
+            register_plugin(plugin_id)
+            # 绑定就绪后再广播事件，避免在同步绑定失败后仍发出"已重载"信号
+            eventmanager.send_event(EventType.PluginReload, data={"plugin_id": plugin_id})
+        except Exception as err:
+            logger.error(f"重载插件 {plugin_id} 同步调度/命令/API 绑定出错：{str(err)}")
 
     @staticmethod
     def _clear_plugin_modules(plugin_id: Optional[str] = None):
@@ -1142,7 +1196,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugins = []
         # 已安装插件
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
-        for pid, plugin_class in self._plugins.items():
+        # 锁内快照后遍历，避免与热重载并发写竞争
+        for pid, plugin_class in self._plugins_snapshot().items():
             # 运行状插件
             plugin_obj = self._running_plugins.get(pid)
             # 基本属性

--- a/tests/test_db_atomic_session.py
+++ b/tests/test_db_atomic_session.py
@@ -1,0 +1,76 @@
+"""atomic_session（P1 #46）：多步 @db_update 写入收敛进单一事务，统一提交或回滚。
+
+验证要点：
+- 提交路径：块内多次装饰写入在块结束一次性提交，全部可见；
+- 回滚路径：块内异常时整体回滚——因 atomic_session 给会话打 ``_atomic_managed`` 标记，
+  @db_update 不再各自提交，故此前已执行的写入同被回滚（证明托管标记生效）；
+- 兼容性：未处于 atomic_session 时，@db_update 仍按原语义各自提交（默认路径不变）。
+"""
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base, Engine, SessionFactory, atomic_session
+
+
+class _AtomicProbe(Base):
+    __tablename__ = "_atomic_probe_p1"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, default="")
+
+
+def _ensure_table() -> None:
+    _AtomicProbe.__table__.create(Engine, checkfirst=True)
+
+
+def _count() -> int:
+    with SessionFactory() as s:
+        return s.query(_AtomicProbe).count()
+
+
+def _purge(*ids: int) -> None:
+    with SessionFactory() as s:
+        for rid in ids:
+            obj = s.get(_AtomicProbe, rid)
+            if obj is not None:
+                s.delete(obj)
+        s.commit()
+
+
+def test_atomic_session_commits_multiple_writes_together():
+    """块内两次装饰写入在块结束统一提交，全部可见。"""
+    _ensure_table()
+    start = _count()
+    try:
+        with atomic_session() as db:
+            _AtomicProbe(id=99001, name="a").create(db)
+            _AtomicProbe(id=99002, name="b").create(db)
+        assert _count() == start + 2
+    finally:
+        _purge(99001, 99002)
+
+
+def test_atomic_session_rolls_back_all_on_exception():
+    """块内异常整体回滚；若装饰器在托管会话上仍逐次提交，则首条写入会幸存——断言其不幸存即证明标记生效。"""
+    _ensure_table()
+    start = _count()
+    try:
+        with atomic_session() as db:
+            _AtomicProbe(id=99003, name="x").create(db)
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    try:
+        assert _count() == start
+    finally:
+        _purge(99003)
+
+
+def test_db_update_outside_atomic_session_still_commits():
+    """默认路径不变：未传会话、未处于 atomic_session 时，@db_update 仍自建会话并提交。"""
+    _ensure_table()
+    start = _count()
+    try:
+        _AtomicProbe(id=99004, name="c").create()
+        assert _count() == start + 1
+    finally:
+        _purge(99004)


### PR DESCRIPTION
## 背景

落实 `docs/architecture-audit-v3python.md` §6 P1 路线图的剩余技术债项（#32+#24+#60 分发内核统一已由 #92 先期合入）。全程采用 worktree 隔离 + 多 agent workflow 侦察与对抗式复核。

## 改动（5 项）

| # | 问题 | 方案 |
|---|---|---|
| **#37** | 插件 `_plugins/_running_plugins` 跨线程无锁 | 新增 `_plugins_lock`(RLock)；`start/stop/`分身摘除改为锁内**原子整体替换**写入（读侧遍历替换前的完整字典，免锁安全）；外部就地 `.plugins.pop` 收口为 `remove_plugin_class()`；`start()` 认证失败替换的 check-then-act 收进锁内消除 TOCTOU |
| **#36** | 热重载只刷一半（残留过期绑定） | `reload_plugin` 内聚重建调度服务/菜单命令/API 路由（惰性导入 `register_plugin`），绑定就绪后再广播 `PluginReload`；去除 API 端点与 agent 工具 `reload_plugin_runtime` 的冗余外层补刷 |
| **#44** | DB 引擎 import 期副作用 | WAL/`journal_mode` 改 `@event.listens_for(connect)` 按连接设置（异步注册于 `sync_engine`）；删除 import 期 `engine.connect()`/`asyncio.run()` 副作用与 `print`；监听器内异常仅告警放行，避免 PRAGMA 失败致连接池拒绝全部连接 |
| **#46** | 装饰器逐调用新建会话非原子 | 新增 `atomic_session`/`async_atomic_session` 上下文 + 会话 `_atomic_managed` 标记，令 `@db_update/@async_db_update` 在托管会话内不各自提交，多步写入收敛单事务统一提交/回滚；既有 `db=` 复用路径（无标记）逐字节不变 |
| **#15** | 分发吞模块异常无法区分错误/空 | `recognize_media/async_recognize_media` 增可选 `raise_exception`，仅为真时才注入分发控制位透传（后端 `**kwargs` 吸收、`on_error` 据此重抛），默认路径不携带该 kwarg、行为不变 |

> #8（Scheduler 双锁）按审计校正为**误判**（刻意防死锁），未改动。

## 设计要点

- **#37 选用「原子整体替换」而非就地锁**：写者重绑新字典（锁内串行化），读者遍历的始终是完整、不被中途改动的字典，免去对约 20 处遍历读取点逐一加锁；`property` 仍返回实时引用以兼容既有 `.get()/.pop()` 调用方。
- **#15 默认零行为变更**：仅 `raise_exception=True` 时才向 `run_module` 注入 `{"raise_exception": True}`，默认调用与改动前对后端逐字节一致。

## 对抗式复核

多 agent 复核（按并发/DB事务/识别回归三维 + 逐项对抗验证）确认并已修：
- `start()` check-then-act **TOCTOU**（检查移入锁内）
- **WAL 监听器缺异常处理**（PRAGMA 失败仅告警放行，避免库整体不可用）
- reload 同步绑定失败后**仍发事件**（改为绑定成功后再广播）

一项「property rebind 语义」候选经对抗验证**驳回为非真问题**（无调用方跨变更持有引用）。

## 测试

- 新增 `tests/test_db_atomic_session.py`：atomic_session 提交/回滚/默认兼容（同步路径），异步路径经冒烟验证。
- 全量 **1898 passed**。剩余失败均为**预存在基线**、与本改动无关（`git stash` 后同样失败）：
  - telegram `f-string` 含反斜杠的收集错误（Python 3.11 vs 3.12 语义）；
  - `smb` 内建存储缺可选依赖。

## 测试计划

- [x] 全量回归（1898 passed，无新增失败）
- [x] 新增 atomic_session 回归测试
- [x] 多 agent 对抗式代码复核 + 修复
- [ ] reviewer 复核热重载在真实运行环境的绑定刷新（建议合并前在 dev 模式手验一次插件文件改动→定时任务/命令/路由指向新实例）
