### PR TITLE
fix(chain): P1 PR-E post_message 消息隔离隐私泄漏（含对抗审查加固）

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1283,9 +1283,10 @@ class _NotificationChainMixin:
                         # 未知动作 / user 无用户上下文 / admin 已发过：fail-closed 跳过，绝不广播到全渠道
                         logger.info(f"{send_message.mtype} 的消息动作 '{action}' 无适用目标，跳过发送")
                         continue
-                    # 目标隔离动作但目标不存在（管理员/用户行缺失）→ 跳过，绝不按无目标广播到全部公开渠道
-                    if send_message.targets is None:
-                        logger.info(f"{send_message.mtype} 的通知目标不存在，跳过发送以避免广播到全部公开渠道")
+                    # 目标隔离动作但目标为空（管理员/用户行缺失 None，或存在但无任何渠道绑定 {}）→ 跳过，
+                    # 绝不按无目标广播到全部公开渠道（集中 fail-closed，兜住下游渠道对空目标处理不一致的风险）
+                    if not send_message.targets:
+                        logger.info(f"{send_message.mtype} 的通知目标为空，跳过发送以避免广播到全部公开渠道")
                         continue
                     # 按设定发送
                     self.eventmanager.send_event(
@@ -1408,9 +1409,10 @@ class _NotificationChainMixin:
                         # 未知动作 / user 无用户上下文 / admin 已发过：fail-closed 跳过，绝不广播到全渠道
                         logger.info(f"{send_message.mtype} 的消息动作 '{action}' 无适用目标，跳过发送")
                         continue
-                    # 目标隔离动作但目标不存在（管理员/用户行缺失）→ 跳过，绝不按无目标广播到全部公开渠道
-                    if send_message.targets is None:
-                        logger.info(f"{send_message.mtype} 的通知目标不存在，跳过发送以避免广播到全部公开渠道")
+                    # 目标隔离动作但目标为空（管理员/用户行缺失 None，或存在但无任何渠道绑定 {}）→ 跳过，
+                    # 绝不按无目标广播到全部公开渠道（集中 fail-closed，兜住下游渠道对空目标处理不一致的风险）
+                    if not send_message.targets:
+                        logger.info(f"{send_message.mtype} 的通知目标为空，跳过发送以避免广播到全部公开渠道")
                         continue
                     # 按设定发送
                     await self.eventmanager.async_send_event(

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1230,7 +1230,8 @@ class _NotificationChainMixin:
             )
             if notify_action:
                 # 'admin' 'user,admin' 'user' 'all'
-                actions = notify_action.split(",")
+                # 规范化动作 token：去空白、转小写、丢弃空项，避免 "user, admin"/大小写等变体绕过隔离
+                actions = [a.strip().lower() for a in notify_action.split(",") if a.strip()]
                 # 是否已发送管理员标志
                 admin_sended = False
                 send_orignal = False
@@ -1273,16 +1274,19 @@ class _NotificationChainMixin:
                         elif send_message.username == settings.SUPERUSER:
                             # 管理员同名已发送
                             admin_sended = True
-                    else:
-                        if action == "user":
-                            # 系统级通知无用户上下文（username 为空），跳过 user 动作，
-                            # 交由后续 admin 等动作处理，避免仅管理员可见的通知被广播到全部公开渠道
-                            logger.info(f"{send_message.mtype} 的消息无用户上下文，跳过 user 发送")
-                            continue
-                        # 显式的全量/未知动作：按原消息发送全体
+                    elif action == "all":
+                        # 显式全量：按原消息发送全体
                         if not admin_sended:
                             send_orignal = True
                         break
+                    else:
+                        # 未知动作 / user 无用户上下文 / admin 已发过：fail-closed 跳过，绝不广播到全渠道
+                        logger.info(f"{send_message.mtype} 的消息动作 '{action}' 无适用目标，跳过发送")
+                        continue
+                    # 目标隔离动作但目标不存在（管理员/用户行缺失）→ 跳过，绝不按无目标广播到全部公开渠道
+                    if send_message.targets is None:
+                        logger.info(f"{send_message.mtype} 的通知目标不存在，跳过发送以避免广播到全部公开渠道")
+                        continue
                     # 按设定发送
                     self.eventmanager.send_event(
                         etype=EventType.NoticeMessage,
@@ -1351,7 +1355,8 @@ class _NotificationChainMixin:
             )
             if notify_action:
                 # 'admin' 'user,admin' 'user' 'all'
-                actions = notify_action.split(",")
+                # 规范化动作 token：去空白、转小写、丢弃空项，避免 "user, admin"/大小写等变体绕过隔离
+                actions = [a.strip().lower() for a in notify_action.split(",") if a.strip()]
                 # 是否已发送管理员标志
                 admin_sended = False
                 send_orignal = False
@@ -1394,16 +1399,19 @@ class _NotificationChainMixin:
                         elif send_message.username == settings.SUPERUSER:
                             # 管理员同名已发送
                             admin_sended = True
-                    else:
-                        if action == "user":
-                            # 系统级通知无用户上下文（username 为空），跳过 user 动作，
-                            # 交由后续 admin 等动作处理，避免仅管理员可见的通知被广播到全部公开渠道
-                            logger.info(f"{send_message.mtype} 的消息无用户上下文，跳过 user 发送")
-                            continue
-                        # 显式的全量/未知动作：按原消息发送全体
+                    elif action == "all":
+                        # 显式全量：按原消息发送全体
                         if not admin_sended:
                             send_orignal = True
                         break
+                    else:
+                        # 未知动作 / user 无用户上下文 / admin 已发过：fail-closed 跳过，绝不广播到全渠道
+                        logger.info(f"{send_message.mtype} 的消息动作 '{action}' 无适用目标，跳过发送")
+                        continue
+                    # 目标隔离动作但目标不存在（管理员/用户行缺失）→ 跳过，绝不按无目标广播到全部公开渠道
+                    if send_message.targets is None:
+                        logger.info(f"{send_message.mtype} 的通知目标不存在，跳过发送以避免广播到全部公开渠道")
+                        continue
                     # 按设定发送
                     await self.eventmanager.async_send_event(
                         etype=EventType.NoticeMessage,

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -1274,7 +1274,12 @@ class _NotificationChainMixin:
                             # 管理员同名已发送
                             admin_sended = True
                     else:
-                        # 按原消息发送全体
+                        if action == "user":
+                            # 系统级通知无用户上下文（username 为空），跳过 user 动作，
+                            # 交由后续 admin 等动作处理，避免仅管理员可见的通知被广播到全部公开渠道
+                            logger.info(f"{send_message.mtype} 的消息无用户上下文，跳过 user 发送")
+                            continue
+                        # 显式的全量/未知动作：按原消息发送全体
                         if not admin_sended:
                             send_orignal = True
                         break
@@ -1390,7 +1395,12 @@ class _NotificationChainMixin:
                             # 管理员同名已发送
                             admin_sended = True
                     else:
-                        # 按原消息发送全体
+                        if action == "user":
+                            # 系统级通知无用户上下文（username 为空），跳过 user 动作，
+                            # 交由后续 admin 等动作处理，避免仅管理员可见的通知被广播到全部公开渠道
+                            logger.info(f"{send_message.mtype} 的消息无用户上下文，跳过 user 发送")
+                            continue
+                        # 显式的全量/未知动作：按原消息发送全体
                         if not admin_sended:
                             send_orignal = True
                         break

--- a/app/modules/feishu/__init__.py
+++ b/app/modules/feishu/__init__.py
@@ -90,6 +90,11 @@ class FeishuModule(_ModuleBase, _MessageBase[Feishu]):
             if not self.check_message(message, conf.name):
                 continue
             userid, chat_id, receive_id_type = self._resolve_message_target(message)
+            # 隔离消息（无 userid 但带 targets）解析不出飞书目标时 fail-closed，
+            # 避免 _resolve_target 回退默认群/默认 open_id 广播（targets 为 None 的全局消息不受影响）
+            if message.targets is not None and not userid and not chat_id:
+                logger.warn("用户没有指定 飞书用户ID，消息无法发送")
+                continue
             client: Feishu = self.get_instance(conf.name)
             if client:
                 if message.image and message.file_path:

--- a/app/modules/qqbot/__init__.py
+++ b/app/modules/qqbot/__init__.py
@@ -358,13 +358,18 @@ class QQBotModule(_ModuleBase, _MessageBase[QQBot]):
                 continue
             targets = message.targets
             userid = message.userid
-            if not userid and targets:
+            if not userid and targets is not None:
                 userid = targets.get("qq_userid") or targets.get("qq_openid")
                 if not userid:
                     userid = targets.get("qq_group_openid") or targets.get("qq_group")
                     if userid:
                         userid = f"group:{userid}"
-            # 无 userid 且无默认配置时，由 client 向曾发过消息的用户/群广播
+                if not userid:
+                    # 隔离消息（无 userid 但带 targets）解析不出 QQ 目标 → fail-closed，
+                    # 避免回退默认群 / 广播给全部历史交互对象
+                    logger.warn("用户没有指定 QQ用户ID，消息无法发送")
+                    return
+            # targets 为 None 的全局消息：仍由 client 按默认配置向曾发过消息的用户/群广播
             client: QQBot = self.get_instance(conf.name)
             if client:
                 client.send_msg(

--- a/app/modules/vocechat/__init__.py
+++ b/app/modules/vocechat/__init__.py
@@ -348,8 +348,13 @@ class VoceChatModule(_ModuleBase, _MessageBase[VoceChat]):
                 continue
             targets = message.targets
             userid = message.userid
-            if not message.userid and targets:
+            if not userid and targets is not None:
+                # 隔离消息（无 userid 但带 targets）：解析不出本渠道 userid 时 fail-closed，
+                # 绝不用 userid=None 调 send_msg（否则会广播到整个 VoceChat 群）
                 userid = targets.get('vocechat_userid')
+                if not userid:
+                    logger.warn("用户没有指定 VoceChat 用户ID，消息无法发送")
+                    return
             client: VoceChat = self.get_instance(conf.name)
             if client:
                 client.send_msg(title=message.title, text=message.text,

--- a/app/modules/webpush/__init__.py
+++ b/app/modules/webpush/__init__.py
@@ -66,6 +66,11 @@ class WebPushModule(_ModuleBase, _MessageBase):
         for conf in self.get_configs().values():
             if not self.check_message(message, conf.name):
                 continue
+            # 隔离消息（admin/user：无 userid 但带 targets）：WebPush 订阅不含用户身份、无法定向，
+            # 只能全量广播 → fail-closed 跳过，避免仅管理员/特定用户可见的通知推送给全部订阅者
+            if not message.userid and message.targets is not None:
+                logger.debug("WebPush 无法定向隔离通知（订阅无用户身份），跳过发送")
+                continue
             webpush_users = conf.config.get("WEBPUSH_USERNAME") or ""
             if webpush_users:
                 # 设定了接收用户时，非该用户的消息不接收

--- a/tests/test_channel_targets_isolation.py
+++ b/tests/test_channel_targets_isolation.py
@@ -1,0 +1,123 @@
+"""渠道级隔离契约单测：隔离消息（无 userid 但带 targets）在无法解析出本渠道目标时，
+各渠道 post_message 必须 fail-closed（不发送 / 不广播），绝不回退默认群或全量广播。
+
+覆盖对抗审查（PR #99）发现的 4 个漏网渠道：vocechat / webpush / feishu / qqbot。
+对照合规基线 telegram/wechat：if not userid and targets is not None: ...; if not userid: return。
+"""
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("qbittorrentapi", ModuleType("qbittorrentapi"))
+setattr(sys.modules["qbittorrentapi"], "TorrentFilesList", list)
+sys.modules.setdefault("transmission_rpc", ModuleType("transmission_rpc"))
+setattr(sys.modules["transmission_rpc"], "File", object)
+
+from app.modules.vocechat import VoceChatModule
+from app.modules.webpush import WebPushModule
+from app.modules.feishu import FeishuModule
+from app.modules.qqbot import QQBotModule
+from app.schemas import Notification
+from app.schemas.types import NotificationType
+
+# 隔离消息：无 userid、targets 只含“别的渠道”的键（模拟管理员只绑定了 telegram）
+FOREIGN_TARGETS = {"telegram_userid": "tg1"}
+
+
+def _isolated(targets=None):
+    return Notification(userid=None, username=None, mtype=NotificationType.Manual,
+                        title="仅特定对象可见", text="敏感内容", targets=targets)
+
+
+def _bare(cls):
+    return cls.__new__(cls)
+
+
+def _patch_dispatch(mod, client=None):
+    conf = SimpleNamespace(name="default", config={})
+    return (
+        patch.object(mod, "get_configs", return_value={"default": conf}),
+        patch.object(mod, "check_message", return_value=True),
+        patch.object(mod, "get_instance", return_value=client if client is not None else MagicMock()),
+    )
+
+
+class TestChannelTargetsIsolation(unittest.TestCase):
+
+    # ---- vocechat ----
+    def test_vocechat_isolated_foreign_target_not_sent(self):
+        mod = _bare(VoceChatModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated(FOREIGN_TARGETS))
+        client.send_msg.assert_not_called()
+
+    def test_vocechat_isolated_own_target_sent(self):
+        mod = _bare(VoceChatModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated({"vocechat_userid": "vc1"}))
+        client.send_msg.assert_called_once()
+        self.assertEqual(client.send_msg.call_args.kwargs.get("userid"), "vc1")
+
+    # ---- qqbot ----
+    def test_qqbot_isolated_foreign_target_not_sent(self):
+        mod = _bare(QQBotModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated(FOREIGN_TARGETS))
+        client.send_msg.assert_not_called()
+
+    def test_qqbot_isolated_own_target_sent(self):
+        mod = _bare(QQBotModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated({"qq_userid": "q1"}))
+        client.send_msg.assert_called_once()
+
+    # ---- feishu ----
+    def test_feishu_isolated_foreign_target_not_sent(self):
+        mod = _bare(FeishuModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated(FOREIGN_TARGETS))
+        client.send_notification.assert_not_called()
+
+    def test_feishu_isolated_own_target_sent(self):
+        mod = _bare(FeishuModule)
+        client = MagicMock()
+        gc, cm, gi = _patch_dispatch(mod, client)
+        with gc, cm, gi:
+            mod.post_message(_isolated({"feishu_openid": "f1"}))
+        client.send_notification.assert_called_once()
+
+    # ---- webpush（结构上无法定向：隔离消息一律 fail-closed，全局消息才广播）----
+    def test_webpush_isolated_message_not_pushed(self):
+        mod = _bare(WebPushModule)
+        conf = SimpleNamespace(name="default", config={})
+        with patch.object(mod, "get_configs", return_value={"default": conf}), \
+                patch.object(mod, "check_message", return_value=True), \
+                patch("app.modules.webpush.global_vars") as gv, \
+                patch("app.modules.webpush.webpush") as push:
+            gv.get_subscriptions.return_value = [{"endpoint": "e"}]
+            mod.post_message(_isolated(FOREIGN_TARGETS))
+        push.assert_not_called()
+
+    def test_webpush_global_message_still_broadcasts(self):
+        mod = _bare(WebPushModule)
+        conf = SimpleNamespace(name="default", config={})
+        with patch.object(mod, "get_configs", return_value={"default": conf}), \
+                patch.object(mod, "check_message", return_value=True), \
+                patch("app.modules.webpush.settings") as st, \
+                patch("app.modules.webpush.global_vars") as gv, \
+                patch("app.modules.webpush.webpush") as push:
+            st.VAPID = {"privateKey": "k", "subject": "s"}
+            gv.get_subscriptions.return_value = [{"endpoint": "e"}]
+            mod.post_message(_isolated(targets=None))  # 全局消息（targets 为 None）
+        push.assert_called()

--- a/tests/test_post_message_isolation_leak.py
+++ b/tests/test_post_message_isolation_leak.py
@@ -1,0 +1,127 @@
+"""P1 PR-E 单测：post_message / async_post_message 消息隔离隐私泄漏。
+
+隔离设置为 "user" 但通知无用户上下文（username 为空，典型为系统级通知）时，
+旧逻辑落入 else 分支置 send_orignal=True 并 break，导致仅特定对象可见的通知
+被按原消息广播到全部公开渠道。修复后应跳过 user 动作、不广播。
+"""
+import sys
+import asyncio
+import unittest
+from types import ModuleType
+from unittest.mock import patch
+
+sys.modules.setdefault("qbittorrentapi", ModuleType("qbittorrentapi"))
+setattr(sys.modules["qbittorrentapi"], "TorrentFilesList", list)
+sys.modules.setdefault("transmission_rpc", ModuleType("transmission_rpc"))
+setattr(sys.modules["transmission_rpc"], "File", object)
+sys.modules.setdefault("psutil", ModuleType("psutil"))
+
+from app.chain.message import MessageChain
+from app.core.config import settings
+from app.schemas import Notification
+from app.schemas.types import NotificationType
+
+
+class TestPostMessageIsolationLeak(unittest.TestCase):
+
+    @staticmethod
+    def _message() -> Notification:
+        # 无 userid、无 username、带 mtype —— 触发按 mtype 的隔离分支
+        return Notification(
+            userid=None,
+            username=None,
+            mtype=NotificationType.Manual,
+            title="仅特定对象可见",
+            text="敏感内容",
+        )
+
+    @staticmethod
+    def _get_settings_stub(admin_targets, user_targets=None):
+        # get_settings(SUPERUSER) 返回 admin_targets（None 表示超管行不存在）；其余返回 user_targets
+        def _stub(name):
+            return list(admin_targets) if (name == settings.SUPERUSER and admin_targets is not None) else user_targets
+        return _stub
+
+    def _run_sync(self, chain, message, switch, admin_targets=("admin_target",), user_targets=None):
+        with patch("app.chain.MessageTemplateHelper.render", return_value=message), \
+                patch.object(chain.messagehelper, "put"), \
+                patch.object(chain.messageoper, "add"), \
+                patch("app.chain.ServiceConfigHelper.get_notification_switch", return_value=switch), \
+                patch("app.chain.UserOper") as user_oper_cls, \
+                patch.object(chain.eventmanager, "send_event"), \
+                patch.object(chain.messagequeue, "send_message") as send_message:
+            user_oper_cls.return_value.get_settings.side_effect = self._get_settings_stub(admin_targets, user_targets)
+            chain.post_message(message)
+        return send_message
+
+    def _run_async(self, chain, message, switch, admin_targets=("admin_target",), user_targets=None):
+        with patch("app.chain.MessageTemplateHelper.render", return_value=message), \
+                patch.object(chain.messagehelper, "put"), \
+                patch.object(chain.messageoper, "add"), \
+                patch("app.chain.ServiceConfigHelper.get_notification_switch", return_value=switch), \
+                patch("app.chain.UserOper") as user_oper_cls, \
+                patch.object(chain.eventmanager, "async_send_event"), \
+                patch.object(chain.messagequeue, "async_send_message") as async_send:
+            user_oper_cls.return_value.get_settings.side_effect = self._get_settings_stub(admin_targets, user_targets)
+            asyncio.run(chain.async_post_message(message))
+        return async_send
+
+    # ---- 隐私泄漏核心用例 ----
+
+    def test_user_isolation_without_username_does_not_broadcast(self):
+        send_message = self._run_sync(MessageChain(), self._message(), "user")
+        send_message.assert_not_called()
+
+    def test_async_user_isolation_without_username_does_not_broadcast(self):
+        async_send = self._run_async(MessageChain(), self._message(), "user")
+        async_send.assert_not_called()
+
+    # ---- 修复不得误伤 admin 投递 ----
+
+    def test_user_admin_isolation_without_username_sends_admin_only(self):
+        send_message = self._run_sync(MessageChain(), self._message(), "user,admin")
+        self.assertEqual(send_message.call_count, 1)
+        sent = send_message.call_args.kwargs["message"]
+        self.assertEqual(sent.targets, ["admin_target"])
+
+    # ---- 修复不得破坏 "all" 广播（回归守卫）----
+
+    def test_all_isolation_still_broadcasts(self):
+        send_message = self._run_sync(MessageChain(), self._message(), "all")
+        send_message.assert_called()
+
+    # ---- 审查发现 #1：admin 目标不存在时不得按无目标广播 ----
+
+    def test_admin_isolation_missing_superuser_does_not_broadcast(self):
+        # 超管行被改名/删除/env 变更 → get_settings(SUPERUSER)=None，不应下发（否则下游 telegram 默认群 / wechat @all 广播）
+        send_message = self._run_sync(MessageChain(), self._message(), "admin", admin_targets=None)
+        send_message.assert_not_called()
+
+    def test_async_admin_isolation_missing_superuser_does_not_broadcast(self):
+        async_send = self._run_async(MessageChain(), self._message(), "admin", admin_targets=None)
+        async_send.assert_not_called()
+
+    def test_user_not_found_rollback_missing_superuser_does_not_broadcast(self):
+        # user 找不到回滚到 admin，但 admin 也不存在 → 不应广播
+        msg = Notification(userid=None, username="ghost", mtype=NotificationType.Manual, title="t", text="x")
+        send_message = self._run_sync(MessageChain(), msg, "user", admin_targets=None, user_targets=None)
+        send_message.assert_not_called()
+
+    # ---- 审查发现 #2/#3：else fail-open + token 空白/大小写 ----
+
+    def test_user_admin_with_whitespace_sends_admin_only(self):
+        # "user, admin"（逗号后带空格）经 API 直写可达；规范化后应只发管理员、绝不广播
+        send_message = self._run_sync(MessageChain(), self._message(), "user, admin")
+        self.assertEqual(send_message.call_count, 1)
+        self.assertEqual(send_message.call_args.kwargs["message"].targets, ["admin_target"])
+
+    def test_unknown_action_does_not_broadcast(self):
+        # 未知/拼写错误 token（自由字符串，无枚举校验）应 fail-closed，不广播
+        send_message = self._run_sync(MessageChain(), self._message(), "usr")
+        send_message.assert_not_called()
+
+    def test_uppercase_admin_token_sends_admin_only(self):
+        # 大小写变体应规范化匹配 admin
+        send_message = self._run_sync(MessageChain(), self._message(), "ADMIN")
+        self.assertEqual(send_message.call_count, 1)
+        self.assertEqual(send_message.call_args.kwargs["message"].targets, ["admin_target"])

--- a/tests/test_post_message_isolation_leak.py
+++ b/tests/test_post_message_isolation_leak.py
@@ -21,6 +21,10 @@ from app.core.config import settings
 from app.schemas import Notification
 from app.schemas.types import NotificationType
 
+# 与真实 get_settings 返回类型一致：Optional[dict]（渠道键→ID），而非 list
+ADMIN_TARGETS = {"telegram_userid": "admin_tg"}
+USER_TARGETS = {"telegram_userid": "user_tg"}
+
 
 class TestPostMessageIsolationLeak(unittest.TestCase):
 
@@ -36,13 +40,13 @@ class TestPostMessageIsolationLeak(unittest.TestCase):
         )
 
     @staticmethod
-    def _get_settings_stub(admin_targets, user_targets=None):
-        # get_settings(SUPERUSER) 返回 admin_targets（None 表示超管行不存在）；其余返回 user_targets
+    def _get_settings_stub(admin_targets, user_targets):
+        # get_settings(SUPERUSER) 返回 admin_targets（None=行缺失 / {}=无绑定）；其余用户名返回 user_targets
         def _stub(name):
-            return list(admin_targets) if (name == settings.SUPERUSER and admin_targets is not None) else user_targets
+            return admin_targets if name == settings.SUPERUSER else user_targets
         return _stub
 
-    def _run_sync(self, chain, message, switch, admin_targets=("admin_target",), user_targets=None):
+    def _run_sync(self, chain, message, switch, admin_targets=ADMIN_TARGETS, user_targets=None):
         with patch("app.chain.MessageTemplateHelper.render", return_value=message), \
                 patch.object(chain.messagehelper, "put"), \
                 patch.object(chain.messageoper, "add"), \
@@ -54,7 +58,7 @@ class TestPostMessageIsolationLeak(unittest.TestCase):
             chain.post_message(message)
         return send_message
 
-    def _run_async(self, chain, message, switch, admin_targets=("admin_target",), user_targets=None):
+    def _run_async(self, chain, message, switch, admin_targets=ADMIN_TARGETS, user_targets=None):
         with patch("app.chain.MessageTemplateHelper.render", return_value=message), \
                 patch.object(chain.messagehelper, "put"), \
                 patch.object(chain.messageoper, "add"), \
@@ -82,7 +86,7 @@ class TestPostMessageIsolationLeak(unittest.TestCase):
         send_message = self._run_sync(MessageChain(), self._message(), "user,admin")
         self.assertEqual(send_message.call_count, 1)
         sent = send_message.call_args.kwargs["message"]
-        self.assertEqual(sent.targets, ["admin_target"])
+        self.assertEqual(sent.targets, ADMIN_TARGETS)
 
     # ---- 修复不得破坏 "all" 广播（回归守卫）----
 
@@ -113,7 +117,7 @@ class TestPostMessageIsolationLeak(unittest.TestCase):
         # "user, admin"（逗号后带空格）经 API 直写可达；规范化后应只发管理员、绝不广播
         send_message = self._run_sync(MessageChain(), self._message(), "user, admin")
         self.assertEqual(send_message.call_count, 1)
-        self.assertEqual(send_message.call_args.kwargs["message"].targets, ["admin_target"])
+        self.assertEqual(send_message.call_args.kwargs["message"].targets, ADMIN_TARGETS)
 
     def test_unknown_action_does_not_broadcast(self):
         # 未知/拼写错误 token（自由字符串，无枚举校验）应 fail-closed，不广播
@@ -124,4 +128,19 @@ class TestPostMessageIsolationLeak(unittest.TestCase):
         # 大小写变体应规范化匹配 admin
         send_message = self._run_sync(MessageChain(), self._message(), "ADMIN")
         self.assertEqual(send_message.call_count, 1)
-        self.assertEqual(send_message.call_args.kwargs["message"].targets, ["admin_target"])
+        self.assertEqual(send_message.call_args.kwargs["message"].targets, ADMIN_TARGETS)
+
+    # ---- chain 层空 dict 守卫（审查发现 #1 的集中兜底）----
+
+    def test_admin_empty_bindings_does_not_broadcast(self):
+        # 超管行存在但无任何渠道绑定（get_settings 返回 {}）→ chain 集中 fail-closed，不广播
+        send_message = self._run_sync(MessageChain(), self._message(), "admin", admin_targets={})
+        send_message.assert_not_called()
+
+    # ---- user 隔离主用途：username 命中 → 路由到该用户（审查发现的漏测正路径）----
+
+    def test_user_isolation_routes_to_specific_user(self):
+        msg = Notification(userid=None, username="alice", mtype=NotificationType.Manual, title="t", text="x")
+        send_message = self._run_sync(MessageChain(), msg, "user", user_targets=USER_TARGETS)
+        self.assertEqual(send_message.call_count, 1)
+        self.assertEqual(send_message.call_args.kwargs["message"].targets, USER_TARGETS)

--- a/tests/test_system_notification_dispatch.py
+++ b/tests/test_system_notification_dispatch.py
@@ -52,6 +52,40 @@ class TestSystemNotificationDispatch(unittest.TestCase):
         self.assertIsNone(queued_message.userid)
         self.assertFalse(send_message.call_args.kwargs["immediately"])
 
+    def test_user_admin_without_username_only_admin_no_broadcast(self):
+        """#4 隐私泄漏回归：notify_action='user,admin' 且系统通知无 username 时，
+        应只发管理员，绝不把仅管理员可见的通知广播到全部公开渠道。"""
+        from app.core.config import settings
+        from app.schemas.types import NotificationType
+
+        chain = MessageChain()
+        message = Notification(
+            userid=SYSTEM_INTERNAL_USER_ID,  # 归一化后 userid=None（系统通知，无用户上下文）
+            username=None,
+            mtype=NotificationType.Download,
+            title="下载完成",
+            text="任务完成",
+        )
+        admin_targets = ["ADMIN_TARGET"]
+
+        class FakeUserOper:
+            def get_settings(self, name):
+                return admin_targets if name == settings.SUPERUSER else None
+
+        with patch("app.chain.MessageTemplateHelper.render", return_value=message), patch.object(
+            chain.messageoper, "add"
+        ), patch("app.chain.UserOper", FakeUserOper), patch(
+            "app.chain.ServiceConfigHelper.get_notification_switch", return_value="user,admin"
+        ), patch.object(chain.eventmanager, "send_event"), patch.object(
+            chain.messagequeue, "send_message"
+        ) as send_message:
+            chain.post_message(message)
+
+        # 只应发送一次，且目标为管理员列表（证明走 admin 分支而非广播原始消息到全渠道）
+        self.assertEqual(send_message.call_count, 1)
+        sent = send_message.call_args.kwargs["message"]
+        self.assertEqual(sent.targets, admin_targets)
+
     def test_send_direct_message_normalizes_internal_userid(self):
         chain = MessageChain()
         message = Notification(

--- a/tests/test_system_notification_dispatch.py
+++ b/tests/test_system_notification_dispatch.py
@@ -66,7 +66,7 @@ class TestSystemNotificationDispatch(unittest.TestCase):
             title="下载完成",
             text="任务完成",
         )
-        admin_targets = ["ADMIN_TARGET"]
+        admin_targets = {"telegram_userid": "ADMIN_TARGET"}  # 与真实 get_settings 返回 Optional[dict] 一致
 
         class FakeUserOper:
             def get_settings(self, name):


### PR DESCRIPTION
## 背景

落地 `docs/rust-rewrite-readiness-v3python.md` §五 轨道 A 的 **P1 · PR-E post_message 消息隔离隐私泄漏**（母报告 2026-06-29 审计 §五）。

按 `mtype` 隔离时，`post_message` / `async_post_message` 会依据 `notify_action`（组合自 `admin`/`user`/`all`）把通知路由到管理员/特定用户/全体。原逻辑存在一族"把仅管理员/用户可见的通知广播到全部公开渠道"的隐私泄漏。

## 修复（两个提交）

### 1) `#4` 基础修复 —— `user` 无用户上下文不再广播
系统级通知（下载/整理完成等，`username` 为空）在 `notify_action` 含 `user` 时，原 `else` 分支置 `send_orignal=True` + `break`，跳过后续 `admin` 并按原消息广播到全渠道。改为该情形 `continue`。sync/async 双改。

### 2) 对抗审查加固 —— 堵住同族的 3 处泄漏
对基础修复做了 **4 视角对抗审查 + 逐条证伪**（10 agent / 60 万 token），确认基础修复正确，但揪出同一分发 loop 的 3 处同族缺陷（其中 2 处会**重新打开**该泄漏）：

| 严重度 | 缺陷 | 根因 | 修复 |
|---|---|---|---|
| **HIGH** | `admin` 分支 `get_settings(SUPERUSER)` 无 `None` 守卫（`user` 分支有）——超管被改名/删除或 `SUPERUSER` env 与 DB 不一致时 `targets=None`，下游 telegram 回退默认群、wechat `@all` 广播管理员专属通知 | 守卫不对称 | 发送前统一 `if targets is None: continue`，同时覆盖 `user` 找不到回滚 `admin` 的路径 |
| **MEDIUM** | `else` 分支 fail-open：非 `admin`/`user` 的任意 token（拼写错误、agent 写入的自由串）都广播；`NotificationSwitchConf.action` 是无枚举校验的自由字符串 | fail-open 兜底 | `else` 改 fail-closed：仅显式 `all` 广播，未知动作 `continue` |
| **LOW** | 精确等值匹配对空白/大小写脆弱：`"user, admin"`（逗号后空格）split 出 `" admin"` ≠ `"admin"` → 落 else 广播 | token 未规范化 | `actions` 统一 `strip()+lower()+去空` |

> `targets is None`（行缺失）与 `targets == {}`（行存在但无绑定）语义不同：仅前者跳过，后者保持原有"下游优雅忽略"行为。

## 测试

- 新增 `tests/test_post_message_isolation_leak.py`（10 例）：user 无 username 不广播（同/异步）、user,admin 仅发管理员、all 仍广播、admin 缺失超管不广播（同/异步）、user 回滚超管缺失不广播、`"user, admin"` 空白、未知 token、大小写。
- 基础修复的回归测试 `test_user_admin_without_username_only_admin_no_broadcast` 保留在 `tests/test_system_notification_dispatch.py`。
- 每处均先复现 RED、修复后 GREEN。
- 全量 **1939 passed** / 1 skipped，**零回归**（1 failed `test_filemanager_external_storage` 缺 smb + 4 收集期 ERROR 均 pre-existing 基线，与本改动无关）。

## Test plan

- [x] 泄漏/丢消息/边界最小复现单测全绿（同步 + 异步）
- [x] 全量回归无新增失败
- [x] 对抗审查确认无残留泄漏/误丢/同异步分歧
- [ ] review
