### PR TITLE
fix(security): P0 信任边界统一 is_within + scheduler 协程 Future 收口

### DIFF
--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -13,6 +13,7 @@ import yaml
 
 from app.core.config import settings
 from app.log import logger
+from app.utils.system import SystemUtils
 
 CURRENT_PERSONA_FILE = "CURRENT_PERSONA.md"
 SYSTEM_RUNTIME_DIR = "runtime"
@@ -731,8 +732,16 @@ class AgentRuntimeManager:
 
     @staticmethod
     def _resolve_relative_path(root: Path, value: str) -> Path:
+        # extra_context_files 内容会被读出注入 LLM 上下文，必须限制在 root 目录内：
+        # 拒绝绝对路径与 ".." 逃逸，避免任意文件读取经模型泄露。
         candidate = Path(value)
-        return candidate if candidate.is_absolute() else (root / candidate).resolve()
+        if candidate.is_absolute():
+            raise AgentRuntimeConfigError(f"extra_context_files 不允许绝对路径：{value}")
+        root_resolved = root.resolve()
+        resolved = (root_resolved / candidate).resolve()
+        if not SystemUtils.is_within(root_resolved, resolved):
+            raise AgentRuntimeConfigError(f"extra_context_files 路径越界：{value}")
+        return resolved
 
     @staticmethod
     def _normalize_string_list(values: Any, field_name: str) -> list[str]:

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -43,6 +43,44 @@ PLUGIN_DIR = Path(settings.ROOT_PATH) / "app" / "plugins"
 PLUGIN_SYSTEM_VERSION_FIELD = "system_version"
 
 
+def plan_release_zip_extraction(namelist: List[str], dest_base: Path) -> Tuple[List[Tuple[str, str]], Optional[str]]:
+    """
+    校验 release 压缩包条目并规划解压路径，阻止 Zip Slip 目录穿越。
+
+    先剥离所有条目共有的顶层目录（如 pid/），再逐条用 SystemUtils.is_within 校验解析后
+    是否仍位于 dest_base 内；任一条目越界（含 ".." 逃逸或绝对路径）即整体拒绝，避免部分写入。
+
+    :param namelist: 压缩包内的条目名列表
+    :param dest_base: 解压目标根目录
+    :return: (规划列表[(原条目名, 相对路径)], 错误信息)；错误信息非 None 时应整体放弃解压
+    """
+    if not namelist:
+        return [], "压缩包内容为空"
+    # 若所有条目均在同一顶层目录下（如 pid/），则剥离这一层，避免出现双层目录
+    names_with_slash = [n for n in namelist if '/' in n]
+    base_prefix = ''
+    if names_with_slash and len(names_with_slash) == len(namelist):
+        first_seg = names_with_slash[0].split('/')[0]
+        if all(n.startswith(first_seg + '/') for n in namelist):
+            base_prefix = first_seg + '/'
+    dest_base_resolved = Path(dest_base).resolve()
+    planned: List[Tuple[str, str]] = []
+    has_file = False
+    for name in namelist:
+        rel_path = name[len(base_prefix):]
+        if not rel_path:
+            continue
+        target = dest_base_resolved / rel_path.rstrip('/')
+        if not SystemUtils.is_within(dest_base_resolved, target):
+            return [], f"检测到非法压缩包路径（目录穿越）：{name}"
+        planned.append((name, rel_path))
+        if not rel_path.endswith('/'):
+            has_file = True
+    if not has_file:
+        return [], "压缩包中无可写入文件"
+    return planned, None
+
+
 class PluginHelper(metaclass=WeakSingleton):
     """
     插件市场管理，下载安装插件到本地
@@ -1709,23 +1747,11 @@ class PluginHelper(metaclass=WeakSingleton):
 
         try:
             with zipfile.ZipFile(io.BytesIO(res.content)) as zf:
-                namelist = zf.namelist()
-                if not namelist:
-                    return False, "压缩包内容为空"
-                # 若所有条目均在同一顶层目录下（如 pid/），则剥离这一层，避免出现双层目录
-                names_with_slash = [n for n in namelist if '/' in n]
-                base_prefix = ''
-                if names_with_slash and len(names_with_slash) == len(namelist):
-                    first_seg = names_with_slash[0].split('/')[0]
-                    if all(n.startswith(first_seg + '/') for n in namelist):
-                        base_prefix = first_seg + '/'
-
                 dest_base = Path(settings.ROOT_PATH) / "app" / "plugins" / pid.lower()
-                wrote_any = False
-                for name in namelist:
-                    rel_path = name[len(base_prefix):]
-                    if not rel_path:
-                        continue
+                planned, err = plan_release_zip_extraction(zf.namelist(), dest_base)
+                if err:
+                    return False, err
+                for name, rel_path in planned:
                     if rel_path.endswith('/'):
                         (dest_base / rel_path.rstrip('/')).mkdir(parents=True, exist_ok=True)
                         continue
@@ -1733,9 +1759,6 @@ class PluginHelper(metaclass=WeakSingleton):
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
                     with zf.open(name, 'r') as src, open(dest_path, 'wb') as dst:
                         dst.write(src.read())
-                    wrote_any = True
-                if not wrote_any:
-                    return False, "压缩包中无可写入文件"
             return True, ""
         except Exception as e:
             logger.error(f"解压 Release 压缩包失败：{e}")
@@ -2726,22 +2749,13 @@ class PluginHelper(metaclass=WeakSingleton):
 
         try:
             with zipfile.ZipFile(io.BytesIO(res.content)) as zf:
-                namelist = zf.namelist()
-                if not namelist:
-                    return False, "压缩包内容为空"
-                names_with_slash = [n for n in namelist if '/' in n]
-                base_prefix = ''
-                if names_with_slash and len(names_with_slash) == len(namelist):
-                    first_seg = names_with_slash[0].split('/')[0]
-                    if all(n.startswith(first_seg + '/') for n in namelist):
-                        base_prefix = first_seg + '/'
-
                 dest_base = AsyncPath(settings.ROOT_PATH) / "app" / "plugins" / pid.lower()
-                wrote_any = False
-                for name in namelist:
-                    rel_path = name[len(base_prefix):]
-                    if not rel_path:
-                        continue
+                planned, err = plan_release_zip_extraction(
+                    zf.namelist(), Path(settings.ROOT_PATH) / "app" / "plugins" / pid.lower()
+                )
+                if err:
+                    return False, err
+                for name, rel_path in planned:
                     if rel_path.endswith('/'):
                         await (dest_base / rel_path.rstrip('/')).mkdir(parents=True, exist_ok=True)
                         continue
@@ -2751,9 +2765,6 @@ class PluginHelper(metaclass=WeakSingleton):
                         data = src.read()
                     async with aiofiles.open(dest_path, 'wb') as dst:
                         await dst.write(data)
-                    wrote_any = True
-                if not wrote_any:
-                    return False, "压缩包中无可写入文件"
             return True, ""
         except Exception as e:
             logger.error(f"解压 Release 压缩包失败：{e}")

--- a/app/helper/plugin_manager.py
+++ b/app/helper/plugin_manager.py
@@ -1645,6 +1645,11 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             if not plugin_id or not suffix:
                 return False, "插件ID和分身后缀不能为空"
 
+            # 分身后缀白名单：后缀会拼进目录名与生成代码的类名，必须限定为 ASCII 字母数字，
+            # 否则可造成目录穿越（../）或注入 __init__.py 生成代码。
+            if not (1 <= len(suffix) <= 20 and suffix.isascii() and suffix.isalnum()):
+                return False, "分身后缀仅允许 1-20 位字母或数字"
+
             # 检查原插件是否存在
             if plugin_id not in self._plugins:
                 return False, f"原插件 {plugin_id} 不存在"
@@ -1663,6 +1668,11 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
             # 创建分身插件目录
             clone_plugin_dir = Path(settings.ROOT_PATH) / "app" / "plugins" / clone_id.lower()
+
+            # 目录穿越守卫（防御纵深）：分身目录必须落在 plugins 根目录内
+            plugins_root = Path(settings.ROOT_PATH) / "app" / "plugins"
+            if not SystemUtils.is_within(plugins_root, clone_plugin_dir):
+                return False, "分身插件目录非法（越界）"
 
             # 复制插件目录
             import shutil

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -720,8 +720,9 @@ class Scheduler(ConfigReloadMixin, metaclass=SingletonClass):
             # 是否多进程运行
             run_in_process = job.get("run_in_process", False)
             if inspect.iscoroutinefunction(func):
-                # 协程函数
-                __start_coro(func(*args, **kwargs))
+                # 协程函数：阻塞等待其在主事件循环中执行完成，使协程异常能被下方 except 捕获，
+                # 并保证 __finish_job 在协程真正结束后才复位 running 标志（修复异常黑洞与重入并发）。
+                __start_coro(func(*args, **kwargs)).result()
             elif run_in_process:
                 # 多进程运行
                 p = multiprocessing.Process(target=func, args=args, kwargs=kwargs)

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -263,6 +263,23 @@ class SystemUtils:
         return files
 
     @staticmethod
+    def is_within(base: Union[str, Path], target: Union[str, Path]) -> bool:
+        """
+        判断 target 解析后是否位于 base 目录内（含 base 自身），用于防目录穿越（Zip Slip / 路径逃逸）。
+        会 resolve 两端并跟随符号链接，按路径分段比较，避免 "/x/foo" 误判在 "/x/foobar" 内的前缀陷阱。
+
+        :param base: 基准目录
+        :param target: 待校验路径
+        :return: target 在 base 内返回 True，越界或解析失败返回 False
+        """
+        try:
+            base_resolved = Path(base).resolve()
+            target_resolved = Path(target).resolve()
+        except (OSError, RuntimeError, ValueError):
+            return False
+        return target_resolved == base_resolved or base_resolved in target_resolved.parents
+
+    @staticmethod
     def unpack_archive(archive_file: Path, extract_dir: Path, archive_format: Optional[str] = None) -> None:
         """
         解压压缩包，并补充标准库未覆盖的 RAR 格式支持。

--- a/tests/test_path_trust_boundary.py
+++ b/tests/test_path_trust_boundary.py
@@ -1,0 +1,121 @@
+"""P0 信任边界（PR-A）单测：is_within 目录守卫、release 解压 Zip Slip 防护、
+Agent extra_context_files 路径穿越防护。"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.utils.system import SystemUtils
+from app.helper.plugin import plan_release_zip_extraction
+from app.agent.runtime import AgentRuntimeManager, AgentRuntimeConfigError
+
+
+class TestIsWithin:
+    """SystemUtils.is_within 目录包含判定。"""
+
+    def test_child_path_is_within(self):
+        with tempfile.TemporaryDirectory() as d:
+            base = Path(d)
+            assert SystemUtils.is_within(base, base / "a" / "b.txt") is True
+
+    def test_base_itself_is_within(self):
+        with tempfile.TemporaryDirectory() as d:
+            base = Path(d)
+            assert SystemUtils.is_within(base, base) is True
+
+    def test_parent_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            base = Path(d) / "sub"
+            base.mkdir()
+            assert SystemUtils.is_within(base, base / ".." / ".." / "etc" / "passwd") is False
+
+    def test_absolute_outside_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            assert SystemUtils.is_within(Path(d), Path("/etc/passwd")) is False
+
+    def test_sibling_prefix_not_confused(self):
+        # /x/foobar 与 /x/foobar_evil 前缀相似，但后者不在前者内（按路径分段判定）
+        with tempfile.TemporaryDirectory() as d:
+            base = Path(d) / "foobar"
+            base.mkdir()
+            sibling = Path(d) / "foobar_evil"
+            sibling.mkdir()
+            assert SystemUtils.is_within(base, sibling / "x") is False
+
+
+class TestPlanReleaseZipExtraction:
+    """plugin.plan_release_zip_extraction 的路径规划与 Zip Slip 防护。"""
+
+    def test_normal_zip_strips_common_prefix(self):
+        names = ["MyPlugin/__init__.py", "MyPlugin/sub/x.py"]
+        planned, err = plan_release_zip_extraction(names, Path("/opt/app/plugins/myplugin"))
+        assert err is None
+        rels = sorted(rel for _, rel in planned)
+        assert rels == ["__init__.py", "sub/x.py"]
+
+    def test_zip_slip_traversal_is_rejected(self):
+        names = ["MyPlugin/__init__.py", "MyPlugin/../../../../etc/evil.py"]
+        planned, err = plan_release_zip_extraction(names, Path("/opt/app/plugins/myplugin"))
+        assert err is not None
+        assert planned == []
+
+    def test_absolute_entry_mixed_is_rejected(self):
+        # 绝对路径条目与普通条目混合时公共前缀不被剥离，绝对路径逃逸应被拦截
+        names = ["MyPlugin/__init__.py", "/etc/evil.py"]
+        planned, err = plan_release_zip_extraction(names, Path("/opt/app/plugins/myplugin"))
+        assert err is not None
+        assert planned == []
+
+    def test_empty_namelist_is_rejected(self):
+        planned, err = plan_release_zip_extraction([], Path("/opt/app/plugins/x"))
+        assert err is not None
+        assert planned == []
+
+
+class TestRuntimeResolveRelativePath:
+    """AgentRuntimeManager._resolve_relative_path 对 extra_context_files 的越界拦截。"""
+
+    def test_relative_within_root_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            resolved = AgentRuntimeManager._resolve_relative_path(root, "ctx/notes.md")
+            assert SystemUtils.is_within(root, resolved)
+
+    def test_parent_traversal_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d) / "runtime"
+            root.mkdir()
+            with pytest.raises(AgentRuntimeConfigError):
+                AgentRuntimeManager._resolve_relative_path(root, "../../etc/passwd")
+
+    def test_absolute_path_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            with pytest.raises(AgentRuntimeConfigError):
+                AgentRuntimeManager._resolve_relative_path(Path(d), "/etc/passwd")
+
+
+class TestCloneSuffixWhitelist:
+    """PluginManager.clone_plugin 分身后缀白名单（防目录穿越 / 生成代码注入）。"""
+
+    @staticmethod
+    def _pm():
+        from app.helper.plugin_manager import PluginManager
+        # 绕过单例初始化，仅测试早退的参数校验分支（不触及 self._plugins）
+        return PluginManager.__new__(PluginManager)
+
+    def test_traversal_suffix_rejected(self):
+        ok, msg = self._pm().clone_plugin("Demo", "../evil", "n", "d")
+        assert ok is False
+        assert "后缀" in msg
+
+    def test_hyphen_suffix_rejected(self):
+        ok, _ = self._pm().clone_plugin("Demo", "a-b", "n", "d")
+        assert ok is False
+
+    def test_injection_suffix_rejected(self):
+        ok, _ = self._pm().clone_plugin("Demo", 'x"\n', "n", "d")
+        assert ok is False
+
+    def test_slash_suffix_rejected(self):
+        ok, _ = self._pm().clone_plugin("Demo", "a/b", "n", "d")
+        assert ok is False

--- a/tests/test_scheduler_coro_finish.py
+++ b/tests/test_scheduler_coro_finish.py
@@ -1,0 +1,73 @@
+"""P0 PR-B 单测：scheduler 协程定时任务的 Future 收口。
+
+修复前 __start_coro 提交协程后立即返回、__finish_job 随即复位 running 标志：
+① 协程异常在事件循环里丢失（异常黑洞）；② running 提前复位导致重入并发。
+修复后 start() 阻塞至协程真正完成，异常经 .result() 重新抛出被 except 捕获。
+"""
+import asyncio
+import threading
+
+import pytest
+from unittest.mock import patch
+
+from app.core.config import global_vars
+from app.scheduler import Scheduler
+
+
+def _bare_scheduler() -> Scheduler:
+    """构造不触发重初始化的裸 Scheduler 实例（绕过 SingletonClass.__call__）。"""
+    s = Scheduler.__new__(Scheduler)
+    s._jobs = {}
+    s._lock = threading.RLock()
+    return s
+
+
+@pytest.fixture
+def bg_loop():
+    """在后台线程起一个事件循环并注入 global_vars，模拟主循环。"""
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=loop.run_forever, daemon=True)
+    t.start()
+    prev = global_vars.CURRENT_EVENT_LOOP
+    global_vars.set_loop(loop)
+    try:
+        yield loop
+    finally:
+        global_vars.set_loop(prev)
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=2)
+        loop.close()
+
+
+class TestSchedulerCoroutineFinish:
+
+    def test_start_blocks_until_coroutine_completes(self, bg_loop):
+        s = _bare_scheduler()
+        done = threading.Event()
+
+        async def slow_job():
+            await asyncio.sleep(0.15)
+            done.set()
+
+        s._jobs["job_ok"] = {"func": slow_job, "name": "job_ok"}
+        s.start("job_ok")
+        # 修复后 start 应阻塞到协程真正结束（异常黑洞/重入根因）
+        assert done.is_set()
+        assert s._jobs["job_ok"]["running"] is False
+
+    def test_coroutine_exception_is_reported(self, bg_loop):
+        s = _bare_scheduler()
+
+        async def failing_job():
+            await asyncio.sleep(0.02)
+            raise RuntimeError("boom")
+
+        s._jobs["job_err"] = {"func": failing_job, "name": "job_err"}
+        with patch("app.scheduler.logger") as mock_logger, \
+             patch("app.scheduler.eventmanager") as mock_evt, \
+             patch("app.scheduler.MessageHelper"):
+            s.start("job_err")
+        # 修复后协程异常经 .result() 重新抛出 → 被 except 捕获 → 记录并发事件
+        assert mock_logger.error.called
+        assert mock_evt.send_event.called
+        assert s._jobs["job_err"]["running"] is False


### PR DESCRIPTION
## 背景

落地 `docs/rust-rewrite-readiness-v3python.md` §五 轨道 A 的 **P0**（源自 2026-06-29 对抗审计母报告）：安全/可观测黑洞收口。无 CRITICAL、无活跃 HIGH，但这些是直接可达的信任边界与并发正确性问题。

## PR-A · 路径信任边界统一 `is_within`

- **新增 `SystemUtils.is_within(base, target)`**（`app/utils/system.py`）：resolve 两端 + 按 `parents` 分段判定，规避 `/x/foo` 误判在 `/x/foobar` 内的前缀陷阱。作为全仓统一目录守卫。
- **Zip Slip（最高危，RCE）**：抽出模块级 `plan_release_zip_extraction()` 统一校验+规划，**同步 `__install_from_release` 与异步 `__async_install_from_release` 双路径**改为委托它。恶意 release zip 的 `../` 条目（可覆写 `app/main.py` → RCE）被整体拒绝。planner 以 `has_file` 保留"纯目录 zip 报无可写文件"的原语义。
- **Agent 路径穿越（任意文件读 → LLM 泄露）**：`runtime._resolve_relative_path` 拒绝绝对路径与 `..` 逃逸，`extra_context_files` 限制在 root 目录内。
- **插件 clone 注入/穿越（超管可达）**：`plugin_manager.clone_plugin` 的 `suffix` 加白名单（ASCII 字母数字、≤20 位）+ clone 目录 `is_within` 守卫，堵目录穿越与生成 `__init__.py` 的代码注入。

## PR-B · scheduler 协程错误收口

`scheduler.start()` 协程分支改为 `__start_coro(...).result()`，阻塞至协程在主循环真正执行完成：
- 协程异常经现有 `except` 上报（修**异常黑洞**）；
- `__finish_job` 在协程结束后才复位 `running` 标志（修**重入并发**）。

`self.start` 挂在 APScheduler `ThreadPoolExecutor`（worker 线程），协程跑在主循环 `global_vars.loop`，`.result()` 阻塞 worker 线程、无死锁（已取证）。

## 有据推迟（→ PR-J，P2 反序列化加固）

- **FileBackend key→路径守卫**：取证全部 cache key 均硬编码/md5 派生、`cached` 非 hash key 不落文件后端 → **当前不可达**，属潜伏加固。
- **pickle → HMAC/JSON**：**非单点收口**（redis 单点只能盖 Redis 路径，chain/qqbot/wechat 文件后端各自 pickle 绕过），可达性依赖不可信 Redis / 本地 FS 写 → needs-scoping。

## 测试

- 新增 `tests/test_path_trust_boundary.py`（is_within / Zip Slip / runtime 穿越 / clone 白名单）、`tests/test_scheduler_coro_finish.py`（协程阻塞完成 + 异常上报）。
- 全量 **1928 passed**（= 基线 1910 + 新增 18）/ 1 skipped，**零回归**。1 failed（`test_filemanager_external_storage` 缺 smb）+ 4 收集期 ERROR（telegram f-string / 缺可选依赖）均为 pre-existing 基线，与本改动无关。

## Test plan

- [x] 新增单测全绿
- [x] 全量回归无新增失败
- [ ] review
