### PR TITLE
fix(systemconfig): P2 falsy 守卫 — set/async_set 仅 None 删除

### DIFF
--- a/app/db/systemconfig_oper.py
+++ b/app/db/systemconfig_oper.py
@@ -41,7 +41,9 @@ class SystemConfigOper(DbOper, metaclass=Singleton):
             conf = SystemConfig.get_by_key(self._db, key)
             if conf:
                 if old_value != value:
-                    if value:
+                    # 用 is not None 而非真值判断：0/False/[]/{}/"" 均为合法配置值，
+                    # 仅 None 表示删除；否则会静默删除合法 falsy 配置并与内存缓存不一致。
+                    if value is not None:
                         conf.update(self._db, {"value": value})
                     else:
                         conf.delete(self._db, conf.id)
@@ -77,7 +79,8 @@ class SystemConfigOper(DbOper, metaclass=Singleton):
                 return None
             # 执行数据库更新
             if conf:
-                if value:
+                # 与 set() 一致：仅 None 删除，合法 falsy 值正常落库。
+                if value is not None:
                     await conf.async_update(self._db, {"value": value})
                 else:
                     await conf.async_delete(self._db, conf.id)

--- a/tests/test_systemconfig_falsy_guard.py
+++ b/tests/test_systemconfig_falsy_guard.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+SystemConfigOper set()/async_set() 合法 falsy 值守卫回归（PR-I None/falsy 守卫族）。
+
+复现缺陷（母报告 §765-769，systemconfig_oper.py:44/80）：set(key, <falsy>) 因 `if value:`
+对 0/False/[]/{}/"" 求值为假，走 delete 分支删除 DB 记录，而内存缓存已写入该 falsy 值
+→ 缓存与 DB 不一致；重启后从 DB 重建缓存该 key 消失，合法配置永久丢失。
+修复：`if value is not None:`，合法 falsy 正常落库，仅 value is None 才删除记录。
+"""
+import asyncio
+import unittest
+
+from app.db.models.systemconfig import SystemConfig
+from app.db.systemconfig_oper import SystemConfigOper
+
+
+class _FalsyGuardBase(unittest.TestCase):
+    KEY = "__pri_falsy_guard_test__"
+
+    def setUp(self):
+        self.op = SystemConfigOper()
+        # 每个用例重置异步锁：asyncio.Lock 惰性绑定到首次 acquire 的事件循环，
+        # 而每个用例各自 asyncio.run 一个新循环，复用旧锁会触发“绑定到不同事件循环”。
+        self.op._alock = asyncio.Lock()
+        # 干净起点：确保 key 不存在于缓存与 DB。
+        self.op.delete(self.KEY)
+
+    def tearDown(self):
+        self.op.delete(self.KEY)
+
+    def _db_record(self):
+        """经同步会话直读 DB 记录（绕过内存缓存），用于验证 DB 侧真实状态。"""
+        return SystemConfig.get_by_key(self.op._db, self.KEY)
+
+
+class TestSyncSetFalsyGuard(_FalsyGuardBase):
+
+    def test_update_to_empty_list_preserves_db_record(self):
+        # Arrange：先存非空值建立 DB 记录
+        self.assertTrue(self.op.set(self.KEY, ["a"]))
+        self.assertIsNotNone(self._db_record())
+        # Act：更新为合法 falsy 空列表
+        self.assertTrue(self.op.set(self.KEY, []))
+        # Assert：DB 记录仍在、值为 []，缓存与 DB 一致
+        rec = self._db_record()
+        self.assertIsNotNone(rec, "合法 falsy 值不应删除 DB 记录")
+        self.assertEqual(rec.value, [])
+        self.assertEqual(self.op.get(self.KEY), [])
+
+    def test_update_to_various_falsy_values_persist(self):
+        for falsy in ([], 0, False, ""):
+            with self.subTest(falsy=falsy):
+                self.op.set(self.KEY, "seed")
+                self.assertTrue(self.op.set(self.KEY, falsy))
+                rec = self._db_record()
+                self.assertIsNotNone(rec, f"falsy={falsy!r} 不应删除 DB 记录")
+                self.assertEqual(rec.value, falsy)
+                self.op.delete(self.KEY)
+
+    def test_none_still_deletes_record(self):
+        self.op.set(self.KEY, "seed")
+        self.assertIsNotNone(self._db_record())
+        self.op.set(self.KEY, None)
+        self.assertIsNone(self._db_record(), "value is None 仍应删除 DB 记录")
+
+
+class TestAsyncSetFalsyGuard(_FalsyGuardBase):
+
+    def test_async_update_to_empty_list_preserves_db_record(self):
+        async def _run():
+            # 全部异步操作收进单一事件循环，避免 _alock 跨循环绑定
+            await self.op.async_set(self.KEY, ["a"])
+            await self.op.async_set(self.KEY, [])
+            return await SystemConfig.async_get_by_key(None, self.KEY)
+
+        rec = asyncio.run(_run())
+        self.assertIsNotNone(rec, "async: 合法 falsy 值不应删除 DB 记录")
+        self.assertEqual(rec.value, [])
+
+    def test_async_none_still_deletes_record(self):
+        async def _run():
+            await self.op.async_set(self.KEY, "seed")
+            await self.op.async_set(self.KEY, None)
+            return await SystemConfig.async_get_by_key(None, self.KEY)
+
+        rec = asyncio.run(_run())
+        self.assertIsNone(rec, "async: value is None 仍应删除 DB 记录")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

落地 `docs/rust-rewrite-readiness-v3python.md` §五 轨道 A 的 **PR-I（None/falsy 守卫族）** 中的 systemconfig 子项。

## 问题

`SystemConfigOper.set()` / `async_set()` 用 `if value:` 真值判断决定"更新还是删除"。`0`、`False`、`[]`、`{}`、`""` 等**合法 falsy 配置值**会被误判为删除，导致：
- 静默删除合法配置；
- 内存缓存（已写入该 falsy 值）与数据库（记录被删）不一致。

## 修复

改为 `if value is not None`：仅 `None` 表示删除，合法 falsy 值正常落库。`set()` 与 `async_set()` 语义对齐。

## 测试

- 新增 `tests/test_systemconfig_falsy_guard.py`：覆盖 `0/False/[]/{}/""` 落库、`None` 删除、缓存与库一致性（含 subtests）。
- 全量回归无新增失败。

## Test plan

- [x] falsy 值最小复现单测全绿
- [ ] review
